### PR TITLE
ci: Dependabotによる依存関係の自動更新を導入

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,78 @@
+# Dependabot configuration for automatic dependency updates
+# Reference: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Node.js dependencies (root)
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Asia/Tokyo'
+    open-pull-requests-limit: 10
+    target-branch: 'main'
+    reviewers:
+      - 'genzouw'
+    labels:
+      - 'dependencies'
+      - 'npm'
+    commit-message:
+      prefix: 'chore'
+      prefix-development: 'chore'
+      include: 'scope'
+    pull-request-branch-name:
+      separator: '/'
+    groups:
+      eslint:
+        patterns:
+          - 'eslint*'
+          - '@eslint/*'
+          - 'typescript-eslint'
+          - '@typescript-eslint/*'
+      testing:
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
+          - '@testing-library/*'
+          - 'jsdom'
+          - '@types/jsdom'
+      typescript:
+        patterns:
+          - 'typescript'
+          - '@types/*'
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
+      vite:
+        patterns:
+          - 'vite'
+          - '@vitejs/*'
+          - 'vite-plugin-*'
+    allow:
+      - dependency-type: 'all'
+
+  # GitHub Actions
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Asia/Tokyo'
+    open-pull-requests-limit: 5
+    target-branch: 'main'
+    reviewers:
+      - 'genzouw'
+    labels:
+      - 'dependencies'
+      - 'github-actions'
+    commit-message:
+      prefix: 'ci'
+      include: 'scope'
+    pull-request-branch-name:
+      separator: '/'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,10 +38,6 @@ updates:
           - '@testing-library/*'
           - 'jsdom'
           - '@types/jsdom'
-      typescript:
-        patterns:
-          - 'typescript'
-          - '@types/*'
       react:
         patterns:
           - 'react'
@@ -53,6 +49,10 @@ updates:
           - 'vite'
           - '@vitejs/*'
           - 'vite-plugin-*'
+      typescript:
+        patterns:
+          - 'typescript'
+          - '@types/*'
     allow:
       - dependency-type: 'all'
 


### PR DESCRIPTION
## Summary

- Dependabot を導入し、npm（root）と GitHub Actions の依存を週次（月曜 09:00 JST）で自動更新します。
- 関連パッケージはグループ化（eslint / typescript / testing / react / vite）し、PR の乱立を防ぎます。
- ../toique のリポジトリ設定をベースに、monopo の構成（単一 npm プロジェクト・Docker 未使用）に合わせて簡略化しました。

## Test plan

- [ ] `.github/dependabot.yml` の構文を GitHub が受理することを確認（merge 後 Settings > Dependabot で表示されること）
- [ ] 月曜 09:00 JST 以降に dependabot による PR が自動オープンされることを確認
- [ ] 生成された PR がグルーピング設定通りにまとまっていることを確認