### PR TITLE
fix: 現在のプレイヤー表示から重複する所持金を削除

### DIFF
--- a/src/components/PlayerPanel/PlayerPanel.module.css
+++ b/src/components/PlayerPanel/PlayerPanel.module.css
@@ -17,10 +17,6 @@
   font-size: 18px;
   font-weight: 700;
 }
-.money {
-  font-size: 16px;
-  font-weight: 600;
-}
 .allPlayers {
   display: flex;
   gap: 8px;

--- a/src/components/PlayerPanel/PlayerPanel.tsx
+++ b/src/components/PlayerPanel/PlayerPanel.tsx
@@ -20,9 +20,6 @@ export default function PlayerPanel({
         <span className={styles.token}>{currentPlayer.token}</span>
         <div className={styles.info}>
           <div className={styles.name}>{currentPlayer.name}のばん</div>
-          <div className={styles.money}>
-            💰 ${currentPlayer.money.toLocaleString()}
-          </div>
         </div>
         {currentPlayer.inJail && <span className={styles.jailBadge}>🔒</span>}
       </div>


### PR DESCRIPTION
## Summary
- ページ上部の「現在のターンプレイヤー」表示にあった所持金（💰 \$X,XXX）を削除
- 直下のプレイヤーチップに同じ金額が表示されており重複していたため
- 未使用となった `.money` CSSクラスも合わせて削除

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm test` 通過（135 tests）
- [ ] ブラウザで「プレイヤー名のばん」表示の下に金額が出ていないことを確認
- [ ] 下段のプレイヤーチップでは引き続き金額が確認できることを確認