### PR TITLE
fix: マスの中央アイコンを拡大して視認性を改善

### DIFF
--- a/src/components/Board/Board.module.css
+++ b/src/components/Board/Board.module.css
@@ -89,8 +89,8 @@
   overflow: hidden;
 }
 .miniSpaceIcon {
-  font-size: clamp(14px, 4cqi, 32px);
-  opacity: 0.7;
+  font-size: clamp(12px, 3.2cqi, 24px);
+  opacity: 0.6;
   position: absolute;
   pointer-events: none;
   z-index: 0;

--- a/src/components/Board/Board.module.css
+++ b/src/components/Board/Board.module.css
@@ -89,8 +89,8 @@
   overflow: hidden;
 }
 .miniSpaceIcon {
-  font-size: clamp(8px, 2.5cqi, 20px);
-  opacity: 0.5;
+  font-size: clamp(14px, 4cqi, 32px);
+  opacity: 0.7;
   position: absolute;
   pointer-events: none;
   z-index: 0;


### PR DESCRIPTION
## Summary
- ボード上の各マス中央に表示されるアイコン（🚂・💧・💡・❓・💝・💸 など）が小さく、視認性が低かった
- `.miniSpaceIcon` の `font-size` を `clamp(8px, 2.5cqi, 20px)` → `clamp(14px, 4cqi, 32px)` に拡大
- `opacity` も `0.5` → `0.7` に調整し、薄すぎて見えづらかった点を改善

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm test` 通過（135 tests）
- [ ] ブラウザでマスのアイコンが従来より大きく、判別しやすくなっていることを確認
- [ ] ボードのレイアウトが崩れていないこと（アイコンがマスからはみ出していないか）を画面サイズ別に確認