### PR TITLE
fix: 刑務所のルールと脱出時のアニメーションを修正

### DIFF
--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -3,6 +3,7 @@ import type { Dispatch } from 'react'
 import type { GameState } from '../../game/types'
 import type { GameAction } from '../../game/actions'
 import { BOARD_SPACES } from '../../game/board'
+import { MAX_JAIL_TURNS } from '../../game/reducer'
 import { calculateTotalAssets } from '../../game/rules'
 import PlayerPanel from '../PlayerPanel/PlayerPanel'
 import MiniMap from '../Board/MiniMap'
@@ -817,7 +818,8 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
                   <div
                     style={{ padding: '4px 0', color: 'var(--color-danger)' }}
                   >
-                    🔒 刑務所にいるよ（{detailPlayer.jailTurns}/3ターン）
+                    🔒 刑務所にいるよ（{detailPlayer.jailTurns}/{MAX_JAIL_TURNS}
+                    ターン）
                   </div>
                 )}
                 {detailPlayer.getOutOfJailCards > 0 && (

--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -36,10 +36,11 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
   const [showSpaceDetail, setShowSpaceDetail] = useState<number | null>(null)
   const { muted, toggleMute, play } = useSound()
   const movingRef = useRef(false)
-  const jailRollRef = useRef(false)
   // Refs to capture current values for the animation callback
   const positionRef = useRef(0)
   const diceRef = useRef<[number, number]>([1, 1])
+  const turnPhaseRef = useRef(state.turnPhase)
+  turnPhaseRef.current = state.turnPhase
 
   const currentPlayer = state.players[state.currentPlayerIndex]
 
@@ -65,9 +66,9 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
   const handleRollComplete = () => {
     setIsRolling(false)
 
-    // ROLL_FOR_JAIL の場合はreducer側で移動処理済みなのでアニメーション不要
-    if (jailRollRef.current) {
-      jailRollRef.current = false
+    // 移動が必要なフェーズのみアニメーション実行
+    // （刑務所内ロールで脱出失敗 → endTurn の場合はスキップ）
+    if (turnPhaseRef.current !== 'moving') {
       return
     }
 
@@ -147,7 +148,8 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
   }
 
   const handleRollForJail = () => {
-    jailRollRef.current = true
+    // 脱出時のアニメーションのため、現在位置をキャプチャ
+    positionRef.current = currentPlayer.position
     play('diceRoll')
     setIsRolling(true)
     dispatch({ type: 'ROLL_FOR_JAIL' })

--- a/src/game/__tests__/reducer-actions.test.ts
+++ b/src/game/__tests__/reducer-actions.test.ts
@@ -562,7 +562,7 @@ describe('DRAW_CARD + DISMISS_CARD (applyCardEffect)', () => {
 // ── ROLL_FOR_JAIL ──
 
 describe('ROLL_FOR_JAIL', () => {
-  it('ゾロ目で脱出して移動する', () => {
+  it('ゾロ目で脱出（位置は moving フェーズで FINISH_MOVING に委譲）', () => {
     let state = startedGame()
     state = withCurrentPlayer(state, {
       inJail: true,
@@ -573,24 +573,34 @@ describe('ROLL_FOR_JAIL', () => {
     vi.spyOn(Math, 'random').mockReturnValue(0) // 常に1が出る → ゾロ目
     const next = gameReducer(state, { type: 'ROLL_FOR_JAIL' })
     expect(next.players[0].inJail).toBe(false)
-    expect(next.players[0].position).toBe(12) // 10 + 1+1
+    expect(next.players[0].jailTurns).toBe(0)
+    // ROLL_FOR_JAIL ではまだ移動しない（アニメーション後に FINISH_MOVING で進む）
+    expect(next.players[0].position).toBe(10)
+    expect(next.turnPhase).toBe('moving')
+    expect(next.dice.values).toEqual([1, 1])
     vi.restoreAllMocks()
   })
 
-  it('2回休んで脱出', () => {
+  it('3回目の試行でゾロ目が出なければ$50払って強制出獄', () => {
     let state = startedGame()
+    const moneyBefore = state.players[0].money
     state = withCurrentPlayer(state, {
       inJail: true,
-      jailTurns: 1, // +1 で 2 → 自動脱出
+      jailTurns: 2, // +1 で 3 → 強制出獄
       position: 10,
     })
     vi.spyOn(Math, 'random').mockReturnValueOnce(0).mockReturnValueOnce(0.5) // 1, 4
     const next = gameReducer(state, { type: 'ROLL_FOR_JAIL' })
     expect(next.players[0].inJail).toBe(false)
+    expect(next.players[0].jailTurns).toBe(0)
+    expect(next.players[0].money).toBe(moneyBefore - 50)
+    // 移動はアニメーション後の FINISH_MOVING で行うため、ここではまだ進まない
+    expect(next.players[0].position).toBe(10)
+    expect(next.turnPhase).toBe('moving')
     vi.restoreAllMocks()
   })
 
-  it('ゾロ目でなく jailTurns < 2 ならまた1回休む', () => {
+  it('1回目の失敗ならまた1回休む（jailTurns: 0 → 1）', () => {
     let state = startedGame()
     state = withCurrentPlayer(state, {
       inJail: true,
@@ -601,6 +611,21 @@ describe('ROLL_FOR_JAIL', () => {
     const next = gameReducer(state, { type: 'ROLL_FOR_JAIL' })
     expect(next.players[0].inJail).toBe(true)
     expect(next.players[0].jailTurns).toBe(1)
+    expect(next.turnPhase).toBe('endTurn')
+    vi.restoreAllMocks()
+  })
+
+  it('2回目の失敗でもまだ刑務所に残る（jailTurns: 1 → 2）', () => {
+    let state = startedGame()
+    state = withCurrentPlayer(state, {
+      inJail: true,
+      jailTurns: 1,
+      position: 10,
+    })
+    vi.spyOn(Math, 'random').mockReturnValueOnce(0).mockReturnValueOnce(0.5) // 1, 4
+    const next = gameReducer(state, { type: 'ROLL_FOR_JAIL' })
+    expect(next.players[0].inJail).toBe(true)
+    expect(next.players[0].jailTurns).toBe(2)
     expect(next.turnPhase).toBe('endTurn')
     vi.restoreAllMocks()
   })

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -20,6 +20,9 @@ import {
 /** 刑務所内でのゾロ目挑戦の最大試行回数（これ以上失敗すると強制出獄） */
 export const MAX_JAIL_TURNS = 3
 
+/** 刑務所から出るための罰金額（PAY_JAIL_FINE / 強制出獄時に支払う） */
+export const JAIL_FINE = 50
+
 // ── ヘルパー関数 ──
 
 export function rollDice(): [number, number] {
@@ -1062,7 +1065,7 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
     case 'PAY_JAIL_FINE': {
       const player = state.players[state.currentPlayerIndex]
       const newState = updateCurrentPlayer(state, {
-        money: player.money - 50,
+        money: player.money - JAIL_FINE,
         inJail: false,
         jailTurns: 0,
       })
@@ -1070,7 +1073,7 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
         ...newState,
         turnPhase: 'roll',
         dice: { ...state.dice, rolled: false },
-        message: `$50はらって刑務所をでたよ！サイコロをふろう！`,
+        message: `$${JAIL_FINE}はらって刑務所をでたよ！サイコロをふろう！`,
       }
     }
 
@@ -1114,10 +1117,10 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
       // ゾロ目でない
       const newJailTurns = player.jailTurns + 1
 
-      // 最大試行回数に達したら → $50払って強制出獄、出目の分だけ進む
+      // 最大試行回数に達したら → 罰金を払って強制出獄、出目の分だけ進む
       if (newJailTurns >= MAX_JAIL_TURNS) {
         const newState = updateCurrentPlayer(state, {
-          money: player.money - 50,
+          money: player.money - JAIL_FINE,
           inJail: false,
           jailTurns: 0,
         })
@@ -1125,7 +1128,7 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
           ...newState,
           dice: { values: [d1, d2], doubles: 0, rolled: true },
           turnPhase: 'moving',
-          message: `3かいゾロ目がでなかったから$50はらって刑務所をでたよ！`,
+          message: `${MAX_JAIL_TURNS}かいゾロ目がでなかったから$${JAIL_FINE}はらって刑務所をでたよ！`,
         }
       }
 

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -1093,48 +1093,38 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
       const isDoubles = d1 === d2
 
       if (isDoubles) {
-        // ゾロ目で脱出
-        const steps = d1 + d2
-        const newPos = (player.position + steps) % 40
-        const passedGo = newPos < player.position
-        let newState = updateCurrentPlayer(state, {
-          position: newPos,
+        // ゾロ目で脱出 → 通常の移動アニメーションで進める
+        const newState = updateCurrentPlayer(state, {
           inJail: false,
           jailTurns: 0,
-          money: passedGo ? player.money + 200 : player.money,
         })
-        newState = {
+        return {
           ...newState,
           dice: { values: [d1, d2], doubles: 0, rolled: true },
-          turnPhase: 'landed',
-          message: `ゾロ目がでたよ！刑務所をぬけだしたよ！`,
+          turnPhase: 'moving',
+          message: `ゾロ目がでたよ！${d1}と${d2}！刑務所をぬけだしたよ！`,
         }
-        return handleLanding(newState)
       }
 
       // ゾロ目でない
       const newJailTurns = player.jailTurns + 1
 
-      // 2回休んだら自動的に脱出（出目の分だけ進む）
-      if (newJailTurns >= 2) {
-        const steps = d1 + d2
-        const newPos = (player.position + steps) % 40
-        const passedGo = newPos < player.position
-        let newState = updateCurrentPlayer(state, {
-          position: newPos,
+      // 3回目の試行も失敗 → $50払って強制出獄、出目の分だけ進む
+      if (newJailTurns >= 3) {
+        const newState = updateCurrentPlayer(state, {
+          money: player.money - 50,
           inJail: false,
           jailTurns: 0,
-          money: passedGo ? player.money + 200 : player.money,
         })
-        newState = {
+        return {
           ...newState,
           dice: { values: [d1, d2], doubles: 0, rolled: true },
-          turnPhase: 'landed',
-          message: `2かい休んだので刑務所をでたよ！`,
+          turnPhase: 'moving',
+          message: `3かいゾロ目がでなかったから$50はらって刑務所をでたよ！`,
         }
-        return handleLanding(newState)
       }
 
+      // 1〜2回目の失敗 → 刑務所続行
       const newState = updateCurrentPlayer(state, {
         jailTurns: newJailTurns,
       })

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -15,6 +15,11 @@ import {
   findNearestSpace,
 } from './rules'
 
+// ── 定数 ──
+
+/** 刑務所内でのゾロ目挑戦の最大試行回数（これ以上失敗すると強制出獄） */
+export const MAX_JAIL_TURNS = 3
+
 // ── ヘルパー関数 ──
 
 export function rollDice(): [number, number] {
@@ -1109,8 +1114,8 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
       // ゾロ目でない
       const newJailTurns = player.jailTurns + 1
 
-      // 3回目の試行も失敗 → $50払って強制出獄、出目の分だけ進む
-      if (newJailTurns >= 3) {
+      // 最大試行回数に達したら → $50払って強制出獄、出目の分だけ進む
+      if (newJailTurns >= MAX_JAIL_TURNS) {
         const newState = updateCurrentPlayer(state, {
           money: player.money - 50,
           inJail: false,


### PR DESCRIPTION
## Summary

### 1. 「3回目でゾロ目が出なかったら強制出獄」ルールに準拠
- 既存実装は2回連続でゾロ目に失敗すると自動脱出していた（ルール違反）
- 正しいルール（3回目の試行でゾロ目が出なかった場合に \$50 払って強制出獄、そのダイス目だけ進む）に修正
- `jailTurns` の閾値を `>= 2` → `>= 3` に変更し、強制出獄時に \$50 を引く処理を追加

### 2. 刑務所脱出時の1マスずつ進むアニメーションを修正
- 既存実装は `ROLL_FOR_JAIL` 内で position を即時更新し、`jailRollRef` フラグでアニメーションをスキップしていた
- 出獄時 (ゾロ目脱出 / 3回目強制出獄) は `turnPhase: 'moving'` に遷移させ、通常のロールと同じく `FINISH_MOVING` でアニメーション後に位置確定するように統一
- GameBoard 側は `turnPhaseRef` で reducer の遷移結果を見て、移動が必要な場合のみアニメーションを起動する形に変更（脱出失敗時は `endTurn` なのでスキップ）

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm test` 通過（136 tests）
  - ROLL_FOR_JAIL 関連テストを新ルールに合わせて追加・修正（脱出時 turnPhase='moving' / 強制出獄時 -\$50 / 1〜2回目失敗の境界）
- [ ] ブラウザで以下を確認:
  - [ ] 刑務所内でゾロ目を出すと、抜け出して1マスずつアニメーションで進むこと
  - [ ] 3回目の試行でゾロ目が出なかった場合に、\$50 引かれて出目分1マスずつ進むこと
  - [ ] 1〜2回目の失敗ではアニメーションが走らずターンが渡ること