### PR TITLE
feat: オークション開始価格を物件購入価格以上に設定

### DIFF
--- a/src/components/ActionDialog/AuctionDialog.tsx
+++ b/src/components/ActionDialog/AuctionDialog.tsx
@@ -32,7 +32,7 @@ export default function AuctionDialog({
         <div className={styles.bidder}>
           {currentBidder
             ? `${currentBidder.token} ${currentBidder.name}がリード中`
-            : 'まだだれもビッドしていないよ'}
+            : `開始価格 $${auction.currentBid}（だれかビッドしてね！）`}
         </div>
         <div
           className={styles.bidder}

--- a/src/game/__tests__/reducer-actions.test.ts
+++ b/src/game/__tests__/reducer-actions.test.ts
@@ -181,6 +181,16 @@ describe('DECLINE_PURCHASE', () => {
     expect(next.auction).not.toBeNull()
     expect(next.auction?.propertyId).toBe('mediterranean')
   })
+
+  it('開始価格は物件のオーナーなしの購入価格になる', () => {
+    let state = startedGame()
+    state = withCurrentPlayer(state, { position: 1 })
+    state = { ...state, turnPhase: 'action' }
+    const next = gameReducer(state, { type: 'DECLINE_PURCHASE' })
+    // mediterranean.price = 60
+    expect(next.auction?.currentBid).toBe(60)
+    expect(next.auction?.currentBidderId).toBeNull()
+  })
 })
 
 // ── PLACE_BID / PASS_AUCTION ──
@@ -193,8 +203,9 @@ describe('オークション (PLACE_BID / PASS_AUCTION)', () => {
       { ...state, turnPhase: 'action' },
       { type: 'DECLINE_PURCHASE' },
     )
-    const next = gameReducer(state, { type: 'PLACE_BID', amount: 50 })
-    expect(next.auction?.currentBid).toBe(50)
+    // mediterranean.price=60 が開始価格なので、それを超える額で入札
+    const next = gameReducer(state, { type: 'PLACE_BID', amount: 70 })
+    expect(next.auction?.currentBid).toBe(70)
     expect(next.auction?.currentBidderId).toBe('player-0')
   })
 
@@ -208,6 +219,19 @@ describe('オークション (PLACE_BID / PASS_AUCTION)', () => {
     state = gameReducer(state, { type: 'PLACE_BID', amount: 100 })
     const next = gameReducer(state, { type: 'PLACE_BID', amount: 50 })
     expect(next.auction?.currentBid).toBe(100)
+  })
+
+  it('PLACE_BID で開始価格以下は拒否される', () => {
+    let state = startedGame()
+    state = withCurrentPlayer(state, { position: 1 })
+    state = gameReducer(
+      { ...state, turnPhase: 'action' },
+      { type: 'DECLINE_PURCHASE' },
+    )
+    // 開始価格は60なので、60以下の入札は拒否される
+    const next = gameReducer(state, { type: 'PLACE_BID', amount: 60 })
+    expect(next.auction?.currentBid).toBe(60)
+    expect(next.auction?.currentBidderId).toBeNull()
   })
 
   it('全員パスで誰も買わなかった場合', () => {
@@ -230,10 +254,10 @@ describe('オークション (PLACE_BID / PASS_AUCTION)', () => {
       { ...state, turnPhase: 'action' },
       { type: 'DECLINE_PURCHASE' },
     )
-    state = gameReducer(state, { type: 'PLACE_BID', amount: 30 })
+    state = gameReducer(state, { type: 'PLACE_BID', amount: 100 })
     const next = gameReducer(state, { type: 'PASS_AUCTION' })
     expect(next.auction).toBeNull()
-    expect(next.players[0].money).toBe(1470) // -30
+    expect(next.players[0].money).toBe(1400) // -100
     expect(next.players[0].properties).toContain('mediterranean')
     expect(next.propertyStates['mediterranean'].ownerId).toBe('player-0')
   })
@@ -781,6 +805,8 @@ describe('SELL_PROPERTY', () => {
     })
     expect(next.turnPhase).toBe('auction')
     expect(next.auction?.sellerId).toBe('player-0')
+    // 開始価格は物件のオーナーなしの購入価格（mediterranean.price=60）
+    expect(next.auction?.currentBid).toBe(60)
   })
 
   it('家がある物件は売れない', () => {

--- a/src/game/__tests__/reducer-actions.test.ts
+++ b/src/game/__tests__/reducer-actions.test.ts
@@ -221,15 +221,28 @@ describe('オークション (PLACE_BID / PASS_AUCTION)', () => {
     expect(next.auction?.currentBid).toBe(100)
   })
 
-  it('PLACE_BID で開始価格以下は拒否される', () => {
+  it('PLACE_BID で開始価格と同額の入札は受け入れられる（初回入札）', () => {
     let state = startedGame()
     state = withCurrentPlayer(state, { position: 1 })
     state = gameReducer(
       { ...state, turnPhase: 'action' },
       { type: 'DECLINE_PURCHASE' },
     )
-    // 開始価格は60なので、60以下の入札は拒否される
+    // 開始価格は60なので、60と同額の入札は受け入れられる
     const next = gameReducer(state, { type: 'PLACE_BID', amount: 60 })
+    expect(next.auction?.currentBid).toBe(60)
+    expect(next.auction?.currentBidderId).toBe('player-0')
+  })
+
+  it('PLACE_BID で開始価格未満の入札は拒否される', () => {
+    let state = startedGame()
+    state = withCurrentPlayer(state, { position: 1 })
+    state = gameReducer(
+      { ...state, turnPhase: 'action' },
+      { type: 'DECLINE_PURCHASE' },
+    )
+    // 開始価格は60なので、60未満の入札は拒否される
+    const next = gameReducer(state, { type: 'PLACE_BID', amount: 59 })
     expect(next.auction?.currentBid).toBe(60)
     expect(next.auction?.currentBidderId).toBeNull()
   })

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -590,9 +590,10 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
       const space = BOARD_SPACES.find((s) => s.position === player.position)
       if (!space) return state
 
+      const startingBid = space.price ?? 0
       const auction: AuctionState = {
         propertyId: space.id,
-        currentBid: 0,
+        currentBid: startingBid,
         currentBidderId: null,
         passedPlayerIds: [],
         activePlayerIndex: state.currentPlayerIndex,
@@ -603,7 +604,7 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
         ...state,
         auction,
         turnPhase: 'auction',
-        message: `${space.name}のオークションをはじめるよ！`,
+        message: `${space.name}のオークションをはじめるよ！開始価格は$${startingBid}！`,
       }
     }
 
@@ -905,8 +906,8 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
       // 家が建っている物件は売れない（先に家を売る必要がある）
       if (propState.houses > 0) return state
 
-      // 開始価格 = 物件価格の半額を10の位で四捨五入
-      const startingBid = Math.round((space.price ?? 0) / 2 / 10) * 10
+      // 開始価格はオーナーなしの状態の購入価格（最低価格）
+      const startingBid = space.price ?? 0
 
       // 売り手以外でオークション開始
       const firstBidderIndex = nextActivePlayer(

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -614,7 +614,12 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
       const auction = state.auction
       const activeBidder = state.players[auction.activePlayerIndex]
 
-      if (action.amount <= auction.currentBid) return state
+      // 初回入札時は開始価格と同額を許容、2回目以降は現在のビッドより大きい必要がある
+      const minBid =
+        auction.currentBidderId === null
+          ? auction.currentBid
+          : auction.currentBid + 1
+      if (action.amount < minBid) return state
 
       const newAuction: AuctionState = {
         ...auction,


### PR DESCRIPTION
## Summary

- オークションの開始価格を「物件のオーナーなしの状態の購入価格 (`space.price`)」以上に変更
- `DECLINE_PURCHASE` で発生するオークション: 開始価格 `0` → `space.price`
- `SELL_PROPERTY` で発生するオークション: 開始価格 `space.price / 2` (10の位で四捨五入) → `space.price`
- `AuctionDialog` の入札前表示を「開始価格」とわかるように変更
- メッセージに開始価格を明示

## Why

これまで `DECLINE_PURCHASE` 後のオークションでは \$1 から入札可能で、本来 \$200 の物件が \$10 等の極端に安い金額で落札される可能性があった。オーナーなしの購入価格を最低開始価格として設定することで、価格バランスを保つ。

## Test plan

- [x] `npm test` (138 tests pass)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] 新規テスト追加:
  - `DECLINE_PURCHASE` の開始価格が `space.price` と一致する
  - `PLACE_BID` で開始価格以下の入札が拒否される
  - `SELL_PROPERTY` の開始価格が `space.price` と一致する