### PR TITLE
fix: オークションで最初のパスで終了する不具合を修正

### DIFF
--- a/src/game/__tests__/reducer-actions.test.ts
+++ b/src/game/__tests__/reducer-actions.test.ts
@@ -247,7 +247,43 @@ describe('オークション (PLACE_BID / PASS_AUCTION)', () => {
     expect(next.auction?.currentBidderId).toBeNull()
   })
 
-  it('全員パスで誰も買わなかった場合', () => {
+  it('最初のプレイヤーがパスしても次のプレイヤーにビッドのターンが回る', () => {
+    let state = startedGame()
+    state = withCurrentPlayer(state, { position: 1 })
+    state = gameReducer(
+      { ...state, turnPhase: 'action' },
+      { type: 'DECLINE_PURCHASE' },
+    )
+    // 最初のビッダー (player-0) がパス → 終了せず player-1 のターンに移る
+    const next = gameReducer(state, { type: 'PASS_AUCTION' })
+    expect(next.auction).not.toBeNull()
+    expect(next.turnPhase).toBe('auction')
+    expect(next.auction?.activePlayerIndex).toBe(1)
+    expect(next.auction?.passedPlayerIds).toEqual(['player-0'])
+  })
+
+  it('3人プレイで入札者なしのまま全員がパスするまで終了しない', () => {
+    let state = startedGame(3)
+    state = withCurrentPlayer(state, { position: 1 })
+    state = gameReducer(
+      { ...state, turnPhase: 'action' },
+      { type: 'DECLINE_PURCHASE' },
+    )
+    // player-0 がパス → 続行、player-1 のターン
+    state = gameReducer(state, { type: 'PASS_AUCTION' })
+    expect(state.auction).not.toBeNull()
+    expect(state.auction?.activePlayerIndex).toBe(1)
+    // player-1 がパス → 続行、player-2 のターン
+    state = gameReducer(state, { type: 'PASS_AUCTION' })
+    expect(state.auction).not.toBeNull()
+    expect(state.auction?.activePlayerIndex).toBe(2)
+    // player-2 がパス → 全員パス → 終了
+    const next = gameReducer(state, { type: 'PASS_AUCTION' })
+    expect(next.auction).toBeNull()
+    expect(next.turnPhase).toBe('endTurn')
+  })
+
+  it('全員パスで誰も買わなかった場合（DECLINE_PURCHASE 由来は空白地のまま）', () => {
     let state = startedGame()
     state = withCurrentPlayer(state, { position: 1 })
     state = gameReducer(
@@ -258,6 +294,10 @@ describe('オークション (PLACE_BID / PASS_AUCTION)', () => {
     const next = gameReducer(state, { type: 'PASS_AUCTION' })
     expect(next.auction).toBeNull()
     expect(next.turnPhase).toBe('endTurn')
+    // 物件は空白地のまま、所持金変動なし
+    expect(next.propertyStates['mediterranean'].ownerId).toBeNull()
+    expect(next.players[0].money).toBe(1500)
+    expect(next.players[1].money).toBe(1500)
   })
 
   it('入札者が居て他がパスすれば落札される', () => {
@@ -836,6 +876,57 @@ describe('SELL_PROPERTY', () => {
       propertyId: 'mediterranean',
     })
     expect(next).toEqual(state)
+  })
+
+  it('売却オークションで誰も入札せず終了 → 売却者に開始価格が入金され空白地になる', () => {
+    let state = startedGame()
+    state = withPropertyOwner(state, 'mediterranean', 'player-0')
+    state = {
+      ...state,
+      players: state.players.map((p) =>
+        p.id === 'player-0' ? { ...p, properties: ['mediterranean'] } : p,
+      ),
+    }
+    state = gameReducer(state, {
+      type: 'SELL_PROPERTY',
+      propertyId: 'mediterranean',
+    })
+    // player-1 がパス → 全員パス → 終了
+    const next = gameReducer(state, { type: 'PASS_AUCTION' })
+    expect(next.auction).toBeNull()
+    expect(next.turnPhase).toBe('endTurn')
+    // 物件は空白地化
+    expect(next.propertyStates['mediterranean'].ownerId).toBeNull()
+    // 売却者 (player-0) は startingBid (=60) を受け取り、物件を失う
+    expect(next.players[0].money).toBe(1560)
+    expect(next.players[0].properties).not.toContain('mediterranean')
+    // 他プレイヤーの所持金は変わらない
+    expect(next.players[1].money).toBe(1500)
+  })
+
+  it('3人プレイの売却オークションで全員パス → 売却者に開始価格が入金される', () => {
+    let state = startedGame(3)
+    state = withPropertyOwner(state, 'mediterranean', 'player-0')
+    state = {
+      ...state,
+      players: state.players.map((p) =>
+        p.id === 'player-0' ? { ...p, properties: ['mediterranean'] } : p,
+      ),
+    }
+    state = gameReducer(state, {
+      type: 'SELL_PROPERTY',
+      propertyId: 'mediterranean',
+    })
+    // player-1 がパス → 続行、player-2 へ
+    state = gameReducer(state, { type: 'PASS_AUCTION' })
+    expect(state.auction).not.toBeNull()
+    expect(state.auction?.activePlayerIndex).toBe(2)
+    // player-2 がパス → 全員パス → 終了
+    const next = gameReducer(state, { type: 'PASS_AUCTION' })
+    expect(next.auction).toBeNull()
+    expect(next.propertyStates['mediterranean'].ownerId).toBeNull()
+    expect(next.players[0].money).toBe(1560)
+    expect(next.players[0].properties).not.toContain('mediterranean')
   })
 })
 

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -646,8 +646,14 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
         (p) => !p.isBankrupt && !newPassedIds.includes(p.id),
       )
 
-      // 全員がパスした or 1人しか残っていない
-      if (activePlayers.length <= 1) {
+      // 終了判定:
+      //   入札者あり → 残りが入札者だけ (1人以下) になったら終了
+      //   入札者なし → 全員がパスする (0人) まで終了させない（次の人に回す）
+      const auctionEnded = auction.currentBidderId
+        ? activePlayers.length <= 1
+        : activePlayers.length === 0
+
+      if (auctionEnded) {
         // 落札者がいれば物件を渡す
         if (auction.currentBidderId) {
           const winner = state.players.find(
@@ -690,16 +696,50 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
             turnPhase: 'endTurn',
             message: `${winner.name}が$${auction.currentBid}で${space.name}を落札したよ！`,
           }
-        } else {
-          // 誰も入札しなかった
+        }
+
+        // 誰も入札しなかった
+        // 売却オークション (SELL_PROPERTY 由来) の場合は、売却者に開始価格を入金し
+        // 物件は空白地化する
+        if (auction.sellerId) {
+          const space = BOARD_SPACES.find((s) => s.id === auction.propertyId)!
+          const newPlayers = state.players.map((p) => {
+            if (p.id === auction.sellerId) {
+              return {
+                ...p,
+                money: p.money + auction.currentBid,
+                properties: p.properties.filter(
+                  (id) => id !== auction.propertyId,
+                ),
+              }
+            }
+            return p
+          })
+          const newPropertyStates: Record<string, PropertyState> = {
+            ...state.propertyStates,
+            [auction.propertyId]: {
+              ...state.propertyStates[auction.propertyId],
+              ownerId: null,
+              isMortgaged: false,
+              houses: 0,
+            },
+          }
           return {
             ...state,
+            players: newPlayers,
+            propertyStates: newPropertyStates,
             auction: null,
             turnPhase: 'endTurn',
-            message: auction.sellerId
-              ? 'だれも買わなかったよ。売れなかった！'
-              : 'だれも入札しなかったよ。競売おわり！',
+            message: `だれも買わなかったよ。${space.name}は$${auction.currentBid}で空き地になったよ！`,
           }
+        }
+
+        // 通常オークション (DECLINE_PURCHASE 由来) で誰も入札しなかった場合
+        return {
+          ...state,
+          auction: null,
+          turnPhase: 'endTurn',
+          message: 'だれも入札しなかったよ。競売おわり！',
         }
       }
 


### PR DESCRIPTION
## Summary

- オークションで「最初のプレイヤーがパスすると、次のプレイヤーにビッドのターンが回らずオークションが終了する」不具合を修正
- 終了判定を「入札者あり: 残り1人」「入札者なし: 全員パス」と入札者の有無で分岐
- `SELL_PROPERTY` 由来のオークションで誰も入札せず終了した場合、売却者は開始価格 (物件の購入価格) を受け取り、物件は空白地化するよう追加

## 背景

`PASS_AUCTION` の終了条件 \`activePlayers.length <= 1\` は、入札者がまだ居なくても次の候補が1人だけになった瞬間に終了させていた。
2人プレイで起こりやすく、最初のプレイヤーが \`DECLINE_PURCHASE\` 直後に \`PASS_AUCTION\` すると、もう一方のプレイヤーが入札する機会を持てないまま競売が終わっていた。

## 変更点

`src/game/reducer.ts` (\`PASS_AUCTION\`)
- 終了条件を入札者の有無で分岐
  - 入札者あり: 残り1人 (=入札者のみ) で終了 — 従来通り
  - 入札者なし: 残り0人 (=全員パス) になるまで終了させない
- 入札者なしで終了した場合、\`sellerId\` がいれば売却者に \`startingBid\` を入金し、物件を空白地化
- \`sellerId\` がいない (\`DECLINE_PURCHASE\` 由来) 場合は従来通り何もしない

## Test plan

- [x] \`npm test\` (143/143 passed)
- [x] \`npm run lint\` (no issues)
- [x] \`npm run typecheck\` (no issues)
- 追加テスト
  - [x] 最初のプレイヤーがパスしても次のプレイヤーにビッドのターンが回る
  - [x] 3人プレイで入札者なしのまま全員がパスするまで終了しない
  - [x] DECLINE_PURCHASE 由来で全員パス → 物件は空白地のまま、所持金変動なし
  - [x] SELL_PROPERTY で全員パス → 売却者に開始価格が入金され空白地化 (2人/3人プレイ)