### PR TITLE
feat: ✨ TradeDialogのおかね入力欄を改善（初期0非表示・クイック加算ボタン追加）

### DIFF
--- a/src/components/ActionDialog/ActionDialog.module.css
+++ b/src/components/ActionDialog/ActionDialog.module.css
@@ -117,3 +117,46 @@
   font-size: 16px;
   text-align: center;
 }
+.moneyInputRow {
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.moneyInputLabel {
+  font-size: 14px;
+}
+.moneyQuickButtons {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.moneyQuickButton {
+  padding: 6px 10px;
+  border: 2px solid var(--color-secondary);
+  border-radius: var(--radius-sm);
+  background: var(--color-white);
+  color: var(--color-secondary);
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+.moneyQuickButton:active {
+  transform: scale(0.96);
+}
+.moneyQuickButtonClear {
+  padding: 6px 10px;
+  border: 2px solid #e0e0e0;
+  border-radius: var(--radius-sm);
+  background: var(--color-white);
+  color: var(--color-text-light);
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+.moneyQuickButtonClear:active {
+  transform: scale(0.96);
+}

--- a/src/components/ActionDialog/ActionDialog.module.css
+++ b/src/components/ActionDialog/ActionDialog.module.css
@@ -132,31 +132,25 @@
   gap: 6px;
   flex-wrap: wrap;
 }
-.moneyQuickButton {
-  padding: 6px 10px;
-  border: 2px solid var(--color-secondary);
-  border-radius: var(--radius-sm);
-  background: var(--color-white);
-  color: var(--color-secondary);
-  font-size: 13px;
-  font-weight: 700;
-  cursor: pointer;
-  touch-action: manipulation;
-}
-.moneyQuickButton:active {
-  transform: scale(0.96);
-}
+.moneyQuickButton,
 .moneyQuickButtonClear {
   padding: 6px 10px;
-  border: 2px solid #e0e0e0;
   border-radius: var(--radius-sm);
   background: var(--color-white);
-  color: var(--color-text-light);
   font-size: 13px;
   font-weight: 700;
   cursor: pointer;
   touch-action: manipulation;
 }
+.moneyQuickButton:active,
 .moneyQuickButtonClear:active {
   transform: scale(0.96);
+}
+.moneyQuickButton {
+  border: 2px solid var(--color-secondary);
+  color: var(--color-secondary);
+}
+.moneyQuickButtonClear {
+  border: 2px solid #e0e0e0;
+  color: var(--color-text-light);
 }

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -9,6 +9,7 @@ import type {
 import Dialog from '../common/Dialog'
 import Button from '../common/Button'
 import styles from './ActionDialog.module.css'
+import { clamp } from './tradeDialog.utils'
 
 const COLOR_MAP: Record<ColorGroup, string> = {
   brown: 'var(--color-brown)',
@@ -21,9 +22,6 @@ const COLOR_MAP: Record<ColorGroup, string> = {
   blue: 'var(--color-blue)',
   railroad: '#555',
 }
-
-const clamp = (val: number, max: number) =>
-  Math.max(0, Math.min(Math.floor(val), max))
 
 type TradeDialogProps = {
   currentPlayer: Player

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -22,6 +22,9 @@ const COLOR_MAP: Record<ColorGroup, string> = {
   railroad: '#555',
 }
 
+const clamp = (val: number, max: number) =>
+  Math.max(0, Math.min(Math.floor(val), max))
+
 type TradeDialogProps = {
   currentPlayer: Player
   targetPlayer: Player
@@ -80,9 +83,6 @@ export default function TradeDialog({
       requestJailCards: 0,
     })
   }
-
-  const clamp = (val: number, max: number) =>
-    Math.max(0, Math.min(Math.floor(val), max))
 
   return (
     <Dialog

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -81,6 +81,9 @@ export default function TradeDialog({
     })
   }
 
+  const clamp = (val: number, max: number) =>
+    Math.max(0, Math.min(Math.floor(val), max))
+
   return (
     <Dialog
       title={`${targetPlayer.token} ${targetPlayer.name}とこうかん`}
@@ -117,28 +120,54 @@ export default function TradeDialog({
             </button>
           ))}
         </div>
-        <div
-          style={{
-            marginTop: 8,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 8,
-          }}
-        >
-          <span style={{ fontSize: 14 }}>おかね: $</span>
+        <div className={styles.moneyInputRow}>
+          <span className={styles.moneyInputLabel}>おかね: $</span>
           <input
             className={styles.moneyInput}
             type="number"
+            inputMode="numeric"
             min={0}
             max={currentPlayer.money}
-            value={offerMoney}
+            value={offerMoney === 0 ? '' : offerMoney}
+            placeholder="0"
             onChange={(e) => {
-              const val = Math.floor(Number(e.target.value))
-              if (isNaN(val)) setOfferMoney(0)
-              else
-                setOfferMoney(Math.max(0, Math.min(val, currentPlayer.money)))
+              const raw = e.target.value
+              if (raw === '') {
+                setOfferMoney(0)
+                return
+              }
+              const val = Number(raw)
+              if (isNaN(val)) return
+              setOfferMoney(clamp(val, currentPlayer.money))
             }}
           />
+          <div className={styles.moneyQuickButtons}>
+            <button
+              type="button"
+              className={styles.moneyQuickButton}
+              onClick={() =>
+                setOfferMoney((prev) => clamp(prev + 10, currentPlayer.money))
+              }
+            >
+              +$10
+            </button>
+            <button
+              type="button"
+              className={styles.moneyQuickButton}
+              onClick={() =>
+                setOfferMoney((prev) => clamp(prev + 100, currentPlayer.money))
+              }
+            >
+              +$100
+            </button>
+            <button
+              type="button"
+              className={styles.moneyQuickButtonClear}
+              onClick={() => setOfferMoney(0)}
+            >
+              クリア
+            </button>
+          </div>
         </div>
       </div>
       <div className={styles.tradeSection}>
@@ -165,28 +194,54 @@ export default function TradeDialog({
             </button>
           ))}
         </div>
-        <div
-          style={{
-            marginTop: 8,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 8,
-          }}
-        >
-          <span style={{ fontSize: 14 }}>おかね: $</span>
+        <div className={styles.moneyInputRow}>
+          <span className={styles.moneyInputLabel}>おかね: $</span>
           <input
             className={styles.moneyInput}
             type="number"
+            inputMode="numeric"
             min={0}
             max={targetPlayer.money}
-            value={requestMoney}
+            value={requestMoney === 0 ? '' : requestMoney}
+            placeholder="0"
             onChange={(e) => {
-              const val = Math.floor(Number(e.target.value))
-              if (isNaN(val)) setRequestMoney(0)
-              else
-                setRequestMoney(Math.max(0, Math.min(val, targetPlayer.money)))
+              const raw = e.target.value
+              if (raw === '') {
+                setRequestMoney(0)
+                return
+              }
+              const val = Number(raw)
+              if (isNaN(val)) return
+              setRequestMoney(clamp(val, targetPlayer.money))
             }}
           />
+          <div className={styles.moneyQuickButtons}>
+            <button
+              type="button"
+              className={styles.moneyQuickButton}
+              onClick={() =>
+                setRequestMoney((prev) => clamp(prev + 10, targetPlayer.money))
+              }
+            >
+              +$10
+            </button>
+            <button
+              type="button"
+              className={styles.moneyQuickButton}
+              onClick={() =>
+                setRequestMoney((prev) => clamp(prev + 100, targetPlayer.money))
+              }
+            >
+              +$100
+            </button>
+            <button
+              type="button"
+              className={styles.moneyQuickButtonClear}
+              onClick={() => setRequestMoney(0)}
+            >
+              クリア
+            </button>
+          </div>
         </div>
       </div>
     </Dialog>

--- a/src/components/ActionDialog/__tests__/tradeDialog.utils.test.ts
+++ b/src/components/ActionDialog/__tests__/tradeDialog.utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { clamp } from '../tradeDialog.utils'
+
+describe('clamp', () => {
+  it('範囲内の値はそのまま小数を切り捨てて返す', () => {
+    expect(clamp(50, 100)).toBe(50)
+    expect(clamp(50.7, 100)).toBe(50)
+  })
+
+  it('負の値は0にクランプする', () => {
+    expect(clamp(-10, 100)).toBe(0)
+  })
+
+  it('最大値を超える値はmaxにクランプする', () => {
+    expect(clamp(150, 100)).toBe(100)
+  })
+
+  it('境界値（0とmax）を正しく扱う', () => {
+    expect(clamp(0, 100)).toBe(0)
+    expect(clamp(100, 100)).toBe(100)
+  })
+})

--- a/src/components/ActionDialog/tradeDialog.utils.ts
+++ b/src/components/ActionDialog/tradeDialog.utils.ts
@@ -1,0 +1,2 @@
+export const clamp = (val: number, max: number) =>
+  Math.max(0, Math.min(Math.floor(val), max))


### PR DESCRIPTION
## Summary

交換ダイアログ（TradeDialog）のおかね入力欄を改善し、特に子供でも誤入力なく操作しやすくしました。

- 初期値 `0` を空表示（placeholder）にしました。フォーカス時にキャレットが `0` の右に立たず、`$20` を入力したいのに `020` になってしまう問題を解消。
- `+$10` / `+$100` / `クリア` のクイック加算ボタンを入力欄の右隣に追加。数字キーボードを開かなくてもタップだけで金額を組み立てられます。
- 上限は所持金（`currentPlayer.money` / `targetPlayer.money`）でクランプ。下限は0。

両方の入力欄（`わたすもの` と `もらうもの`）に適用しています。

## Changes
- `src/components/ActionDialog/TradeDialog.tsx`
  - `value` を `0` のとき空文字に切り替え
  - クイック加算ボタンを追加し、`clamp` ヘルパーで上限/下限を統一
- `src/components/ActionDialog/ActionDialog.module.css`
  - `moneyInputRow` / `moneyInputLabel` / `moneyQuickButtons` / `moneyQuickButton` / `moneyQuickButtonClear` を追加
  - インラインスタイルだったレイアウトを CSS Modules 側へ移動

## Test plan
- [x] `npm run typecheck` 成功
- [x] `npm run lint` 成功
- [x] `npm run format:check` 成功
- [x] `npm test`（143 tests passed）
- [ ] 手元で起動し、交換ダイアログを開く → おかね欄の初期表示が空になっていることを確認
- [ ] フォーカスして `20` と入力 → `020` にならず `20` のみ表示されることを確認
- [ ] `+$10` を 2 回タップ → `20` になることを確認
- [ ] `+$100` を所持金以上タップしても所持金で頭打ちになることを確認
- [ ] `クリア` で空表示に戻ることを確認