### PR TITLE
feat: ✨ セットアップ画面の設定をlocalStorageで永続化

### DIFF
--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -19,14 +19,15 @@ const DEFAULT_NAMES = [
 const DEFAULT_TOKENS: string[] = [TOKENS[0], TOKENS[1], TOKENS[2], TOKENS[3]]
 
 export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
+  const [initialConfig] = useState(() => loadSetupConfig())
   const [playerCount, setPlayerCount] = useState(
-    () => loadSetupConfig()?.playerCount ?? 2,
+    initialConfig?.playerCount ?? 2,
   )
   const [names, setNames] = useState<string[]>(
-    () => loadSetupConfig()?.names ?? DEFAULT_NAMES,
+    initialConfig?.names ?? DEFAULT_NAMES,
   )
   const [selectedTokens, setSelectedTokens] = useState<string[]>(
-    () => loadSetupConfig()?.tokens ?? DEFAULT_TOKENS,
+    initialConfig?.tokens ?? DEFAULT_TOKENS,
   )
 
   useEffect(() => {

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { TOKENS } from '../../game/types'
+import { TOKENS, MIN_PLAYERS, MAX_PLAYERS } from '../../game/types'
 import type { GameState } from '../../game/types'
 import { loadSetupConfig, saveSetupConfig } from '../../game/storage'
 import Button from '../common/Button'
@@ -21,7 +21,7 @@ const DEFAULT_TOKENS: string[] = [TOKENS[0], TOKENS[1], TOKENS[2], TOKENS[3]]
 export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
   const [initialConfig] = useState(() => loadSetupConfig())
   const [playerCount, setPlayerCount] = useState(
-    initialConfig?.playerCount ?? 2,
+    initialConfig?.playerCount ?? MIN_PLAYERS,
   )
   const [names, setNames] = useState<string[]>(
     initialConfig?.names ?? DEFAULT_NAMES,
@@ -88,7 +88,7 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
         <button
           className={styles.countButton}
           onClick={() => setPlayerCount((c) => c - 1)}
-          disabled={playerCount <= 2}
+          disabled={playerCount <= MIN_PLAYERS}
         >
           −
         </button>
@@ -96,7 +96,7 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
         <button
           className={styles.countButton}
           onClick={() => setPlayerCount((c) => c + 1)}
-          disabled={playerCount >= 4}
+          disabled={playerCount >= MAX_PLAYERS}
         >
           ＋
         </button>

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { TOKENS } from '../../game/types'
 import type { GameState } from '../../game/types'
+import { loadSetupConfig, saveSetupConfig } from '../../game/storage'
 import Button from '../common/Button'
 import styles from './Setup.module.css'
 
@@ -15,16 +16,22 @@ const DEFAULT_NAMES = [
   'プレイヤー3',
   'プレイヤー4',
 ]
+const DEFAULT_TOKENS: string[] = [TOKENS[0], TOKENS[1], TOKENS[2], TOKENS[3]]
 
 export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
-  const [playerCount, setPlayerCount] = useState(2)
-  const [names, setNames] = useState(DEFAULT_NAMES)
-  const [selectedTokens, setSelectedTokens] = useState<string[]>([
-    TOKENS[0],
-    TOKENS[1],
-    TOKENS[2],
-    TOKENS[3],
-  ])
+  const [playerCount, setPlayerCount] = useState(
+    () => loadSetupConfig()?.playerCount ?? 2,
+  )
+  const [names, setNames] = useState<string[]>(
+    () => loadSetupConfig()?.names ?? DEFAULT_NAMES,
+  )
+  const [selectedTokens, setSelectedTokens] = useState<string[]>(
+    () => loadSetupConfig()?.tokens ?? DEFAULT_TOKENS,
+  )
+
+  useEffect(() => {
+    saveSetupConfig({ playerCount, names, tokens: selectedTokens })
+  }, [playerCount, names, selectedTokens])
 
   const handleNameChange = (index: number, name: string) => {
     const newNames = [...names]

--- a/src/game/__tests__/storage.test.ts
+++ b/src/game/__tests__/storage.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  saveGame,
+  loadGame,
+  clearSave,
+  saveSetupConfig,
+  loadSetupConfig,
+} from '../storage'
+import type { GameState } from '../types'
+import { TOKENS } from '../types'
+
+const STORAGE_KEY = 'monopoly-save'
+const SETUP_KEY = 'monopoly-setup'
+
+const createPlayingState = (): GameState =>
+  ({
+    phase: 'playing',
+    players: [
+      {
+        id: 'p1',
+        name: 'たろう',
+        token: '🚗',
+        money: 1500,
+        position: 0,
+        properties: [],
+        inJail: false,
+        jailTurns: 0,
+        getOutOfJailCards: 0,
+        isBankrupt: false,
+      },
+    ],
+    currentPlayerIndex: 0,
+    board: [],
+    propertyStates: {},
+    cards: { chance: [], communityChest: [] },
+    dice: { values: [1, 1], doubles: 0, rolled: false },
+    turnPhase: 'roll',
+    auction: null,
+    trade: null,
+    currentCard: null,
+    message: '',
+    winnerId: null,
+  }) as GameState
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('saveGame / loadGame', () => {
+  it('phase=playingのstateを保存して復元できる', () => {
+    const state = createPlayingState()
+    saveGame(state)
+    const loaded = loadGame()
+    expect(loaded).not.toBeNull()
+    expect(loaded?.players[0].name).toBe('たろう')
+  })
+
+  it('phase=playing以外のstateは保存しない', () => {
+    const state = { ...createPlayingState(), phase: 'setup' } as GameState
+    saveGame(state)
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('保存がなければnullを返す', () => {
+    expect(loadGame()).toBeNull()
+  })
+
+  it('phaseがplayingでない保存データはnullを返す', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ ...createPlayingState(), phase: 'setup' }),
+    )
+    expect(loadGame()).toBeNull()
+  })
+
+  it('playersが空ならnullを返す', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ ...createPlayingState(), players: [] }),
+    )
+    expect(loadGame()).toBeNull()
+  })
+
+  it('壊れたJSONはnullを返す', () => {
+    localStorage.setItem(STORAGE_KEY, '{ invalid json')
+    expect(loadGame()).toBeNull()
+  })
+
+  it('saveGameはlocalStorageの例外を握りつぶす', () => {
+    const spy = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('quota exceeded')
+      })
+    expect(() => saveGame(createPlayingState())).not.toThrow()
+    spy.mockRestore()
+  })
+})
+
+describe('clearSave', () => {
+  it('保存データを削除する', () => {
+    saveGame(createPlayingState())
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull()
+    clearSave()
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('removeItem例外を握りつぶす', () => {
+    const spy = vi
+      .spyOn(Storage.prototype, 'removeItem')
+      .mockImplementation(() => {
+        throw new Error('failed')
+      })
+    expect(() => clearSave()).not.toThrow()
+    spy.mockRestore()
+  })
+})
+
+describe('saveSetupConfig / loadSetupConfig', () => {
+  const validConfig = {
+    playerCount: 3,
+    names: ['A', 'B', 'C', 'D'],
+    tokens: [TOKENS[0], TOKENS[1], TOKENS[2], TOKENS[3]],
+  }
+
+  it('正常な設定を保存して復元できる', () => {
+    saveSetupConfig(validConfig)
+    expect(loadSetupConfig()).toEqual(validConfig)
+  })
+
+  it('保存がなければnullを返す', () => {
+    expect(loadSetupConfig()).toBeNull()
+  })
+
+  it('壊れたJSONはnullを返す', () => {
+    localStorage.setItem(SETUP_KEY, 'not-json')
+    expect(loadSetupConfig()).toBeNull()
+  })
+
+  it('playerCountが範囲外ならnullを返す', () => {
+    localStorage.setItem(
+      SETUP_KEY,
+      JSON.stringify({ ...validConfig, playerCount: 5 }),
+    )
+    expect(loadSetupConfig()).toBeNull()
+    localStorage.setItem(
+      SETUP_KEY,
+      JSON.stringify({ ...validConfig, playerCount: 1 }),
+    )
+    expect(loadSetupConfig()).toBeNull()
+  })
+
+  it('playerCountが数値でなければnullを返す', () => {
+    localStorage.setItem(
+      SETUP_KEY,
+      JSON.stringify({ ...validConfig, playerCount: '3' }),
+    )
+    expect(loadSetupConfig()).toBeNull()
+  })
+
+  it('namesの長さが4でなければnullを返す', () => {
+    localStorage.setItem(
+      SETUP_KEY,
+      JSON.stringify({ ...validConfig, names: ['A', 'B', 'C'] }),
+    )
+    expect(loadSetupConfig()).toBeNull()
+  })
+
+  it('tokensの長さが4でなければnullを返す', () => {
+    localStorage.setItem(
+      SETUP_KEY,
+      JSON.stringify({ ...validConfig, tokens: [TOKENS[0]] }),
+    )
+    expect(loadSetupConfig()).toBeNull()
+  })
+
+  it('namesが配列でなければnullを返す', () => {
+    localStorage.setItem(
+      SETUP_KEY,
+      JSON.stringify({ ...validConfig, names: 'ABCD' }),
+    )
+    expect(loadSetupConfig()).toBeNull()
+  })
+
+  it('tokensが配列でなければnullを返す', () => {
+    localStorage.setItem(
+      SETUP_KEY,
+      JSON.stringify({ ...validConfig, tokens: 'XXXX' }),
+    )
+    expect(loadSetupConfig()).toBeNull()
+  })
+
+  it('namesに非文字列が混ざっていればnullを返す', () => {
+    localStorage.setItem(
+      SETUP_KEY,
+      JSON.stringify({ ...validConfig, names: ['A', 'B', 'C', 1] }),
+    )
+    expect(loadSetupConfig()).toBeNull()
+  })
+
+  it('tokensに未知の値が含まれていればnullを返す', () => {
+    localStorage.setItem(
+      SETUP_KEY,
+      JSON.stringify({
+        ...validConfig,
+        tokens: [TOKENS[0], TOKENS[1], TOKENS[2], '🦄'],
+      }),
+    )
+    expect(loadSetupConfig()).toBeNull()
+  })
+
+  it('saveSetupConfigはlocalStorageの例外を握りつぶす', () => {
+    const spy = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('quota exceeded')
+      })
+    expect(() => saveSetupConfig(validConfig)).not.toThrow()
+    spy.mockRestore()
+  })
+})

--- a/src/game/storage.ts
+++ b/src/game/storage.ts
@@ -1,6 +1,14 @@
 import type { GameState } from './types'
+import { TOKENS } from './types'
 
 const STORAGE_KEY = 'monopoly-save'
+const SETUP_KEY = 'monopoly-setup'
+
+export type SetupConfig = {
+  playerCount: number
+  names: string[]
+  tokens: string[]
+}
 
 export function saveGame(state: GameState): void {
   if (state.phase !== 'playing') return
@@ -29,5 +37,44 @@ export function clearSave(): void {
     localStorage.removeItem(STORAGE_KEY)
   } catch {
     // silently fail
+  }
+}
+
+export function saveSetupConfig(config: SetupConfig): void {
+  try {
+    localStorage.setItem(SETUP_KEY, JSON.stringify(config))
+  } catch {
+    // localStorage full or unavailable - silently fail
+  }
+}
+
+export function loadSetupConfig(): SetupConfig | null {
+  try {
+    const saved = localStorage.getItem(SETUP_KEY)
+    if (!saved) return null
+    const config = JSON.parse(saved) as Partial<SetupConfig>
+    if (
+      typeof config.playerCount !== 'number' ||
+      config.playerCount < 2 ||
+      config.playerCount > 4 ||
+      !Array.isArray(config.names) ||
+      !Array.isArray(config.tokens) ||
+      config.names.length !== 4 ||
+      config.tokens.length !== 4 ||
+      !config.names.every((n) => typeof n === 'string') ||
+      !config.tokens.every(
+        (t) =>
+          typeof t === 'string' && (TOKENS as readonly string[]).includes(t),
+      )
+    ) {
+      return null
+    }
+    return {
+      playerCount: config.playerCount,
+      names: config.names,
+      tokens: config.tokens,
+    }
+  } catch {
+    return null
   }
 }

--- a/src/game/storage.ts
+++ b/src/game/storage.ts
@@ -1,5 +1,5 @@
 import type { GameState } from './types'
-import { TOKENS } from './types'
+import { TOKENS, MIN_PLAYERS, MAX_PLAYERS } from './types'
 
 const STORAGE_KEY = 'monopoly-save'
 const SETUP_KEY = 'monopoly-setup'
@@ -55,12 +55,12 @@ export function loadSetupConfig(): SetupConfig | null {
     const config = JSON.parse(saved) as Partial<SetupConfig>
     if (
       typeof config.playerCount !== 'number' ||
-      config.playerCount < 2 ||
-      config.playerCount > 4 ||
+      config.playerCount < MIN_PLAYERS ||
+      config.playerCount > MAX_PLAYERS ||
       !Array.isArray(config.names) ||
       !Array.isArray(config.tokens) ||
-      config.names.length !== 4 ||
-      config.tokens.length !== 4 ||
+      config.names.length !== MAX_PLAYERS ||
+      config.tokens.length !== MAX_PLAYERS ||
       !config.names.every((n) => typeof n === 'string') ||
       !config.tokens.every(
         (t) =>

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -1,6 +1,10 @@
 // ── プレイヤートークン ──
 export const TOKENS = ['🚗', '🎩', '👞', '🐕', '🚀', '🌟'] as const
 
+// ── プレイヤー数の範囲 ──
+export const MIN_PLAYERS = 2
+export const MAX_PLAYERS = 4
+
 // ── 物件カラーグループ ──
 export type ColorGroup =
   | 'brown'


### PR DESCRIPTION
## Summary

- トップページのセットアップ画面で入力する**プレイヤー人数 / 名前 / コマ**を localStorage に保存し、再訪時に自動で復元するようにした。
- 毎回ゼロから設定し直す手間をなくすことが目的。
- `saveSetupConfig` / `loadSetupConfig` を追加。読み込み時は型バリデーションで壊れたデータをはじき、デフォルト値にフォールバックする。

## 変更点

- `src/game/storage.ts`: `SetupConfig` 型と `saveSetupConfig` / `loadSetupConfig` を追加（`monopoly-setup` キーで保存）。
- `src/components/Setup/Setup.tsx`: `useState` の初期値を `loadSetupConfig()` から復元、`useEffect` で人数・名前・コマの変更を検知して自動保存。

## Test plan

- [ ] 初回訪問時はデフォルト値（2人 / プレイヤー1〜4 / 🚗🎩👞🐕）が表示されることを確認。
- [ ] 人数・名前・コマをそれぞれ変更し、ページリロード後も維持されていることを確認。
- [ ] localStorage の `monopoly-setup` を不正な JSON / 不正な値に書き換えてリロードし、デフォルト値にフォールバックすることを確認。
- [ ] 既存ゲーム（`monopoly-save`）のロード機能（つづきからあそぶ）に影響がないことを確認。
- [x] `npm run typecheck` / `npm run lint` / `npm test` がすべてパス（147 tests passed）。