### PR TITLE
fix: 物件購入後もマス目の中央画像を表示する

### DIFF
--- a/src/components/Board/MiniMap.tsx
+++ b/src/components/Board/MiniMap.tsx
@@ -129,9 +129,7 @@ const MiniMap = memo(function MiniMap({
                   }}
                 />
               )}
-              {icon && !ownerId && (
-                <span className={styles.miniSpaceIcon}>{icon}</span>
-              )}
+              {icon && <span className={styles.miniSpaceIcon}>{icon}</span>}
               {ownerId && (
                 <span className={styles.miniOwnerToken}>
                   {players.find((p) => p.id === ownerId)?.token}

--- a/src/components/Board/MiniMap.tsx
+++ b/src/components/Board/MiniMap.tsx
@@ -129,7 +129,11 @@ const MiniMap = memo(function MiniMap({
                   }}
                 />
               )}
-              {icon && <span className={styles.miniSpaceIcon}>{icon}</span>}
+              {icon && (
+                <span className={styles.miniSpaceIcon} aria-hidden="true">
+                  {icon}
+                </span>
+              )}
               {ownerId && (
                 <span className={styles.miniOwnerToken}>
                   {players.find((p) => p.id === ownerId)?.token}


### PR DESCRIPTION
## Summary
- 物件を購入したマスでオーナー背景色（薄色）が付くと中央のアイコン（🚂 🅿️ 💰 等）が消えていた問題を修正
- `MiniMap.tsx` でアイコン表示条件から `!ownerId` を除外し、背景色・中央画像・右下の所有者トークンが共存するように
- CSS 上 `miniSpaceIcon` は中央配置・`miniOwnerToken` は右下配置のため、レイアウト調整は不要

## Test plan
- [ ] `npm run typecheck` が通る
- [ ] `npm run lint` が通る
- [ ] 物件未購入のマスで中央アイコンが表示される（既存挙動の確認）
- [ ] 物件購入後のマスで「背景色 + 中央アイコン + 右下のオーナートークン」が同時に表示される
- [ ] `chance` / `communityChest` / 駅 / 公共サービス / GO / Jail などの各マスで購入後も該当アイコンが残ることを確認