### PR TITLE
refactor: 💡 [Code Review] reducer側でTradeOfferの値範囲バリデーションを追加

### DIFF
--- a/src/game/__tests__/reducer-actions.test.ts
+++ b/src/game/__tests__/reducer-actions.test.ts
@@ -803,6 +803,97 @@ describe('トレード (OPEN/PROPOSE/ACCEPT/REJECT/CLOSE)', () => {
     const next = gameReducer(state, { type: 'REJECT_TRADE' })
     expect(next.trade).toBeNull()
   })
+
+  it('PROPOSE_TRADE で負の金額のオファーは state を変えない', () => {
+    const state = startedGame()
+    const offer = {
+      fromPlayerId: 'player-0',
+      toPlayerId: 'player-1',
+      offerProperties: [],
+      offerMoney: -100,
+      offerJailCards: 0,
+      requestProperties: [],
+      requestMoney: 0,
+      requestJailCards: 0,
+    }
+    const next = gameReducer(state, { type: 'PROPOSE_TRADE', offer })
+    expect(next).toBe(state)
+  })
+
+  it('PROPOSE_TRADE で所持金超過のオファーは state を変えない', () => {
+    const state = startedGame()
+    const offer = {
+      fromPlayerId: 'player-0',
+      toPlayerId: 'player-1',
+      offerProperties: [],
+      offerMoney: state.players[0].money + 1,
+      offerJailCards: 0,
+      requestProperties: [],
+      requestMoney: 0,
+      requestJailCards: 0,
+    }
+    const next = gameReducer(state, { type: 'PROPOSE_TRADE', offer })
+    expect(next).toBe(state)
+  })
+
+  it('PROPOSE_TRADE で非整数のオファーは state を変えない', () => {
+    const state = startedGame()
+    const offer = {
+      fromPlayerId: 'player-0',
+      toPlayerId: 'player-1',
+      offerProperties: [],
+      offerMoney: 10.5,
+      offerJailCards: 0,
+      requestProperties: [],
+      requestMoney: 0,
+      requestJailCards: 0,
+    }
+    const next = gameReducer(state, { type: 'PROPOSE_TRADE', offer })
+    expect(next).toBe(state)
+  })
+
+  it('PROPOSE_TRADE で他人の物件オファーは state を変えない', () => {
+    const state = startedGame()
+    const offer = {
+      fromPlayerId: 'player-0',
+      toPlayerId: 'player-1',
+      offerProperties: ['mediterranean'],
+      offerMoney: 0,
+      offerJailCards: 0,
+      requestProperties: [],
+      requestMoney: 0,
+      requestJailCards: 0,
+    }
+    const next = gameReducer(state, { type: 'PROPOSE_TRADE', offer })
+    expect(next).toBe(state)
+  })
+
+  it('ACCEPT_TRADE で提案後に提示者の所持金が減ると state を変えない', () => {
+    let state = startedGame()
+    const offerMoney = 1000
+    const offer = {
+      fromPlayerId: 'player-0',
+      toPlayerId: 'player-1',
+      offerProperties: [],
+      offerMoney,
+      offerJailCards: 0,
+      requestProperties: [],
+      requestMoney: 0,
+      requestJailCards: 0,
+    }
+    state = gameReducer(state, { type: 'PROPOSE_TRADE', offer })
+    // 提案後にプレイヤー0の所持金がオファー金額未満になるように改ざん
+    state = {
+      ...state,
+      players: state.players.map((p) =>
+        p.id === 'player-0' ? { ...p, money: offerMoney - 1 } : p,
+      ),
+    }
+    const before = state
+    const next = gameReducer(state, { type: 'ACCEPT_TRADE' })
+    expect(next).toBe(before)
+    expect(next.players[0].money).toBe(offerMoney - 1)
+  })
 })
 
 // ── ダイアログ開閉 ──

--- a/src/game/__tests__/rules.test.ts
+++ b/src/game/__tests__/rules.test.ts
@@ -475,4 +475,32 @@ describe('validateTradeOffer', () => {
     )
     expect(result).toEqual({ isValid: false, reason: 'PROPERTY_HAS_HOUSES' })
   })
+
+  it('同じカラーグループの他物件に家がある場合も PROPERTY_HAS_HOUSES', () => {
+    const base = startedGame()
+    const state: GameState = {
+      ...base,
+      players: base.players.map((p, i) =>
+        i === 0 ? { ...p, properties: ['mediterranean', 'baltic'] } : p,
+      ),
+      propertyStates: {
+        ...base.propertyStates,
+        mediterranean: {
+          ownerId: 'player-0',
+          houses: 0,
+          isMortgaged: false,
+        },
+        baltic: {
+          ownerId: 'player-0',
+          houses: 1,
+          isMortgaged: false,
+        },
+      },
+    }
+    const result = validateTradeOffer(
+      state,
+      makeOffer({ offerProperties: ['mediterranean'] }),
+    )
+    expect(result).toEqual({ isValid: false, reason: 'PROPERTY_HAS_HOUSES' })
+  })
 })

--- a/src/game/__tests__/rules.test.ts
+++ b/src/game/__tests__/rules.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import type { Player, PropertyState } from '../types'
+import type { GameState, Player, PropertyState, TradeOffer } from '../types'
 import { BOARD_SPACES } from '../board'
+import { createInitialGameState, gameReducer } from '../reducer'
 import {
   calculateRent,
   canBuildHouse,
@@ -9,6 +10,7 @@ import {
   canMortgage,
   canSellHouse,
   canUnmortgage,
+  validateTradeOffer,
 } from '../rules'
 
 function makePlayer(overrides: Partial<Player> = {}): Player {
@@ -317,5 +319,160 @@ describe('canUnmortgage', () => {
     expect(
       canUnmortgage('mediterranean', 'p1', player, states, BOARD_SPACES),
     ).toBe(false)
+  })
+})
+
+describe('validateTradeOffer', () => {
+  function startedGame(): GameState {
+    const initial = createInitialGameState()
+    return gameReducer(initial, {
+      type: 'START_GAME',
+      playerNames: ['プレイヤー1', 'プレイヤー2'],
+      playerTokens: ['🚗', '🎩'],
+    })
+  }
+
+  function makeOffer(overrides: Partial<TradeOffer> = {}): TradeOffer {
+    return {
+      fromPlayerId: 'player-0',
+      toPlayerId: 'player-1',
+      offerProperties: [],
+      offerMoney: 0,
+      offerJailCards: 0,
+      requestProperties: [],
+      requestMoney: 0,
+      requestJailCards: 0,
+      ...overrides,
+    }
+  }
+
+  it('正常なオファーは isValid: true を返す', () => {
+    const state = startedGame()
+    const result = validateTradeOffer(state, makeOffer({ offerMoney: 100 }))
+    expect(result.isValid).toBe(true)
+  })
+
+  it('存在しないプレイヤーIDは PLAYER_NOT_FOUND', () => {
+    const state = startedGame()
+    const result = validateTradeOffer(
+      state,
+      makeOffer({ toPlayerId: 'unknown' }),
+    )
+    expect(result).toEqual({ isValid: false, reason: 'PLAYER_NOT_FOUND' })
+  })
+
+  it('破産プレイヤーは PLAYER_BANKRUPT', () => {
+    const base = startedGame()
+    const state: GameState = {
+      ...base,
+      players: base.players.map((p, i) =>
+        i === 0 ? { ...p, isBankrupt: true } : p,
+      ),
+    }
+    const result = validateTradeOffer(state, makeOffer())
+    expect(result).toEqual({ isValid: false, reason: 'PLAYER_BANKRUPT' })
+  })
+
+  it('小数の金額は NOT_INTEGER', () => {
+    const state = startedGame()
+    const result = validateTradeOffer(state, makeOffer({ offerMoney: 10.5 }))
+    expect(result).toEqual({ isValid: false, reason: 'NOT_INTEGER' })
+  })
+
+  it('小数の刑務所カード枚数は NOT_INTEGER', () => {
+    const state = startedGame()
+    const result = validateTradeOffer(state, makeOffer({ offerJailCards: 1.5 }))
+    expect(result).toEqual({ isValid: false, reason: 'NOT_INTEGER' })
+  })
+
+  it('NaN の金額は NOT_INTEGER', () => {
+    const state = startedGame()
+    const result = validateTradeOffer(state, makeOffer({ offerMoney: NaN }))
+    expect(result).toEqual({ isValid: false, reason: 'NOT_INTEGER' })
+  })
+
+  it('負の金額は NEGATIVE_VALUE', () => {
+    const state = startedGame()
+    const result = validateTradeOffer(state, makeOffer({ offerMoney: -1 }))
+    expect(result).toEqual({ isValid: false, reason: 'NEGATIVE_VALUE' })
+  })
+
+  it('負の刑務所カード枚数は NEGATIVE_VALUE', () => {
+    const state = startedGame()
+    const result = validateTradeOffer(
+      state,
+      makeOffer({ requestJailCards: -1 }),
+    )
+    expect(result).toEqual({ isValid: false, reason: 'NEGATIVE_VALUE' })
+  })
+
+  it('提示者の所持金超過は INSUFFICIENT_FUNDS', () => {
+    const state = startedGame()
+    const fromMoney = state.players[0].money
+    const result = validateTradeOffer(
+      state,
+      makeOffer({ offerMoney: fromMoney + 1 }),
+    )
+    expect(result).toEqual({ isValid: false, reason: 'INSUFFICIENT_FUNDS' })
+  })
+
+  it('受け手の所持金超過は INSUFFICIENT_FUNDS', () => {
+    const state = startedGame()
+    const toMoney = state.players[1].money
+    const result = validateTradeOffer(
+      state,
+      makeOffer({ requestMoney: toMoney + 1 }),
+    )
+    expect(result).toEqual({ isValid: false, reason: 'INSUFFICIENT_FUNDS' })
+  })
+
+  it('刑務所カード枚数不足は INSUFFICIENT_JAIL_CARDS', () => {
+    const state = startedGame()
+    const result = validateTradeOffer(state, makeOffer({ offerJailCards: 1 }))
+    expect(result).toEqual({
+      isValid: false,
+      reason: 'INSUFFICIENT_JAIL_CARDS',
+    })
+  })
+
+  it('提示者が所有していない物件は NOT_PROPERTY_OWNER', () => {
+    const state = startedGame()
+    const result = validateTradeOffer(
+      state,
+      makeOffer({ offerProperties: ['mediterranean'] }),
+    )
+    expect(result).toEqual({ isValid: false, reason: 'NOT_PROPERTY_OWNER' })
+  })
+
+  it('受け手が所有していない物件は NOT_PROPERTY_OWNER', () => {
+    const state = startedGame()
+    const result = validateTradeOffer(
+      state,
+      makeOffer({ requestProperties: ['baltic'] }),
+    )
+    expect(result).toEqual({ isValid: false, reason: 'NOT_PROPERTY_OWNER' })
+  })
+
+  it('家が建っている物件は PROPERTY_HAS_HOUSES', () => {
+    const base = startedGame()
+    const state: GameState = {
+      ...base,
+      players: base.players.map((p, i) =>
+        i === 0 ? { ...p, properties: ['mediterranean'] } : p,
+      ),
+      propertyStates: {
+        ...base.propertyStates,
+        mediterranean: {
+          ownerId: 'player-0',
+          houses: 1,
+          isMortgaged: false,
+        },
+      },
+    }
+    const result = validateTradeOffer(
+      state,
+      makeOffer({ offerProperties: ['mediterranean'] }),
+    )
+    expect(result).toEqual({ isValid: false, reason: 'PROPERTY_HAS_HOUSES' })
   })
 })

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -13,6 +13,7 @@ import {
   canBuildHouse,
   canSellHouse,
   findNearestSpace,
+  validateTradeOffer,
 } from './rules'
 
 // ── 定数 ──
@@ -1017,6 +1018,7 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
 
     // ── PROPOSE_TRADE ──
     case 'PROPOSE_TRADE': {
+      if (!validateTradeOffer(state, action.offer).isValid) return state
       return {
         ...state,
         trade: action.offer,
@@ -1028,6 +1030,7 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
     // ── ACCEPT_TRADE ──
     case 'ACCEPT_TRADE': {
       if (!state.trade) return state
+      if (!validateTradeOffer(state, state.trade).isValid) return state
       const offer = state.trade
       const fromPlayer = state.players.find((p) => p.id === offer.fromPlayerId)!
       const toPlayer = state.players.find((p) => p.id === offer.toPlayerId)!

--- a/src/game/rules.ts
+++ b/src/game/rules.ts
@@ -1,4 +1,11 @@
-import type { BoardSpace, Player, PropertyState } from './types'
+import type {
+  BoardSpace,
+  GameState,
+  Player,
+  PropertyState,
+  TradeOffer,
+  TradeValidationResult,
+} from './types'
 
 export function getColorGroup(
   propertyId: string,
@@ -133,6 +140,69 @@ export function calculateTotalAssets(
       total += Math.floor(((space.houseCost ?? 0) * state.houses) / 2)
   }
   return total
+}
+
+export function validateTradeOffer(
+  state: GameState,
+  offer: TradeOffer,
+): TradeValidationResult {
+  const fromPlayer = state.players.find((p) => p.id === offer.fromPlayerId)
+  const toPlayer = state.players.find((p) => p.id === offer.toPlayerId)
+  if (!fromPlayer || !toPlayer) {
+    return { isValid: false, reason: 'PLAYER_NOT_FOUND' }
+  }
+  if (fromPlayer.isBankrupt || toPlayer.isBankrupt) {
+    return { isValid: false, reason: 'PLAYER_BANKRUPT' }
+  }
+
+  const numericFields = [
+    offer.offerMoney,
+    offer.requestMoney,
+    offer.offerJailCards,
+    offer.requestJailCards,
+  ]
+  if (numericFields.some((n) => !Number.isInteger(n))) {
+    return { isValid: false, reason: 'NOT_INTEGER' }
+  }
+  if (numericFields.some((n) => n < 0)) {
+    return { isValid: false, reason: 'NEGATIVE_VALUE' }
+  }
+
+  if (
+    offer.offerMoney > fromPlayer.money ||
+    offer.requestMoney > toPlayer.money
+  ) {
+    return { isValid: false, reason: 'INSUFFICIENT_FUNDS' }
+  }
+  if (
+    offer.offerJailCards > fromPlayer.getOutOfJailCards ||
+    offer.requestJailCards > toPlayer.getOutOfJailCards
+  ) {
+    return { isValid: false, reason: 'INSUFFICIENT_JAIL_CARDS' }
+  }
+
+  if (
+    !offer.offerProperties.every((id) => fromPlayer.properties.includes(id))
+  ) {
+    return { isValid: false, reason: 'NOT_PROPERTY_OWNER' }
+  }
+  if (
+    !offer.requestProperties.every((id) => toPlayer.properties.includes(id))
+  ) {
+    return { isValid: false, reason: 'NOT_PROPERTY_OWNER' }
+  }
+
+  const tradedProperties = [
+    ...offer.offerProperties,
+    ...offer.requestProperties,
+  ]
+  if (
+    tradedProperties.some((id) => (state.propertyStates[id]?.houses ?? 0) > 0)
+  ) {
+    return { isValid: false, reason: 'PROPERTY_HAS_HOUSES' }
+  }
+
+  return { isValid: true }
 }
 
 export function canSellHouse(

--- a/src/game/rules.ts
+++ b/src/game/rules.ts
@@ -197,7 +197,10 @@ export function validateTradeOffer(
     ...offer.requestProperties,
   ]
   if (
-    tradedProperties.some((id) => (state.propertyStates[id]?.houses ?? 0) > 0)
+    tradedProperties.some((id) => {
+      const group = getColorGroup(id, state.board)
+      return group.some((gid) => (state.propertyStates[gid]?.houses ?? 0) > 0)
+    })
   ) {
     return { isValid: false, reason: 'PROPERTY_HAS_HOUSES' }
   }

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -101,6 +101,21 @@ export type TradeOffer = {
   requestJailCards: number
 }
 
+// ── 取引検証結果 ──
+export type TradeInvalidReason =
+  | 'PLAYER_NOT_FOUND'
+  | 'PLAYER_BANKRUPT'
+  | 'NOT_INTEGER'
+  | 'NEGATIVE_VALUE'
+  | 'INSUFFICIENT_FUNDS'
+  | 'INSUFFICIENT_JAIL_CARDS'
+  | 'NOT_PROPERTY_OWNER'
+  | 'PROPERTY_HAS_HOUSES'
+
+export type TradeValidationResult =
+  | { isValid: true }
+  | { isValid: false; reason: TradeInvalidReason }
+
 // ── ターンフェーズ ──
 export type TurnPhase =
   | 'roll'


### PR DESCRIPTION
## Summary

- Issue #33 の対応として、`PROPOSE_TRADE` / `ACCEPT_TRADE` の reducer 側に防御的バリデーションを追加
- 検証ロジックは `src/game/rules.ts` の `validateTradeOffer` に集約（純粋関数）
- 検証結果は `{ isValid, reason? }` 型で、将来の UI エラー通知拡張に対応

## 変更内容

### 検証ルール（`validateTradeOffer`）
- プレイヤー存在・非破産チェック
- `offerMoney` / `requestMoney` / `offerJailCards` / `requestJailCards` が `Number.isInteger` かつ 0 以上
- 所持金超過（`offerMoney` > `fromPlayer.money` 等）の拒否
- 刑務所カード枚数超過の拒否
- プロパティ所有権の検証（オファー側／受け手側）
- 家が建っている物件の除外（既存 UI ロジックと整合）

### Reducer
- 既存の `BUILD_HOUSE` / `FORCE_BUY` パターンに合わせて、無効なら `return state`（no-op）
- `ACCEPT_TRADE` でも再検証（提案～受理間の `state` 変化を考慮）

### 多層防御
- `TradeDialog.tsx` の UI 側 `clamp` は維持（重複防御として有効）

## Test plan

- [x] `pnpm test` グリーン（187/187 pass、`validateTradeOffer` 単体テスト14件 + 統合テスト5件追加）
- [x] `pnpm typecheck` パス
- [x] `pnpm lint` 警告なし
- [x] `pnpm format:check` パス

Closes #33