### PR TITLE
refactor: 💡 プレイヤー情報エリアと操作ボタンのレイアウトを整理

### DIFF
--- a/src/components/Board/MiniMap.tsx
+++ b/src/components/Board/MiniMap.tsx
@@ -5,6 +5,7 @@ import type {
   PropertyState,
   ColorGroup,
 } from '../../game/types'
+import { getOwnerBg } from '../common/playerColors'
 import styles from './Board.module.css'
 
 const COLOR_MAP: Record<ColorGroup, string> = {
@@ -17,14 +18,6 @@ const COLOR_MAP: Record<ColorGroup, string> = {
   green: 'var(--color-green)',
   blue: 'var(--color-blue)',
   railroad: '#555',
-}
-
-/** プレイヤーごとの所有マス背景色（薄い色） */
-const OWNER_BG: Record<string, string> = {
-  'player-0': 'rgba(255, 107, 107, 0.25)',
-  'player-1': 'rgba(78, 205, 196, 0.25)',
-  'player-2': 'rgba(255, 230, 109, 0.35)',
-  'player-3': 'rgba(155, 89, 182, 0.25)',
 }
 
 /** マスタイプに応じたアイコン */
@@ -99,9 +92,7 @@ const MiniMap = memo(function MiniMap({
           const propState = propertyStates[space.id]
           const icon = getSpaceIcon(space)
           const ownerId = propState?.ownerId
-          const ownerBg = ownerId
-            ? (OWNER_BG[ownerId] ?? 'rgba(150,150,150,0.2)')
-            : undefined
+          const ownerBg = ownerId ? getOwnerBg(ownerId) : undefined
 
           return (
             <div

--- a/src/components/GameBoard/GameBoard.module.css
+++ b/src/components/GameBoard/GameBoard.module.css
@@ -28,20 +28,32 @@
   gap: 8px;
   align-items: center;
 }
+.subActionsRow {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 32px;
+  gap: 8px;
+}
 .subActions {
+  flex: 1;
   display: flex;
   gap: 8px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   justify-content: center;
+  min-width: 0;
+}
+.subActionButton {
+  padding-left: 10px;
+  padding-right: 10px;
 }
 .muteButton {
-  position: fixed;
-  top: 8px;
-  right: 8px;
+  flex-shrink: 0;
   background: none;
   border: none;
   font-size: 20px;
   cursor: pointer;
-  z-index: 50;
   opacity: 0.6;
+  padding: 4px;
+  margin-left: auto;
 }

--- a/src/components/GameBoard/GameBoard.module.css
+++ b/src/components/GameBoard/GameBoard.module.css
@@ -40,6 +40,7 @@
   display: flex;
   gap: 8px;
   flex-wrap: nowrap;
+  overflow-x: auto;
   justify-content: center;
   min-width: 0;
 }

--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -256,13 +256,6 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
 
   return (
     <div className={styles.gameBoard}>
-      <PlayerPanel
-        currentPlayer={currentPlayer}
-        allPlayers={state.players}
-        currentPlayerIndex={state.currentPlayerIndex}
-        onPlayerClick={handlePlayerClick}
-      />
-
       <div className={styles.boardSection}>
         <MiniMap
           board={state.board}
@@ -275,6 +268,12 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
       </div>
 
       {state.message && <div className={styles.message}>{state.message}</div>}
+
+      <PlayerPanel
+        allPlayers={state.players}
+        currentPlayerIndex={state.currentPlayerIndex}
+        onPlayerClick={handlePlayerClick}
+      />
 
       <div className={styles.actions}>
         {state.turnPhase === 'roll' && !currentPlayer.inJail && (
@@ -301,43 +300,48 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
           </Button>
         )}
 
-        {canSubAction && (
-          <div className={styles.subActions}>
-            <Button
-              size="small"
-              variant="secondary"
-              onClick={() => dispatch({ type: 'OPEN_BUILD_DIALOG' })}
-            >
-              🏠 いえをたてる
-            </Button>
-            <Button
-              size="small"
-              variant="secondary"
-              onClick={() => dispatch({ type: 'OPEN_SELL_DIALOG' })}
-            >
-              🏷️ 売りだし
-            </Button>
-            {otherActivePlayers.length > 0 && (
+        <div className={styles.subActionsRow}>
+          {canSubAction && (
+            <div className={styles.subActions}>
               <Button
                 size="small"
                 variant="secondary"
-                onClick={() => setShowTradeSelect(true)}
+                className={styles.subActionButton}
+                onClick={() => dispatch({ type: 'OPEN_BUILD_DIALOG' })}
               >
-                🤝 こうかん
+                🏠 いえをたてる
               </Button>
-            )}
-          </div>
-        )}
+              <Button
+                size="small"
+                variant="secondary"
+                className={styles.subActionButton}
+                onClick={() => dispatch({ type: 'OPEN_SELL_DIALOG' })}
+              >
+                🏷️ 売りだし
+              </Button>
+              {otherActivePlayers.length > 0 && (
+                <Button
+                  size="small"
+                  variant="secondary"
+                  className={styles.subActionButton}
+                  onClick={() => setShowTradeSelect(true)}
+                >
+                  🤝 こうかん
+                </Button>
+              )}
+            </div>
+          )}
+          <button
+            type="button"
+            className={styles.muteButton}
+            onClick={toggleMute}
+            aria-label={muted ? 'サウンドをオンにする' : 'サウンドをオフにする'}
+            title={muted ? 'サウンドをオンにする' : 'サウンドをオフにする'}
+          >
+            {muted ? '🔇' : '🔊'}
+          </button>
+        </div>
       </div>
-
-      <button
-        className={styles.muteButton}
-        onClick={toggleMute}
-        aria-label={muted ? 'サウンドをオンにする' : 'サウンドをオフにする'}
-        title={muted ? 'サウンドをオンにする' : 'サウンドをオフにする'}
-      >
-        {muted ? '🔇' : '🔊'}
-      </button>
 
       {/* Dialogs */}
       {showPurchaseDialog && currentSpace && (

--- a/src/components/PlayerPanel/PlayerPanel.module.css
+++ b/src/components/PlayerPanel/PlayerPanel.module.css
@@ -15,6 +15,7 @@
   font-weight: 600;
   white-space: nowrap;
   box-shadow: var(--shadow);
+  cursor: pointer;
 }
 .playerChipActive {
   border: 2px solid var(--color-primary);

--- a/src/components/PlayerPanel/PlayerPanel.module.css
+++ b/src/components/PlayerPanel/PlayerPanel.module.css
@@ -1,22 +1,3 @@
-.currentPlayer {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 12px 16px;
-  background: var(--color-white);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
-}
-.token {
-  font-size: 32px;
-}
-.info {
-  flex: 1;
-}
-.name {
-  font-size: 18px;
-  font-weight: 700;
-}
 .allPlayers {
   display: flex;
   gap: 8px;

--- a/src/components/PlayerPanel/PlayerPanel.tsx
+++ b/src/components/PlayerPanel/PlayerPanel.tsx
@@ -21,7 +21,7 @@ const PlayerPanel = memo(function PlayerPanel({
           key={player.id}
           className={`${styles.playerChip} ${idx === currentPlayerIndex ? styles.playerChipActive : ''} ${player.isBankrupt ? styles.playerChipBankrupt : ''}`}
           onClick={() => onPlayerClick?.(player.id)}
-          style={{ cursor: 'pointer', background: getOwnerBg(player.id) }}
+          style={{ background: getOwnerBg(player.id) }}
         >
           <span>{player.token}</span>
           <span>${player.money.toLocaleString()}</span>

--- a/src/components/PlayerPanel/PlayerPanel.tsx
+++ b/src/components/PlayerPanel/PlayerPanel.tsx
@@ -1,44 +1,34 @@
 import { memo } from 'react'
 import type { Player } from '../../game/types'
+import { getOwnerBg } from '../common/playerColors'
 import styles from './PlayerPanel.module.css'
 
 type PlayerPanelProps = {
-  currentPlayer: Player
   allPlayers: Player[]
   currentPlayerIndex: number
   onPlayerClick?: (playerId: string) => void
 }
 
 const PlayerPanel = memo(function PlayerPanel({
-  currentPlayer,
   allPlayers,
   currentPlayerIndex,
   onPlayerClick,
 }: PlayerPanelProps) {
   return (
-    <>
-      <div className={styles.currentPlayer}>
-        <span className={styles.token}>{currentPlayer.token}</span>
-        <div className={styles.info}>
-          <div className={styles.name}>{currentPlayer.name}のばん</div>
+    <div className={styles.allPlayers}>
+      {allPlayers.map((player, idx) => (
+        <div
+          key={player.id}
+          className={`${styles.playerChip} ${idx === currentPlayerIndex ? styles.playerChipActive : ''} ${player.isBankrupt ? styles.playerChipBankrupt : ''}`}
+          onClick={() => onPlayerClick?.(player.id)}
+          style={{ cursor: 'pointer', background: getOwnerBg(player.id) }}
+        >
+          <span>{player.token}</span>
+          <span>${player.money.toLocaleString()}</span>
+          {player.inJail && <span className={styles.jailBadge}>🔒</span>}
         </div>
-        {currentPlayer.inJail && <span className={styles.jailBadge}>🔒</span>}
-      </div>
-      <div className={styles.allPlayers}>
-        {allPlayers.map((player, idx) => (
-          <div
-            key={player.id}
-            className={`${styles.playerChip} ${idx === currentPlayerIndex ? styles.playerChipActive : ''} ${player.isBankrupt ? styles.playerChipBankrupt : ''}`}
-            onClick={() => onPlayerClick?.(player.id)}
-            style={{ cursor: 'pointer' }}
-          >
-            <span>{player.token}</span>
-            <span>${player.money.toLocaleString()}</span>
-            {player.inJail && <span className={styles.jailBadge}>🔒</span>}
-          </div>
-        ))}
-      </div>
-    </>
+      ))}
+    </div>
   )
 })
 

--- a/src/components/common/playerColors.ts
+++ b/src/components/common/playerColors.ts
@@ -1,0 +1,14 @@
+/** プレイヤーごとの所有マス背景色（薄い色） */
+export const OWNER_BG: Record<string, string> = {
+  'player-0': 'rgba(255, 107, 107, 0.25)',
+  'player-1': 'rgba(78, 205, 196, 0.25)',
+  'player-2': 'rgba(255, 230, 109, 0.35)',
+  'player-3': 'rgba(155, 89, 182, 0.25)',
+}
+
+export const OWNER_BG_FALLBACK = 'rgba(150, 150, 150, 0.2)'
+
+export function getOwnerBg(playerId: string | null | undefined): string {
+  if (!playerId) return OWNER_BG_FALLBACK
+  return OWNER_BG[playerId] ?? OWNER_BG_FALLBACK
+}


### PR DESCRIPTION
## Summary

- ページ最上部の「〜のばん」表示を削除（黄色メッセージバーと重複していたため）
- 所持金額チップ（PlayerPanel）をサイコロ操作エリアの直上に移動
- 各プレイヤーの所持金額チップに所有マスと同じ背景色を適用し、ボード上の所有物件と色でひとめでマッチング可能に
- 音声On/Offボタンを右上の固定位置からサブアクション行の右端へ移動
- いえをたてる／売りだし／こうかんの3ボタンが折り返さず横一線に並ぶようpaddingを調整
- `OWNER_BG` 定義を `src/components/common/playerColors.ts` に共通化（MiniMap・PlayerPanel間で重複していた定義を集約）

## Test plan

- [ ] ゲーム開始後、ページ最上部に「〜のばん」のヘッダーが表示されないこと
- [ ] 所持金額チップがミニマップ・メッセージバーの直下、さいころをふるボタンの直上に表示されること
- [ ] 各プレイヤーのチップ背景色が、ボード上で所有しているマスの背景色と一致していること
- [ ] 音声On/Offボタンがサブアクション行の右端に表示され、3つのサブアクションボタンと重ならないこと
- [ ] スマートフォン幅でも、いえをたてる／売りだし／こうかんの3ボタンが折り返さず横一線で表示されること
- [ ] ミュート切り替えが従来通り動作すること
- [ ] `npx tsc --noEmit` が通ること
- [ ] `npx eslint src/components` が通ること