### PR TITLE
🎨 Palette: Accessibility improvements for the Setup screen

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+## 2024-03-24 - Symbol-only Buttons & Implicit Inputs
+
+**Learning:** Symbol-only buttons (like `＋` and `−`) and inputs lacking visible labels but having placeholders are entirely inaccessible to screen readers without explicit ARIA attributes. Furthermore, when dynamic content like player count updates without a page load, screen readers will remain silent unless instructed to announce the change.
+**Action:** When creating setup forms or any interactive components, ensure every interactive element has a discernible name (via text content, `aria-label`, or `<label>`). For dynamic text that updates based on user action without changing focus, employ `aria-live="polite"` so screen readers proactively announce the new state.

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -93,7 +93,7 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
         >
           −
         </button>
-        <span aria-live="polite">{playerCount}人であそぶ</span>
+        <span role="status">{playerCount}人であそぶ</span>
         <button
           className={styles.countButton}
           onClick={() => setPlayerCount((c) => c + 1)}

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -89,14 +89,16 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
           className={styles.countButton}
           onClick={() => setPlayerCount((c) => c - 1)}
           disabled={playerCount <= MIN_PLAYERS}
+          aria-label="プレイヤーを減らす"
         >
           −
         </button>
-        <span>{playerCount}人であそぶ</span>
+        <span aria-live="polite">{playerCount}人であそぶ</span>
         <button
           className={styles.countButton}
           onClick={() => setPlayerCount((c) => c + 1)}
           disabled={playerCount >= MAX_PLAYERS}
+          aria-label="プレイヤーを増やす"
         >
           ＋
         </button>
@@ -128,6 +130,7 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
               value={names[i]}
               onChange={(e) => handleNameChange(i, e.target.value)}
               placeholder={`プレイヤー${i + 1}のなまえ`}
+              aria-label={`プレイヤー${i + 1}のなまえ`}
             />
           </div>
         ))}


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label`s to symbol-only `＋` and `−` buttons in the Setup screen, added `aria-live="polite"` to the dynamic player count, and added `aria-label` to the player name `<input>` that previously relied solely on a placeholder. Documented this finding in `.jules/palette.md`.

🎯 **Why:** To make the initial game setup screen navigable and usable for screen reader users by giving explicit accessible names to interactive elements and announcing state changes. 

📸 **Before/After:** The changes are purely structural (semantic HTML) and do not affect visual layout.

♿ **Accessibility:**
- Symbol-only minus/plus buttons are now announced properly.
- Dynamic text updates (player count) are now read aloud immediately.
- Form inputs have explicit accessible names.

---
*PR created automatically by Jules for task [15434057480907265557](https://jules.google.com/task/15434057480907265557) started by @genzouw*