### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input length limits to player names

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,8 @@
 **Vulnerability:** A player could potentially enter a negative number for `offerMoney` or `requestMoney` in `TradeDialog.tsx`, or values exceeding their actual balance. This is because HTML `min`/`max` attributes only constrain browser UI up/down arrows, not keyboard input or script-level changes.
 **Learning:** React state updates on `<input type="number">` bypass HTML min/max constraints.
 **Prevention:** Always enforce logical constraints in the `onChange` handler or just before saving the state, bounding values to valid ranges.
+## 2026-05-07 - Unbounded Player Name Inputs
+
+**Vulnerability:** Player names lacked maximum length limits in both the UI and storage layers, risking DoS or UI overflow issues from overly large strings.
+**Learning:** Relying solely on UI limits is insufficient; storage boundary validation is critical defense-in-depth.
+**Prevention:** Apply `maxLength` in UI inputs, truncate programmatically, and validate max limits during storage retrieval.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,6 +3,7 @@
 **Vulnerability:** A player could potentially enter a negative number for `offerMoney` or `requestMoney` in `TradeDialog.tsx`, or values exceeding their actual balance. This is because HTML `min`/`max` attributes only constrain browser UI up/down arrows, not keyboard input or script-level changes.
 **Learning:** React state updates on `<input type="number">` bypass HTML min/max constraints.
 **Prevention:** Always enforce logical constraints in the `onChange` handler or just before saving the state, bounding values to valid ranges.
+
 ## 2026-05-07 - Unbounded Player Name Inputs
 
 **Vulnerability:** Player names lacked maximum length limits in both the UI and storage layers, risking DoS or UI overflow issues from overly large strings.

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -36,7 +36,8 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
 
   const handleNameChange = (index: number, name: string) => {
     const newNames = [...names]
-    newNames[index] = name
+    // Security enhancement: enforce max length on names to prevent potential DoS or memory issues
+    newNames[index] = name.slice(0, 20)
     setNames(newNames)
   }
 
@@ -131,6 +132,7 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
               onChange={(e) => handleNameChange(i, e.target.value)}
               placeholder={`プレイヤー${i + 1}のなまえ`}
               aria-label={`プレイヤー${i + 1}のなまえ`}
+              maxLength={20}
             />
           </div>
         ))}

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -1,5 +1,10 @@
 import { useState, useEffect } from 'react'
-import { TOKENS, MIN_PLAYERS, MAX_PLAYERS } from '../../game/types'
+import {
+  TOKENS,
+  MIN_PLAYERS,
+  MAX_PLAYERS,
+  MAX_NAME_LENGTH,
+} from '../../game/types'
 import type { GameState } from '../../game/types'
 import { loadSetupConfig, saveSetupConfig } from '../../game/storage'
 import Button from '../common/Button'
@@ -36,8 +41,9 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
 
   const handleNameChange = (index: number, name: string) => {
     const newNames = [...names]
-    // Security enhancement: enforce max length on names to prevent potential DoS or memory issues
-    newNames[index] = name.slice(0, 20)
+    // Security enhancement: enforce max length on names to prevent potential DoS or memory issues.
+    // Use code-point-based truncation so emoji/surrogate-pair chars match the input's maxLength behavior.
+    newNames[index] = [...name].slice(0, MAX_NAME_LENGTH).join('')
     setNames(newNames)
   }
 
@@ -132,7 +138,7 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
               onChange={(e) => handleNameChange(i, e.target.value)}
               placeholder={`プレイヤー${i + 1}のなまえ`}
               aria-label={`プレイヤー${i + 1}のなまえ`}
-              maxLength={20}
+              maxLength={MAX_NAME_LENGTH}
             />
           </div>
         ))}

--- a/src/game/__tests__/storage.test.ts
+++ b/src/game/__tests__/storage.test.ts
@@ -202,6 +202,17 @@ describe('saveSetupConfig / loadSetupConfig', () => {
     expect(loadSetupConfig()).toBeNull()
   })
 
+  it('namesの長さが20文字を超えていればnullを返す', () => {
+    localStorage.setItem(
+      SETUP_KEY,
+      JSON.stringify({
+        ...validConfig,
+        names: ['A', 'B', 'C', 'A'.repeat(21)],
+      }),
+    )
+    expect(loadSetupConfig()).toBeNull()
+  })
+
   it('tokensに未知の値が含まれていればnullを返す', () => {
     localStorage.setItem(
       SETUP_KEY,

--- a/src/game/__tests__/storage.test.ts
+++ b/src/game/__tests__/storage.test.ts
@@ -213,6 +213,22 @@ describe('saveSetupConfig / loadSetupConfig', () => {
     expect(loadSetupConfig()).toBeNull()
   })
 
+  it('絵文字（サロゲートペア）はコードポイント基準で文字数判定する', () => {
+    // 絵文字20文字（UTF-16コードユニットでは40だが、コードポイントでは20）はOK
+    const ok = '🎩'.repeat(20)
+    saveSetupConfig({ ...validConfig, names: [ok, 'B', 'C', 'D'] })
+    expect(loadSetupConfig()).not.toBeNull()
+    // 絵文字21文字（コードポイント21）はNG
+    localStorage.setItem(
+      SETUP_KEY,
+      JSON.stringify({
+        ...validConfig,
+        names: ['🎩'.repeat(21), 'B', 'C', 'D'],
+      }),
+    )
+    expect(loadSetupConfig()).toBeNull()
+  })
+
   it('tokensに未知の値が含まれていればnullを返す', () => {
     localStorage.setItem(
       SETUP_KEY,

--- a/src/game/storage.ts
+++ b/src/game/storage.ts
@@ -61,7 +61,7 @@ export function loadSetupConfig(): SetupConfig | null {
       !Array.isArray(config.tokens) ||
       config.names.length !== MAX_PLAYERS ||
       config.tokens.length !== MAX_PLAYERS ||
-      !config.names.every((n) => typeof n === 'string') ||
+      !config.names.every((n) => typeof n === 'string' && n.length <= 20) ||
       !config.tokens.every(
         (t) =>
           typeof t === 'string' && (TOKENS as readonly string[]).includes(t),

--- a/src/game/storage.ts
+++ b/src/game/storage.ts
@@ -1,5 +1,5 @@
 import type { GameState } from './types'
-import { TOKENS, MIN_PLAYERS, MAX_PLAYERS } from './types'
+import { TOKENS, MIN_PLAYERS, MAX_PLAYERS, MAX_NAME_LENGTH } from './types'
 
 const STORAGE_KEY = 'monopoly-save'
 const SETUP_KEY = 'monopoly-setup'
@@ -61,7 +61,9 @@ export function loadSetupConfig(): SetupConfig | null {
       !Array.isArray(config.tokens) ||
       config.names.length !== MAX_PLAYERS ||
       config.tokens.length !== MAX_PLAYERS ||
-      !config.names.every((n) => typeof n === 'string' && n.length <= 20) ||
+      !config.names.every(
+        (n) => typeof n === 'string' && [...n].length <= MAX_NAME_LENGTH,
+      ) ||
       !config.tokens.every(
         (t) =>
           typeof t === 'string' && (TOKENS as readonly string[]).includes(t),

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -5,6 +5,9 @@ export const TOKENS = ['🚗', '🎩', '👞', '🐕', '🚀', '🌟'] as const
 export const MIN_PLAYERS = 2
 export const MAX_PLAYERS = 4
 
+// ── プレイヤー名の最大文字数（コードポイント基準） ──
+export const MAX_NAME_LENGTH = 20
+
 // ── 物件カラーグループ ──
 export type ColorGroup =
   | 'brown'


### PR DESCRIPTION
Added defense-in-depth length validation for player names in the Setup screen and Storage layers to mitigate DoS / UI overflow risks.

---
*PR created automatically by Jules for task [8754141427032041625](https://jules.google.com/task/8754141427032041625) started by @genzouw*