### PR TITLE
style: ゲーム画面下部UIを固定高さ化してMiniMapのチラつきを解消

### DIFF
--- a/src/components/GameBoard/GameBoard.module.css
+++ b/src/components/GameBoard/GameBoard.module.css
@@ -50,20 +50,21 @@
   align-items: center;
   width: 100%;
   height: 58px;
-  gap: 8px;
+  gap: 4px;
 }
 .subActions {
   flex: 1;
   display: flex;
-  gap: 8px;
+  gap: 4px;
   flex-wrap: nowrap;
   overflow-x: auto;
   justify-content: center;
   min-width: 0;
 }
 .subActionButton {
-  padding-left: 10px;
-  padding-right: 10px;
+  padding-left: 6px;
+  padding-right: 6px;
+  white-space: nowrap;
 }
 .muteButton {
   flex-shrink: 0;
@@ -72,6 +73,6 @@
   font-size: 20px;
   cursor: pointer;
   opacity: 0.6;
-  padding: 4px;
-  margin-left: auto;
+  padding: 2px;
+  margin-left: 0;
 }

--- a/src/components/GameBoard/GameBoard.module.css
+++ b/src/components/GameBoard/GameBoard.module.css
@@ -13,13 +13,23 @@
 }
 .message {
   text-align: center;
-  padding: 8px 16px;
+  padding: 6px 16px;
   font-size: 15px;
+  line-height: 1.35;
   font-weight: 600;
   color: var(--color-text);
   background: var(--color-accent);
   border-radius: var(--radius-sm);
   margin: 0 16px;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+.messageEmpty {
+  visibility: hidden;
 }
 .actions {
   padding: 12px 16px;
@@ -28,11 +38,18 @@
   gap: 8px;
   align-items: center;
 }
+.primaryAction {
+  width: 100%;
+  height: 62px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 .subActionsRow {
   display: flex;
   align-items: center;
   width: 100%;
-  min-height: 32px;
+  height: 58px;
   gap: 8px;
 }
 .subActions {

--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -267,7 +267,12 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
         </MiniMap>
       </div>
 
-      {state.message && <div className={styles.message}>{state.message}</div>}
+      <div
+        className={`${styles.message} ${state.message ? '' : styles.messageEmpty}`}
+        aria-live="polite"
+      >
+        {state.message || ' '}
+      </div>
 
       <PlayerPanel
         allPlayers={state.players}
@@ -276,29 +281,31 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
       />
 
       <div className={styles.actions}>
-        {state.turnPhase === 'roll' && !currentPlayer.inJail && (
-          <Button size="large" onClick={handleRoll} disabled={isRolling}>
-            🎲 さいころをふる！
-          </Button>
-        )}
+        <div className={styles.primaryAction}>
+          {state.turnPhase === 'roll' && !currentPlayer.inJail && (
+            <Button size="large" onClick={handleRoll} disabled={isRolling}>
+              🎲 さいころをふる！
+            </Button>
+          )}
 
-        {showDrawCard && (
-          <Button size="large" onClick={handleDrawCard}>
-            カードをひく！
-          </Button>
-        )}
+          {showDrawCard && (
+            <Button size="large" onClick={handleDrawCard}>
+              カードをひく！
+            </Button>
+          )}
 
-        {showPayTax && (
-          <Button size="large" variant="danger" onClick={handlePayTax}>
-            💸 ぜいきんをはらう（${currentSpace?.price}）
-          </Button>
-        )}
+          {showPayTax && (
+            <Button size="large" variant="danger" onClick={handlePayTax}>
+              💸 ぜいきんをはらう（${currentSpace?.price}）
+            </Button>
+          )}
 
-        {state.turnPhase === 'endTurn' && (
-          <Button size="large" onClick={handleEndTurn}>
-            つぎのひとへ →
-          </Button>
-        )}
+          {state.turnPhase === 'endTurn' && (
+            <Button size="large" onClick={handleEndTurn}>
+              つぎのひとへ →
+            </Button>
+          )}
+        </div>
 
         <div className={styles.subActionsRow}>
           {canSubAction && (

--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -269,7 +269,7 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
 
       <div
         className={`${styles.message} ${state.message ? '' : styles.messageEmpty}`}
-        aria-live="polite"
+        role="status"
       >
         {state.message || ' '}
       </div>


### PR DESCRIPTION
## Summary

スマホ縦長画面でゲームをプレイしているとき、下部UI（メッセージ・「つぎのひとへ」等の大ボタン・「いえをたてる」等のサブアクション）の表示有無で `.boardSection` の高さが変動し、上部のマップ表示位置が上下にずれてチラついていた問題を修正します。

各UI要素の高さを固定値に揃えることで、フェーズ遷移時にも MiniMap の位置を一定に保ちます。

### 変更点

- \`.message\` を \`height: 56px\` に固定。state.message が空のときは \`visibility: hidden\` で領域だけ確保（背景色も含めて非表示）
- \`.primaryAction\` を新設し \`height: 62px\` に固定（large ボタン1つ分）
- \`.subActionsRow\` を \`min-height: 32px\` から \`height: 58px\` に変更（subActions 展開時の自然サイズに合わせる）

### 検証

iPhone X 相当 (375 × 812) のビューポートで Playwright を用いて30ステップ自動操作し、ロール／移動アニメーション／購入ダイアログ／カードダイアログ／endTurn の各フェーズで `.boardSection` の高さが完全に同一値（551px）に保たれることを確認しました。

修正前は フェーズによって 551 / 569 / 575 / 593 の4種類の高さになり、その差で MiniMap が上下にズレていました。

## ベースブランチについて

\`.jules/\` 系ディレクトリを除外する PR #43 がまだ未マージのため、本 PR はそちらをベースにスタックしています。PR #43 がマージされたら自動的にベースが \`main\` に切り替わります。

## Test plan

- [x] \`npm run typecheck\` 通過
- [x] \`npm run lint\` 通過
- [x] \`npm run format:check\` 通過
- [x] \`npm run test\` 全190件通過
- [x] iPhone X 相当のビューポートで30ステップ自動操作し、boardSection の高さが完全固定であることを確認