### PR TITLE
🎨 Palette: Improve Dialog accessibility with ARIA attributes

### DIFF
--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -1,13 +1,22 @@
+import { useId } from 'react'
 import type { ReactNode } from 'react'
 import styles from './common.module.css'
 
 type DialogProps = { title: string; children: ReactNode; actions?: ReactNode }
 
 export default function Dialog({ title, children, actions }: DialogProps) {
+  const titleId = useId()
   return (
     <div className={styles.overlay}>
-      <div className={styles.dialog}>
-        <div className={styles.dialogTitle}>{title}</div>
+      <div
+        className={styles.dialog}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+      >
+        <div id={titleId} className={styles.dialogTitle}>
+          {title}
+        </div>
         {children}
         {actions && <div className={styles.dialogActions}>{actions}</div>}
       </div>

--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -14,7 +14,12 @@ export default function Dialog({ title, children, actions }: DialogProps) {
         aria-modal="true"
         aria-labelledby={titleId}
       >
-        <div id={titleId} className={styles.dialogTitle}>
+        <div
+          id={titleId}
+          className={styles.dialogTitle}
+          role="heading"
+          aria-level={2}
+        >
           {title}
         </div>
         {children}


### PR DESCRIPTION
🎨 Palette: Improve Dialog accessibility with ARIA attributes

💡 What: Added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` with a unique ID from `useId()` to the generic `Dialog` component.
🎯 Why: Screen readers were not correctly identifying dialogs or reading their titles, degrading accessibility.
♿ Accessibility: Ensures correct modal behavior and title announcement for all dialogs in the app.

---
*PR created automatically by Jules for task [4007768623900348685](https://jules.google.com/task/4007768623900348685) started by @genzouw*