### PR TITLE
⚡ Bolt: Optimize MiniMap player rendering

### DIFF
--- a/src/components/Board/MiniMap.tsx
+++ b/src/components/Board/MiniMap.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, useMemo } from 'react'
 import type { BoardSpace, Player, PropertyState } from '../../game/types'
 import styles from './Board.module.css'
 
@@ -26,15 +26,26 @@ const MiniMap = memo(function MiniMap({
   onSpaceClick,
   children,
 }: MiniMapProps) {
-  const activePlayers = players.filter((p) => !p.isBankrupt)
+  // ⚡ Bolt: group players by position once (O(N)) to avoid O(N*M) nested filtering over 40 spaces.
+  const playersByPosition = useMemo(() => {
+    const grouped: Record<number, Player[]> = {}
+    for (const p of players) {
+      if (!p.isBankrupt) {
+        if (!grouped[p.position]) {
+          grouped[p.position] = []
+        }
+        grouped[p.position].push(p)
+      }
+    }
+    return grouped
+  }, [players])
+
   return (
     <div className={styles.miniMap}>
       <div className={styles.miniMapBoard}>
         {board.map((space) => {
           const { row, col } = getGridPosition(space.position)
-          const playersHere = activePlayers.filter(
-            (p) => p.position === space.position,
-          )
+          const playersHere = playersByPosition[space.position] || []
           const propState = propertyStates[space.id]
 
           return (

--- a/src/components/Board/MiniMap.tsx
+++ b/src/components/Board/MiniMap.tsx
@@ -29,16 +29,16 @@ const MiniMap = memo(function MiniMap({
   // ⚡ Bolt: group players by position once (O(N)) to avoid O(N*M) nested filtering over 40 spaces.
   const playersByPosition = useMemo(() => {
     const grouped: Record<number, Player[]> = {}
+    for (const space of board) {
+      grouped[space.position] = []
+    }
     for (const p of players) {
-      if (!p.isBankrupt) {
-        if (!grouped[p.position]) {
-          grouped[p.position] = []
-        }
+      if (!p.isBankrupt && grouped[p.position]) {
         grouped[p.position].push(p)
       }
     }
     return grouped
-  }, [players])
+  }, [players, board])
 
   return (
     <div className={styles.miniMap}>

--- a/src/components/Board/MiniMap.tsx
+++ b/src/components/Board/MiniMap.tsx
@@ -45,7 +45,7 @@ const MiniMap = memo(function MiniMap({
       <div className={styles.miniMapBoard}>
         {board.map((space) => {
           const { row, col } = getGridPosition(space.position)
-          const playersHere = playersByPosition[space.position] || []
+          const playersHere = playersByPosition[space.position]
           const propState = propertyStates[space.id]
 
           return (


### PR DESCRIPTION
⚡ Bolt: Optimize MiniMap player rendering

What: Replaced O(N*M) nested filtering with O(N) grouping using useMemo in MiniMap component
Why: The previous implementation iterated over all players for every single space (40 spaces) during every render, causing O(N*M) complexity which slows down rapid animation renders like dice rolls
Impact: Reduces MiniMap render time complexity from O(N*M) to O(N+M), significantly improving performance during board updates
Measurement: Verify tests pass and game board interactions/animations remain smooth

---
*PR created automatically by Jules for task [308181080232492066](https://jules.google.com/task/308181080232492066) started by @genzouw*