### PR TITLE
🎨 Palette: Improve TradeDialog accessibility

### DIFF
--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useId } from 'react'
 import type {
   BoardSpace,
   ColorGroup,
@@ -40,6 +40,8 @@ export default function TradeDialog({
   onPropose,
   onClose,
 }: TradeDialogProps) {
+  const offerMoneyId = useId()
+  const requestMoneyId = useId()
   const [offerProperties, setOfferProperties] = useState<string[]>([])
   const [requestProperties, setRequestProperties] = useState<string[]>([])
   const [offerMoney, setOfferMoney] = useState(0)
@@ -97,30 +99,37 @@ export default function TradeDialog({
       <div className={styles.tradeSection}>
         <div className={styles.tradeSectionTitle}>わたすもの</div>
         <div className={styles.tradePropertyList}>
-          {myProperties.map((space) => (
-            <button
-              key={space.id}
-              className={`${styles.tradePropertyChip} ${offerProperties.includes(space.id) ? styles.tradePropertyChipSelected : ''}`}
-              onClick={() => toggleOffer(space.id)}
-            >
-              {space.color && (
-                <span
-                  className={styles.tradePropertyColor}
-                  style={{ background: COLOR_MAP[space.color] }}
-                />
-              )}
-              <span>{space.name}</span>
-              {space.price != null && (
-                <span className={styles.tradePropertyPrice}>
-                  ${space.price}
-                </span>
-              )}
-            </button>
-          ))}
+          {myProperties.map((space) => {
+            const isSelected = offerProperties.includes(space.id)
+            return (
+              <button
+                key={space.id}
+                className={`${styles.tradePropertyChip} ${isSelected ? styles.tradePropertyChipSelected : ''}`}
+                onClick={() => toggleOffer(space.id)}
+                aria-pressed={isSelected}
+              >
+                {space.color && (
+                  <span
+                    className={styles.tradePropertyColor}
+                    style={{ background: COLOR_MAP[space.color] }}
+                  />
+                )}
+                <span>{space.name}</span>
+                {space.price != null && (
+                  <span className={styles.tradePropertyPrice}>
+                    ${space.price}
+                  </span>
+                )}
+              </button>
+            )
+          })}
         </div>
         <div className={styles.moneyInputRow}>
-          <span className={styles.moneyInputLabel}>おかね: $</span>
+          <label htmlFor={offerMoneyId} className={styles.moneyInputLabel}>
+            おかね: $
+          </label>
           <input
+            id={offerMoneyId}
             className={styles.moneyInput}
             type="number"
             inputMode="numeric"
@@ -171,30 +180,37 @@ export default function TradeDialog({
       <div className={styles.tradeSection}>
         <div className={styles.tradeSectionTitle}>もらうもの</div>
         <div className={styles.tradePropertyList}>
-          {theirProperties.map((space) => (
-            <button
-              key={space.id}
-              className={`${styles.tradePropertyChip} ${requestProperties.includes(space.id) ? styles.tradePropertyChipSelected : ''}`}
-              onClick={() => toggleRequest(space.id)}
-            >
-              {space.color && (
-                <span
-                  className={styles.tradePropertyColor}
-                  style={{ background: COLOR_MAP[space.color] }}
-                />
-              )}
-              <span>{space.name}</span>
-              {space.price != null && (
-                <span className={styles.tradePropertyPrice}>
-                  ${space.price}
-                </span>
-              )}
-            </button>
-          ))}
+          {theirProperties.map((space) => {
+            const isSelected = requestProperties.includes(space.id)
+            return (
+              <button
+                key={space.id}
+                className={`${styles.tradePropertyChip} ${isSelected ? styles.tradePropertyChipSelected : ''}`}
+                onClick={() => toggleRequest(space.id)}
+                aria-pressed={isSelected}
+              >
+                {space.color && (
+                  <span
+                    className={styles.tradePropertyColor}
+                    style={{ background: COLOR_MAP[space.color] }}
+                  />
+                )}
+                <span>{space.name}</span>
+                {space.price != null && (
+                  <span className={styles.tradePropertyPrice}>
+                    ${space.price}
+                  </span>
+                )}
+              </button>
+            )
+          })}
         </div>
         <div className={styles.moneyInputRow}>
-          <span className={styles.moneyInputLabel}>おかね: $</span>
+          <label htmlFor={requestMoneyId} className={styles.moneyInputLabel}>
+            おかね: $
+          </label>
           <input
+            id={requestMoneyId}
             className={styles.moneyInput}
             type="number"
             inputMode="numeric"

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -112,6 +112,7 @@ export default function TradeDialog({
                   <span
                     className={styles.tradePropertyColor}
                     style={{ background: COLOR_MAP[space.color] }}
+                    aria-hidden="true"
                   />
                 )}
                 <span>{space.name}</span>

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -194,6 +194,7 @@ export default function TradeDialog({
                   <span
                     className={styles.tradePropertyColor}
                     style={{ background: COLOR_MAP[space.color] }}
+                    aria-hidden="true"
                   />
                 )}
                 <span>{space.name}</span>


### PR DESCRIPTION
💡 What: Replaced span-based pseudo-labels with native `<label>` elements linked to inputs via unique IDs, and added `aria-pressed` states to property selection toggle buttons.
🎯 Why: Enhances screen reader compatibility by accurately announcing form inputs and making toggle buttons' selection states explicit.
♿ Accessibility:
- Replaced `<span className={styles.moneyInputLabel}>` with explicitly associated `<label>` using React's `useId()`.
- Added `aria-pressed` to TradeDialog's property selection `<button>` chips.

---
*PR created automatically by Jules for task [695313379580584609](https://jules.google.com/task/695313379580584609) started by @genzouw*