### PR TITLE
docs: add MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Toshiaki Wakabayashi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ export default defineConfig([
   },
 ])
 ```
+
+## License
+
+This project is licensed under the [MIT License](./LICENSE).

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "license": "MIT",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Summary
- 公開リポジトリ化に伴い、`LICENSE` ファイル（MIT）をリポジトリ直下に追加します。
- copyright holder: `Toshiaki Wakabayashi`
- 年: `2026`

## Why
ライセンス未設定の public リポジトリは事実上「全権利留保」とみなされ、外部からの fork / 利用 / コントリビュートの法的根拠が曖昧になります。GitHub Actions 等の OSS 連携 SaaS の利用前提としても、ライセンス明示は最低ラインのため事前に整備します。

## Test plan
- [ ] GitHub UI 上の "About" 欄にライセンス（MIT）が認識・表示されることを確認
- [ ] CI（lint / format / typecheck / build / test）が green