### PR TITLE
ci: pin third-party actions to commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     name: ESLint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20
           cache: npm
@@ -30,8 +30,8 @@ jobs:
     name: Prettier
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20
           cache: npm
@@ -42,8 +42,8 @@ jobs:
     name: TypeScript
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20
           cache: npm
@@ -54,8 +54,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20
           cache: npm
@@ -66,8 +66,8 @@ jobs:
     name: Test (with coverage)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20
           cache: npm
@@ -75,7 +75,7 @@ jobs:
       - run: npm run test:coverage
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-report
           path: coverage/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,14 +20,14 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20
       - run: npm install
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: dist
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5


### PR DESCRIPTION
## Summary
`.github/workflows/{ci,deploy}.yml` 内の third-party Actions をすべて commit SHA に固定し、SHA 後にバージョンタグをコメントとして併記します（Dependabot 互換のフォーマット）。

| Action | Before | After (SHA + version) |
|--------|--------|------------------------|
| actions/checkout | `@v6` | `@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6` |
| actions/setup-node | `@v6` | `@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6` |
| actions/upload-artifact | `@v4` | `@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4` |
| actions/upload-pages-artifact | `@v5` | `@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5` |
| actions/deploy-pages | `@v5` | `@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5` |

合計 15 箇所のピン止め。

## Why
- 公開リポジトリでは fork 経由の PR から Actions が実行される攻撃面が広がる
- タグ（`v6` 等）はミュータブルで、Action リポジトリ側で書き換えられる可能性がある
- commit SHA はイミュータブルなため、Action 側が乗っ取られても本リポジトリの CI/CD が即座に汚染されるのを防げる
- 公式（GitHub Hardening for GitHub Actions）でも推奨される運用

## Follow-up
- [ ] リポジトリ Settings → Actions → "Require approval for all outside collaborators" を有効化
- [ ] `actions/permissions` の `sha_pinning_required = true` を terraform / API で有効化（別 PR）
- [ ] `allowed_actions = "selected"` で利用 Action を allowlist 化（別 PR）

## Test plan
- [ ] PR 上で CI（lint / format / typecheck / build / test）が green
- [ ] `main` マージ後、`Deploy to GitHub Pages` ワークフローが従来通り成功