### PR TITLE
ci: add npm audit job (block high/critical) (F32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,15 @@ jobs:
           name: coverage-report
           path: coverage/
           retention-days: 7
+
+  audit:
+    name: npm audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 20
+          cache: npm
+      # Dependabot で moderate 以下は自動 PR されるため、CI では high/critical のみブロックする。
+      - run: npm audit --audit-level=high


### PR DESCRIPTION
## Summary
`.github/workflows/ci.yml` に `audit` ジョブを追加し、PR 単位で **high / critical の依存パッケージ脆弱性をマージ前にブロック** します。

\`\`\`yaml
audit:
  name: npm audit
  runs-on: ubuntu-latest
  steps:
    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
      with:
        node-version: 20
        cache: npm
    - run: npm audit --audit-level=high
\`\`\`

## Why
- 公開リポジトリ化により、依存パッケージの脆弱性が外部から可視化される
- Dependabot は **更新 PR を投げる** だけで、マージしない限り脆弱性は残る
- CI で `--audit-level=high` を実行することで「high/critical のまま放置された PR を merge できない」というガードを敷く
- low / moderate は Dependabot で随時 PR 化されるため CI では無視（誤検知ノイズを避ける）

## Coordination
- 新規 actions 使用箇所は **SHA ピン止め形式** で記述。PR #51（既存 actions の SHA pin 化）の merge 順に依存せず、最終状態で一貫性が保たれる。
- 別 PR（genzouw.com #49）で `required_status_checks` に CI ジョブを追加する際、`npm audit` も必須化候補に追加可能（現状の PR には含めず、本 PR のマージ後 follow-up）。

## Local verification
\`\`\`
$ npm audit --audit-level=high
found 0 vulnerabilities
\`\`\`

## Follow-up
- [ ] `osv-scanner` の追加検討（allowed_actions=selected ポリシー下での verified creator 確認後）
- [ ] genzouw.com #49 の `required_status_checks_contexts` に `"npm audit"` を追加

## Test plan
- [x] ローカルで `npm audit --audit-level=high` が exit 0
- [ ] PR 上の CI で `npm audit` ジョブが green
- [ ] 意図的に脆弱性入りのパッケージを試しに追加 → CI fail を確認（やらなくてもよい）