### PR TITLE
feat: add CodeRabbit configuration as bot reviewer

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -33,7 +33,11 @@ reviews:
     - '!coverage/**'
     - '!node_modules/**'
     - '!pnpm-lock.yaml'
+    - '!package-lock.json'
+    - '!yarn.lock'
     - '!**/*.min.js'
+    - '!**/*.min.css'
+    - '!**/*.map'
     - '!**/*.snap'
 
   abort_on_close: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,45 @@
+# CodeRabbit configuration
+# https://docs.coderabbit.ai/reference/configuration
+
+language: ja-JP
+early_access: false
+enable_free_tier: true
+
+reviews:
+  # 個人運営のためレビューはまず "chill" で緩めに始める。
+  # 必要に応じて "assertive" に切り替えて検出感度を上げる。
+  profile: chill
+
+  # CodeRabbit を bot reviewer として動作させる。
+  # 問題なしと判断した PR に対して Approve ステータスを返す。
+  # 個人運営での self-merge 運用 (PR 作成者は自分の PR を承認できない GitHub 仕様)
+  # を補助する目的で有効化。Approve は最終判断ではなく補助。
+  request_changes_workflow: true
+
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+
+  # 生成物 / 依存物 / ロックファイルなどはレビュー対象から除外する。
+  path_filters:
+    - '!dist/**'
+    - '!coverage/**'
+    - '!node_modules/**'
+    - '!pnpm-lock.yaml'
+    - '!**/*.min.js'
+    - '!**/*.snap'
+
+  abort_on_close: true
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  opt_out: false


### PR DESCRIPTION
## Summary

monopo に CodeRabbit を bot reviewer として導入する。

## Why

genzouw.com#54 (PR-B) で `required_approving_review_count = 1` を導入した。GitHub の仕様で PR 作成者は自分の PR を Approve できないため、個人運営での self-merge は `pull_request_bypassers = [\"genzouw\"]` で迂回する。CodeRabbit を補助レビュアーとして導入し、機械的なレビュー観点 (バグ・セキュリティ・型安全性) をカバーする。

## Configuration choices

| key | value | 理由 |
|-----|-------|---|
| `language` | `ja-JP` | プロジェクトの主言語に合わせる |
| `reviews.profile` | `chill` | 検出感度は緩めから開始、必要なら assertive に上げる |
| `reviews.request_changes_workflow` | `true` | CodeRabbit を GitHub Reviewer として動作させ、問題なしと判断した PR に Approve を返す |
| `auto_review.base_branches` | `[main]` | main 向けの PR のみ自動レビュー |
| `path_filters` | `dist` / `coverage` / `pnpm-lock.yaml` 等を除外 | 生成物・依存物はレビュー対象外 |

## Manual setup required

本 PR は **設定ファイルのみ**。CodeRabbit GitHub App のインストールはリポジトリ管理者が GitHub UI から実施する必要がある:

1. https://github.com/apps/coderabbitai にアクセス
2. **Install** をクリック
3. monopo リポジトリのみを対象にインストール (account-wide はおすすめしない)
4. インストール後、本 PR を draft 解除して動作確認 (CodeRabbit が PR にレビューを投稿することを確認)

## Test plan

- [ ] CodeRabbit GitHub App を monopo にインストール
- [ ] 本 PR で CodeRabbit が自動レビューを生成することを確認
- [ ] 次の通常 PR で CodeRabbit が Approve / Comment を返すことを確認
- [ ] Approve の場合、`required_approving_review_count = 1` を満たすか確認 (満たさなければ bypass を継続活用)

## Refs

- 関連: genzouw.com#54 (branch protection 強化)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CodeRabbit configuration to streamline development workflow settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/55)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->