### PR TITLE
fix: ignore pnpm-lock.yaml in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,3 @@
 dist
 node_modules
-package-lock.json
+pnpm-lock.yaml


### PR DESCRIPTION
## Summary

PR #54 (pnpm 統一) で `package-lock.json` を `pnpm-lock.yaml` に切り替えた際、`.prettierignore` の更新を見逃していた。これにより `pnpm-lock.yaml` が `prettier --check` の対象となり、Dependabot が lockfile を更新する PR (#57 など) で Prettier ジョブが失敗していた。

## Root cause

```
# CI ログ (Prettier ジョブ, PR #57)
[warn] pnpm-lock.yaml
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
[ELIFECYCLE] Command failed with exit code 1.
```

main の `pnpm-lock.yaml` はローカル pnpm 11.0.9 で生成された形式で、Prettier の整形と "たまたま" 一致していたが、Dependabot 側で生成された lockfile は異なる pnpm バージョン由来で改行・インデントが微妙に違うため検出される。本質的に lockfile を Prettier 対象にすること自体が誤り。

## Fix

`.prettierignore` の `package-lock.json` を `pnpm-lock.yaml` に置き換える (1 行差分)。

```diff
 dist
 node_modules
-package-lock.json
+pnpm-lock.yaml
```

## Local verification

```
$ pnpm format:check
$ prettier --check .
Checking formatting...
All matched files use Prettier code style!
```

## After merge

- PR #57 の Dependabot に `@dependabot rebase` コメントを付与すれば CI が再走して通る見込み
- 今後の Dependabot lockfile bump で同様の事象は発生しない

## Test plan

- [x] ローカルで `pnpm format:check` が通る
- [ ] CI Prettier ジョブが green
- [ ] マージ後、PR #57 を rebase して Prettier が通ることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他**
  * Prettier設定を更新：プロジェクトで使用するパッケージロックファイルの指定をnpm形式からpnpm形式に変更しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/67)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->