### PR TITLE
🎨 Palette: Improve keyboard focus states for buttons

### DIFF
--- a/src/components/Setup/Setup.module.css
+++ b/src/components/Setup/Setup.module.css
@@ -31,13 +31,14 @@
   border: none;
   background: var(--color-secondary);
   color: var(--color-white);
+  font: inherit;
   font-size: 24px;
   font-weight: 700;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  outline: none;
+  touch-action: manipulation;
 }
 .countButton:focus-visible {
   outline: 2px solid var(--color-primary);

--- a/src/components/Setup/Setup.module.css
+++ b/src/components/Setup/Setup.module.css
@@ -37,6 +37,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  outline: none;
+}
+.countButton:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 .countButton:disabled {
   opacity: 0.3;

--- a/src/components/common/common.module.css
+++ b/src/components/common/common.module.css
@@ -6,6 +6,7 @@
   padding: 12px 24px;
   border: none;
   border-radius: var(--radius);
+  font: inherit;
   font-size: 16px;
   font-weight: 700;
   cursor: pointer;
@@ -13,7 +14,6 @@
     transform 0.1s,
     box-shadow 0.1s;
   touch-action: manipulation;
-  outline: none;
 }
 .button:focus-visible {
   outline: 2px solid var(--color-primary);

--- a/src/components/common/common.module.css
+++ b/src/components/common/common.module.css
@@ -13,6 +13,11 @@
     transform 0.1s,
     box-shadow 0.1s;
   touch-action: manipulation;
+  outline: none;
+}
+.button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 .button:active {
   transform: scale(0.96);


### PR DESCRIPTION
### 💡 What
Added explicit `:focus-visible` styling to common buttons and setup counter buttons to provide clear visual feedback during keyboard navigation.

### 🎯 Why
Common UI elements like custom buttons often lack clear indicators when focused via keyboard if the default browser outline is removed or overridden. Explicitly defining a `:focus-visible` state ensures an accessible experience for keyboard users while retaining a clean look for mouse and touch users.

### ♿ Accessibility
- Added a high-contrast focus ring using the primary brand color to `.button` (`common.module.css`) and `.countButton` (`Setup.module.css`).
- Prevented default inconsistent browser outlines by explicitly setting `outline: none`, falling back to the controlled `:focus-visible` style.
- Documented learning in Palette's journal for future reference.

---
*PR created automatically by Jules for task [11720679360411108552](https://jules.google.com/task/11720679360411108552) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **スタイル**
  * ボタンの見た目と操作性を改善しました。ボタンでフォント継承とタッチ操作の最適化を導入し、タッチ／クリックの挙動を安定させます。
  * キーボード操作時に2pxの強調アウトライン（オフセット付き）を表示するフォーカススタイルを追加し、アクセシビリティと視認性を向上させました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/68)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->