### PR TITLE
refactor: 💡 [Code Review] Dialog コンポーネントにフォーカストラップとキーボード操作対応を追加

### DIFF
--- a/src/components/ActionDialog/BuildDialog.tsx
+++ b/src/components/ActionDialog/BuildDialog.tsx
@@ -65,6 +65,7 @@ export default function BuildDialog({
   return (
     <Dialog
       title="いえをたてる・うる"
+      onClose={onClose}
       actions={
         <Button variant="secondary" onClick={onClose}>
           とじる

--- a/src/components/ActionDialog/ForceBuyDialog.tsx
+++ b/src/components/ActionDialog/ForceBuyDialog.tsx
@@ -30,6 +30,7 @@ export default function ForceBuyDialog({
   return (
     <Dialog
       title="5ばいがいする？"
+      onClose={onDecline}
       actions={
         <>
           <Button onClick={onBuy}>${cost.toLocaleString()}で買いとる！</Button>

--- a/src/components/ActionDialog/MortgageDialog.tsx
+++ b/src/components/ActionDialog/MortgageDialog.tsx
@@ -28,6 +28,7 @@ export default function MortgageDialog({
   return (
     <Dialog
       title="ていとう"
+      onClose={onClose}
       actions={
         <Button variant="secondary" onClick={onClose}>
           とじる

--- a/src/components/ActionDialog/PurchaseDialog.tsx
+++ b/src/components/ActionDialog/PurchaseDialog.tsx
@@ -20,6 +20,7 @@ export default function PurchaseDialog({
   return (
     <Dialog
       title="かいますか？"
+      onClose={onDecline}
       actions={
         <>
           <Button onClick={onBuy} disabled={!canAfford}>

--- a/src/components/ActionDialog/SellDialog.tsx
+++ b/src/components/ActionDialog/SellDialog.tsx
@@ -67,6 +67,7 @@ export default function SellDialog({
   return (
     <Dialog
       title={title}
+      onClose={forced ? undefined : onClose}
       actions={
         forced ? (
           <div

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -87,6 +87,7 @@ export default function TradeDialog({
   return (
     <Dialog
       title={`${targetPlayer.token} ${targetPlayer.name}とこうかん`}
+      onClose={onClose}
       actions={
         <>
           <Button onClick={handlePropose}>ていあんする！</Button>

--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -575,6 +575,7 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
           return (
             <Dialog
               title={space.name}
+              onClose={() => setShowSpaceDetail(null)}
               actions={
                 <Button
                   variant="ghost"
@@ -800,6 +801,7 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
           return (
             <Dialog
               title={`${detailPlayer.token} ${detailPlayer.name}`}
+              onClose={() => setShowPlayerDetail(null)}
               actions={
                 <Button
                   variant="ghost"
@@ -931,6 +933,7 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
       {showTradeSelect && (
         <Dialog
           title="だれとこうかんする？"
+          onClose={() => setShowTradeSelect(false)}
           actions={
             <Button
               variant="secondary"

--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId } from 'react'
+import { useEffect, useId, useRef } from 'react'
 import type { ReactNode } from 'react'
 import { useFocusTrap } from '../../hooks/useFocusTrap'
 import styles from './common.module.css'
@@ -19,18 +19,21 @@ export default function Dialog({
 }: DialogProps) {
   const titleId = useId()
   const containerRef = useFocusTrap<HTMLDivElement>()
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
 
+  const closeEnabled = !!onClose
   useEffect(() => {
-    if (!onClose) return
+    if (!closeEnabled) return
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault()
-        onClose()
+        onCloseRef.current?.()
       }
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [onClose])
+  }, [closeEnabled])
 
   return (
     <div className={styles.overlay}>

--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -1,18 +1,46 @@
-import { useId } from 'react'
+import { useEffect, useId } from 'react'
 import type { ReactNode } from 'react'
+import { useFocusTrap } from '../../hooks/useFocusTrap'
 import styles from './common.module.css'
 
-type DialogProps = { title: string; children: ReactNode; actions?: ReactNode }
+type DialogProps = {
+  title: string
+  children: ReactNode
+  actions?: ReactNode
+  /** 指定時のみ Escape でクローズ可能。業務的に強制遷移が必要な Dialog（破産・オークション等）では意図的に未指定にする。 */
+  onClose?: () => void
+}
 
-export default function Dialog({ title, children, actions }: DialogProps) {
+export default function Dialog({
+  title,
+  children,
+  actions,
+  onClose,
+}: DialogProps) {
   const titleId = useId()
+  const containerRef = useFocusTrap<HTMLDivElement>()
+
+  useEffect(() => {
+    if (!onClose) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
   return (
     <div className={styles.overlay}>
       <div
+        ref={containerRef}
         className={styles.dialog}
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
+        tabIndex={-1}
       >
         <div
           id={titleId}

--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -20,7 +20,9 @@ export default function Dialog({
   const titleId = useId()
   const containerRef = useFocusTrap<HTMLDivElement>()
   const onCloseRef = useRef(onClose)
-  onCloseRef.current = onClose
+  useEffect(() => {
+    onCloseRef.current = onClose
+  })
 
   const closeEnabled = !!onClose
   useEffect(() => {

--- a/src/components/common/__tests__/Dialog.test.tsx
+++ b/src/components/common/__tests__/Dialog.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent, screen, cleanup } from '@testing-library/react'
+import { afterEach } from 'vitest'
+import Dialog from '../Dialog'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('Dialog', () => {
+  it('role="dialog" と aria-modal を持つ', () => {
+    render(
+      <Dialog title="テスト">
+        <button>OK</button>
+      </Dialog>,
+    )
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+  })
+
+  it('aria-labelledby が title 要素と関連付けされている', () => {
+    render(
+      <Dialog title="タイトル文字列">
+        <div>本文</div>
+      </Dialog>,
+    )
+    const dialog = screen.getByRole('dialog')
+    const labelledBy = dialog.getAttribute('aria-labelledby')
+    expect(labelledBy).toBeTruthy()
+    expect(document.getElementById(labelledBy!)?.textContent).toBe(
+      'タイトル文字列',
+    )
+  })
+
+  it('onClose が指定されているとき Escape で onClose が呼ばれる', () => {
+    const onClose = vi.fn()
+    render(
+      <Dialog title="テスト" onClose={onClose}>
+        <button>OK</button>
+      </Dialog>,
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('onClose が未指定のとき Escape ではクローズしない', () => {
+    render(
+      <Dialog title="テスト">
+        <button>OK</button>
+      </Dialog>,
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('マウント時に Dialog 内の最初の focusable 要素にフォーカスが当たる', () => {
+    render(
+      <Dialog
+        title="テスト"
+        actions={
+          <>
+            <button>キャンセル</button>
+            <button>OK</button>
+          </>
+        }
+      >
+        <button>本文ボタン</button>
+      </Dialog>,
+    )
+    expect(document.activeElement).toBe(
+      screen.getByRole('button', { name: '本文ボタン' }),
+    )
+  })
+
+  it('最後の要素で Tab を押すと最初の focusable 要素に循環する', () => {
+    render(
+      <Dialog
+        title="テスト"
+        actions={
+          <>
+            <button>キャンセル</button>
+            <button>OK</button>
+          </>
+        }
+      >
+        <button>本文ボタン</button>
+      </Dialog>,
+    )
+    const buttons = screen.getAllByRole('button')
+    const first = buttons[0]
+    const last = buttons[buttons.length - 1]
+    last.focus()
+    fireEvent.keyDown(last, { key: 'Tab' })
+    expect(document.activeElement).toBe(first)
+  })
+
+  it('最初の要素で Shift+Tab を押すと最後の focusable 要素に循環する', () => {
+    render(
+      <Dialog
+        title="テスト"
+        actions={
+          <>
+            <button>キャンセル</button>
+            <button>OK</button>
+          </>
+        }
+      >
+        <button>本文ボタン</button>
+      </Dialog>,
+    )
+    const buttons = screen.getAllByRole('button')
+    const first = buttons[0]
+    const last = buttons[buttons.length - 1]
+    first.focus()
+    fireEvent.keyDown(first, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(last)
+  })
+
+  it('アンマウント時に直前のアクティブ要素にフォーカスが復帰する', () => {
+    const trigger = document.createElement('button')
+    trigger.textContent = 'トリガー'
+    document.body.appendChild(trigger)
+    trigger.focus()
+    expect(document.activeElement).toBe(trigger)
+
+    const { unmount } = render(
+      <Dialog title="テスト">
+        <button>OK</button>
+      </Dialog>,
+    )
+    expect(document.activeElement).not.toBe(trigger)
+    unmount()
+    expect(document.activeElement).toBe(trigger)
+
+    document.body.removeChild(trigger)
+  })
+})

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -36,7 +36,12 @@ export function useFocusTrap<T extends HTMLElement>() {
       const first = current[0]
       const last = current[current.length - 1]
       const active = document.activeElement
-      if (e.shiftKey && (active === first || !container.contains(active))) {
+      if (
+        e.shiftKey &&
+        (active === first ||
+          active === container ||
+          !container.contains(active))
+      ) {
         e.preventDefault()
         last.focus({ preventScroll: true })
       } else if (
@@ -48,9 +53,9 @@ export function useFocusTrap<T extends HTMLElement>() {
       }
     }
 
-    container.addEventListener('keydown', handleKeyDown)
+    document.addEventListener('keydown', handleKeyDown)
     return () => {
-      container.removeEventListener('keydown', handleKeyDown)
+      document.removeEventListener('keydown', handleKeyDown)
       previouslyFocused?.focus({ preventScroll: true })
     }
   }, [])

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from 'react'
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]:not([hidden])',
+  'button:not([disabled]):not([hidden])',
+  'input:not([disabled]):not([hidden])',
+  'select:not([disabled]):not([hidden])',
+  'textarea:not([disabled]):not([hidden])',
+  '[tabindex]:not([tabindex="-1"]):not([hidden])',
+].join(',')
+
+function getFocusables(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+}
+
+export function useFocusTrap<T extends HTMLElement>() {
+  const containerRef = useRef<T>(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const previouslyFocused = document.activeElement as HTMLElement | null
+
+    const focusables = getFocusables(container)
+    const initial = focusables[0] ?? container
+    initial.focus({ preventScroll: true })
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return
+      const current = getFocusables(container)
+      if (current.length === 0) {
+        e.preventDefault()
+        return
+      }
+      const first = current[0]
+      const last = current[current.length - 1]
+      const active = document.activeElement
+      if (e.shiftKey && (active === first || !container.contains(active))) {
+        e.preventDefault()
+        last.focus({ preventScroll: true })
+      } else if (
+        !e.shiftKey &&
+        (active === last || !container.contains(active))
+      ) {
+        e.preventDefault()
+        first.focus({ preventScroll: true })
+      }
+    }
+
+    container.addEventListener('keydown', handleKeyDown)
+    return () => {
+      container.removeEventListener('keydown', handleKeyDown)
+      previouslyFocused?.focus({ preventScroll: true })
+    }
+  }, [])
+
+  return containerRef
+}

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -2,10 +2,10 @@ import { useEffect, useRef } from 'react'
 
 const FOCUSABLE_SELECTOR = [
   'a[href]:not([hidden])',
-  'button:not([disabled]):not([hidden])',
-  'input:not([disabled]):not([hidden])',
-  'select:not([disabled]):not([hidden])',
-  'textarea:not([disabled]):not([hidden])',
+  'button:not([disabled]):not([hidden]):not([tabindex="-1"])',
+  'input:not([disabled]):not([hidden]):not([tabindex="-1"])',
+  'select:not([disabled]):not([hidden]):not([tabindex="-1"])',
+  'textarea:not([disabled]):not([hidden]):not([tabindex="-1"])',
   '[tabindex]:not([tabindex="-1"]):not([hidden])',
 ].join(',')
 


### PR DESCRIPTION
## Summary
- `Dialog` に `onClose?: () => void` を追加し、指定時のみ Escape キーで閉じられるよう拡張
- `useFocusTrap` カスタムフックを新規作成し、初期フォーカス・Tab/Shift+Tab 循環・アンマウント時のフォーカス復帰を 1 ファイルに集約
- 業務的にキャンセル可能な 9 箇所の Dialog 呼び出し元に `onClose` を接続
- 強制遷移が必要な Dialog（Auction / Card / Bankrupt / Jail / GameBoard 内 TradeOffer / SellDialog の `forced=true` 時）は意図的に未指定とし、Dialog.tsx の JSDoc に方針を明文化

## 設計の要点
- 既存 Dialog API は後方互換（`onClose` は optional）
- フォーカストラップは外部ライブラリ不使用（React 19 のフックのみ）。複雑化したら `focus-trap-react` へ撤退可能な構造にフックを分離
- `tabIndex={-1}` をコンテナに付与し focusable 要素が無い場合のフォールバックを担保

## Test plan
- [x] `Dialog.test.tsx` の Vitest 8 ケース PASS（ARIA / Escape 有効・無効 / 初期フォーカス / Tab 循環 / Shift+Tab 循環 / 復帰）
- [x] TypeScript 型チェック PASS
- [x] ESLint (project local v10) PASS
- [x] Prettier PASS
- [ ] ブラウザで各 Dialog の Tab / Shift+Tab / Escape の挙動を実機確認

> Note: `src/game/__tests__/storage.test.ts` の 23 件失敗は本 PR の変更前から main で再現する既存問題（`jsdom` の localStorage 周り）で、本 PR のスコープ外です。

Closes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ダイアログが Escape キーで閉じられるオプションをサポート
  * フォーカストラップを導入し、ダイアログ内で Tab/Shift+Tab が循環するように

* **改善**
  * 複数のダイアログで閉じるハンドリングを統一適用
  * 強制モード中はユーザーによるダイアログ閉鎖を無効化

* **テスト**
  * ダイアログのアクセシビリティ、キーボード操作、フォーカス挙動の網羅的テストを追加

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/69)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->