### PR TITLE
🎨 Palette: Improve accessibility of game board spaces

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,3 @@
-## 2024-05-12 - Ensure Keyboard Accessibility on Game Board Spaces
+## 2026-05-12 - Ensure Keyboard Accessibility on Game Board Spaces
 **Learning:** Found an accessibility issue where interactable game board spaces (`div` elements acting as buttons) could not be focused via keyboard navigation because they lacked `focus-visible` styles and a focusable `button` element container.
 **Action:** Always replace interactive `div` elements with `<button>` tags and ensure appropriate focus management through CSS modules when converting custom clickable elements to accessible actions.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-12 - Ensure Keyboard Accessibility on Game Board Spaces
+**Learning:** Found an accessibility issue where interactable game board spaces (`div` elements acting as buttons) could not be focused via keyboard navigation because they lacked `focus-visible` styles and a focusable `button` element container.
+**Action:** Always replace interactive `div` elements with `<button>` tags and ensure appropriate focus management through CSS modules when converting custom clickable elements to accessible actions.

--- a/src/components/Board/Board.module.css
+++ b/src/components/Board/Board.module.css
@@ -84,12 +84,12 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  font-size: 6px;
   overflow: hidden;
   border: none;
-  outline: none;
   padding: 0;
-  font-family: inherit;
+  font: inherit;
+  font-size: 6px;
+  touch-action: manipulation;
 }
 .miniSpace:focus-visible {
   outline: 2px solid var(--color-primary);

--- a/src/components/Board/Board.module.css
+++ b/src/components/Board/Board.module.css
@@ -86,6 +86,15 @@
   cursor: pointer;
   font-size: 6px;
   overflow: hidden;
+  border: none;
+  outline: none;
+  padding: 0;
+  font-family: inherit;
+}
+.miniSpace:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+  z-index: 10;
 }
 .miniSpaceIcon {
   font-size: clamp(12px, 3.2cqi, 24px);

--- a/src/components/Board/MemoizedMiniSpace.tsx
+++ b/src/components/Board/MemoizedMiniSpace.tsx
@@ -102,7 +102,8 @@ export const MemoizedMiniSpace = memo(function MemoizedMiniSpace({
   const ownerBg = ownerId ? getOwnerBg(ownerId) : undefined
 
   return (
-    <div
+    <button
+      type="button"
       className={styles.miniSpace}
       style={{
         gridRow: row,
@@ -116,6 +117,7 @@ export const MemoizedMiniSpace = memo(function MemoizedMiniSpace({
               : 'var(--color-white)'),
       }}
       onClick={() => onSpaceClick(space.position)}
+      aria-label={space.name}
     >
       {space.color && (
         <div
@@ -150,6 +152,6 @@ export const MemoizedMiniSpace = memo(function MemoizedMiniSpace({
           {p.token}
         </span>
       ))}
-    </div>
+    </button>
   )
 }, areEqual)

--- a/src/components/Board/MemoizedMiniSpace.tsx
+++ b/src/components/Board/MemoizedMiniSpace.tsx
@@ -83,8 +83,19 @@ const areEqual = (
     }
   }
 
-  // space, row, col, allPlayers, onSpaceClick are assumed stable
-  // allPlayers is only used for `allPlayers.find` for token, which only matters if ownerId changes
+  const prevOwnerId = prevPropState?.ownerId
+  const nextOwnerId = nextPropState?.ownerId
+  if (prevOwnerId && nextOwnerId && prevOwnerId === nextOwnerId) {
+    const prevOwner = prevProps.allPlayers.find((p) => p.id === prevOwnerId)
+    const nextOwner = nextProps.allPlayers.find((p) => p.id === nextOwnerId)
+    if (
+      prevOwner?.name !== nextOwner?.name ||
+      prevOwner?.token !== nextOwner?.token
+    ) {
+      return false
+    }
+  }
+
   return true
 }
 

--- a/src/components/Board/MemoizedMiniSpace.tsx
+++ b/src/components/Board/MemoizedMiniSpace.tsx
@@ -100,6 +100,18 @@ export const MemoizedMiniSpace = memo(function MemoizedMiniSpace({
   const icon = getSpaceIcon(space)
   const ownerId = propState?.ownerId
   const ownerBg = ownerId ? getOwnerBg(ownerId) : undefined
+  const ownerName = ownerId
+    ? allPlayers.find((p) => p.id === ownerId)?.name
+    : undefined
+  const houses = propState?.houses ?? 0
+  const ariaLabel = [
+    space.name,
+    ownerName && `所有者: ${ownerName}`,
+    houses > 0 && (houses === 5 ? 'ホテル' : `家${houses}軒`),
+    playersHere.length > 0 && `プレイヤー${playersHere.length}人滞在中`,
+  ]
+    .filter(Boolean)
+    .join(' ')
 
   return (
     <button
@@ -117,7 +129,7 @@ export const MemoizedMiniSpace = memo(function MemoizedMiniSpace({
               : 'var(--color-white)'),
       }}
       onClick={() => onSpaceClick(space.position)}
-      aria-label={space.name}
+      aria-label={ariaLabel}
     >
       {space.color && (
         <div


### PR DESCRIPTION
### 💡 What:
Converted the interactive game board spaces (`MemoizedMiniSpace` component) from `div` elements to semantic `button` tags and added keyboard focus styling (`:focus-visible`).

### 🎯 Why:
Users relying on keyboard navigation could not "tab" to spaces on the game board map because the interactive elements lacked the proper semantic tags and focus indicators.

### ♿ Accessibility:
- Changed the root `<div>` to a `<button type="button">` to ensure focusability and standard keyboard interaction (Enter/Space to click).
- Added `aria-label={space.name}` to make the spaces readable by screen readers.
- Added a clear 2px outline for `focus-visible` state without affecting mouse users.
- Maintained exact visual appearance by resetting default button styles.

---
*PR created automatically by Jules for task [9549056720792019183](https://jules.google.com/task/9549056720792019183) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ゲームボード上のスペース要素のキーボード操作性とフォーカス表示を改善しました。タブで確実にフォーカスでき、視覚的なフォーカス指標（フォーカス時のアウトライン）を追加しています。

* **New Features**
  * スペース要素を意味的なボタンとして扱うように変更し、支配状況・建物数・周辺プレイヤー数などを含む読み上げ用ラベル（ariaラベル）を強化しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/71)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->