### PR TITLE
⚡ Bolt: Memoize board lookups in rules to convert O(N) scans to O(1)

### DIFF
--- a/src/game/rules.ts
+++ b/src/game/rules.ts
@@ -48,9 +48,10 @@ export function getColorGroup(
   propertyId: string,
   board: BoardSpace[],
 ): string[] {
-  const space = getSpaceById(propertyId, board)
+  const cache = getBoardCache(board)
+  const space = cache.byId.get(propertyId)
   if (!space?.color) return []
-  return getBoardCache(board).byColor.get(space.color) || []
+  return cache.byColor.get(space.color) ?? []
 }
 
 export function ownsFullColorGroup(

--- a/src/game/rules.ts
+++ b/src/game/rules.ts
@@ -11,6 +11,7 @@ import type {
 type BoardCache = {
   byId: Map<string, BoardSpace>
   byColor: Map<string, string[]>
+  byType: Map<string, string[]>
 }
 const boardCacheMap = new WeakMap<BoardSpace[], BoardCache>()
 
@@ -19,6 +20,7 @@ function getBoardCache(board: BoardSpace[]): BoardCache {
   if (!cache) {
     const byId = new Map<string, BoardSpace>()
     const byColor = new Map<string, string[]>()
+    const byType = new Map<string, string[]>()
 
     for (const space of board) {
       byId.set(space.id, space)
@@ -26,8 +28,10 @@ function getBoardCache(board: BoardSpace[]): BoardCache {
         if (!byColor.has(space.color)) byColor.set(space.color, [])
         byColor.get(space.color)!.push(space.id)
       }
+      if (!byType.has(space.type)) byType.set(space.type, [])
+      byType.get(space.type)!.push(space.id)
     }
-    cache = { byId, byColor }
+    cache = { byId, byColor, byType }
     boardCacheMap.set(board, cache)
   }
   return cache
@@ -68,25 +72,24 @@ export function calculateRent(
 ): number {
   const state = propertyStates[propertyId]
   if (!state?.ownerId || state.isMortgaged) return 0
-  const space = getSpaceById(propertyId, board)!
+  const cache = getBoardCache(board)
+  const space = cache.byId.get(propertyId)!
   if (space.type === 'railroad') {
-    const ownedRailroads = board
-      .filter((s) => s.type === 'railroad')
-      .filter(
-        (s) =>
-          propertyStates[s.id]?.ownerId === state.ownerId &&
-          !propertyStates[s.id]?.isMortgaged,
-      ).length
+    const railroadIds = cache.byType.get('railroad') ?? []
+    const ownedRailroads = railroadIds.filter(
+      (id) =>
+        propertyStates[id]?.ownerId === state.ownerId &&
+        !propertyStates[id]?.isMortgaged,
+    ).length
     return space.rent![ownedRailroads - 1]
   }
   if (space.type === 'utility') {
-    const ownedUtilities = board
-      .filter((s) => s.type === 'utility')
-      .filter(
-        (s) =>
-          propertyStates[s.id]?.ownerId === state.ownerId &&
-          !propertyStates[s.id]?.isMortgaged,
-      ).length
+    const utilityIds = cache.byType.get('utility') ?? []
+    const ownedUtilities = utilityIds.filter(
+      (id) =>
+        propertyStates[id]?.ownerId === state.ownerId &&
+        !propertyStates[id]?.isMortgaged,
+    ).length
     const diceTotal = diceValues[0] + diceValues[1]
     return diceTotal * (ownedUtilities === 1 ? 4 : 10)
   }

--- a/src/game/rules.ts
+++ b/src/game/rules.ts
@@ -51,7 +51,8 @@ export function getColorGroup(
   const cache = getBoardCache(board)
   const space = cache.byId.get(propertyId)
   if (!space?.color) return []
-  return cache.byColor.get(space.color) ?? []
+  const ids = cache.byColor.get(space.color)
+  return ids ? [...ids] : []
 }
 
 export function ownsFullColorGroup(

--- a/src/game/rules.ts
+++ b/src/game/rules.ts
@@ -7,13 +7,46 @@ import type {
   TradeValidationResult,
 } from './types'
 
+// ⚡ Bolt: Cache board lookups to prevent O(N) array scans during frequent operations
+type BoardCache = {
+  byId: Map<string, BoardSpace>
+  byColor: Map<string, string[]>
+}
+const boardCacheMap = new WeakMap<BoardSpace[], BoardCache>()
+
+function getBoardCache(board: BoardSpace[]): BoardCache {
+  let cache = boardCacheMap.get(board)
+  if (!cache) {
+    const byId = new Map<string, BoardSpace>()
+    const byColor = new Map<string, string[]>()
+
+    for (const space of board) {
+      byId.set(space.id, space)
+      if (space.color) {
+        if (!byColor.has(space.color)) byColor.set(space.color, [])
+        byColor.get(space.color)!.push(space.id)
+      }
+    }
+    cache = { byId, byColor }
+    boardCacheMap.set(board, cache)
+  }
+  return cache
+}
+
+export function getSpaceById(
+  propertyId: string,
+  board: BoardSpace[],
+): BoardSpace | undefined {
+  return getBoardCache(board).byId.get(propertyId)
+}
+
 export function getColorGroup(
   propertyId: string,
   board: BoardSpace[],
 ): string[] {
-  const space = board.find((s) => s.id === propertyId)
+  const space = getSpaceById(propertyId, board)
   if (!space?.color) return []
-  return board.filter((s) => s.color === space.color).map((s) => s.id)
+  return getBoardCache(board).byColor.get(space.color) || []
 }
 
 export function ownsFullColorGroup(
@@ -35,7 +68,7 @@ export function calculateRent(
 ): number {
   const state = propertyStates[propertyId]
   if (!state?.ownerId || state.isMortgaged) return 0
-  const space = board.find((s) => s.id === propertyId)!
+  const space = getSpaceById(propertyId, board)!
   if (space.type === 'railroad') {
     const ownedRailroads = board
       .filter((s) => s.type === 'railroad')
@@ -109,7 +142,7 @@ export function canUnmortgage(
   const state = propertyStates[propertyId]
   if (!state || state.ownerId !== playerId) return false
   if (!state.isMortgaged) return false
-  const space = board.find((s) => s.id === propertyId)!
+  const space = getSpaceById(propertyId, board)!
   const unmortgageCost = Math.floor((space.mortgageValue ?? 0) * 1.1)
   return player.money >= unmortgageCost
 }
@@ -132,9 +165,10 @@ export function calculateTotalAssets(
   board: BoardSpace[],
 ): number {
   let total = player.money
+  const cache = getBoardCache(board)
   for (const propId of player.properties) {
     const state = propertyStates[propId]
-    const space = board.find((s) => s.id === propId)!
+    const space = cache.byId.get(propId)!
     if (!state?.isMortgaged) total += space.mortgageValue ?? 0
     if (state && state.houses > 0)
       total += Math.floor(((space.houseCost ?? 0) * state.houses) / 2)


### PR DESCRIPTION
💡 What: Implemented a `WeakMap`-backed `BoardCache` for the static board spaces, along with helper methods to fetch `byId` and `byColor` in `src/game/rules.ts`. Replaced `board.find()` and `board.filter()` linear iterations across rule functions.
🎯 Why: Methods like `calculateRent`, `getColorGroup`, and `calculateTotalAssets` are evaluated frequently. In instances such as dialog rendering and computing wealth, these cause N^2 overhead via inner-loop filtering. 
📊 Impact: Converts previous O(N) linear iteration scans into instant O(1) map lookups, significantly improving state calculations and mitigating React re-render blocking.
🔬 Measurement: Verify all tests in `vitest` pass perfectly (proving unchanged return types), or use browser DevTools React Profiler to witness lowered compute times across `BuildDialog` and map calculations.

---
*PR created automatically by Jules for task [8810405879935429265](https://jules.google.com/task/8810405879935429265) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **パフォーマンス改善**
  * ゲームロジックの検索・集計処理を内部でキャッシュするよう最適化し、家賃計算、抵当解除、資産合計の処理がより高速・安定になりました。ゲームプレイがよりスムーズになります。

* **新機能**
  * 物件検索を簡単に行える公開ヘルパー関数を追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/72)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->