### PR TITLE
chore: configure CodeRabbit for stricter Japanese reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,7 +2,7 @@
 # https://docs.coderabbit.ai/reference/configuration
 
 language: ja-JP
-tone_instructions: 'すべての投稿、コメント、レビューは必ず日本語で行ってください。セキュリティ、パフォーマンス、可読性、設計の妥当性など、幅広い観点から厳格にコードを評価してください。'
+tone_instructions: 'すべての投稿、コメント、レビューは必ず日本語で行ってください。セキュリティ、パフォーマンス、可読性、設計の妥当性に加え、命名規則、マジックナンバー、将来のリファクタリングを見据えた設計改善など、細部まで厳格に評価し、具体的な改善案を提案してください。'
 early_access: false
 enable_free_tier: true
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,13 +2,13 @@
 # https://docs.coderabbit.ai/reference/configuration
 
 language: ja-JP
+tone_instructions: 'すべての投稿、コメント、レビューは必ず日本語で行ってください。セキュリティ、パフォーマンス、可読性、設計の妥当性など、幅広い観点から厳格にコードを評価してください。'
 early_access: false
 enable_free_tier: true
 
 reviews:
-  # 個人運営のためレビューはまず "chill" で緩めに始める。
-  # 必要に応じて "assertive" に切り替えて検出感度を上げる。
-  profile: chill
+  # レビュー観点を厳しめに設定するため "assertive" に設定。
+  profile: assertive
 
   # CodeRabbit を bot reviewer として動作させる。
   # 問題なしと判断した PR に対して Approve ステータスを返す。
@@ -23,7 +23,7 @@ reviews:
 
   auto_review:
     enabled: true
-    drafts: false
+    drafts: true
     base_branches:
       - main
 


### PR DESCRIPTION
This PR updates the `.coderabbit.yaml` configuration to address issues where comments were occasionally in English and sets up stricter, more comprehensive review guidelines:

1. **Language & Scope:** Added `tone_instructions` to ensure all CodeRabbit interactions are in Japanese and explicitly instructed it to take a broader review perspective covering security, performance, readability, and design.
2. **Strictness:** Upgraded the review `profile` from `chill` to `assertive` for more stringent feedback.
3. **Broadened Review Triggers:** Enabled `drafts: true` in the `auto_review` section to allow CodeRabbit to review draft PRs automatically.

---
*PR created automatically by Jules for task [15241277672402645254](https://jules.google.com/task/15241277672402645254) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * 出力言語を日本語に統一し、すべての投稿・コメント・レビューが日本語で生成されるようにしました。
  * セキュリティ、パフォーマンス、可読性、設計（命名・マジックナンバー・リファクタリング配慮を含む）に対する評価を強化しました。
  * レビュートーンを「assertive（断定的）」に変更し、検出の厳格さを向上させました。
  * ドラフトPRに対する自動レビューを有効化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/78)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->