### PR TITLE
chore(editorconfig): .editorconfig を追加

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,13 +8,6 @@ indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
 
-[*.go]
-indent_style = tab
-indent_size = 4
-
-[*.{php,py,java}]
-indent_size = 4
-
 [*.md]
 trim_trailing_whitespace = false
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,13 @@ indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
 
+[*.go]
+indent_style = tab
+indent_size = 4
+
+[*.{php,py,java}]
+indent_size = 4
+
 [*.md]
 trim_trailing_whitespace = false
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,5 +18,5 @@ indent_size = 4
 [*.md]
 trim_trailing_whitespace = false
 
-[Makefile]
+[{Makefile,makefile,GNUmakefile,*.mk}]
 indent_style = tab


### PR DESCRIPTION
## Summary

- リポジトリの主要言語構成に合わせた `.editorconfig` を整備
- charset (utf-8) / end_of_line (lf) / insert_final_newline / trim_trailing_whitespace を統一
- 主要言語に応じたインデント設定（Go/PHP/Python/Java は 4、それ以外は 2）

## Test plan

- [ ] EditorConfig 対応エディタで開いた際に意図した設定が反映されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **チョア**
  * リポジトリ全体のエディタ／フォーマット設定を追加・更新しました。改行・文字エンコーディング・末尾改行・空白トリム・インデントの標準を整備し、MarkdownやMakefile系には個別の例外を設定しています。ユーザー向けの機能変更や公開APIの変更はありません。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/79)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->