### PR TITLE
ci: add SonarCloud Scan to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -90,6 +92,11 @@ jobs:
           name: coverage-report
           path: coverage/
           retention-days: 7
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
 
   audit:
     name: pnpm audit

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+sonar.projectKey=genzouw_monopo
+sonar.organization=genzouw
+
+sonar.sources=src
+sonar.tests=src
+sonar.test.inclusions=**/*.test.ts,**/*.test.tsx
+sonar.exclusions=**/*.test.ts,**/*.test.tsx,src/test-setup.ts,src/main.tsx,**/*.d.ts,dist/**,coverage/**
+
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.typescript.lcov.reportPaths=coverage/lcov.info
+
+sonar.sourceEncoding=UTF-8

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       include: ['src/**'],
-      reporter: [['text', { maxCols: 150 }], 'json-summary', 'html'],
+      reporter: [['text', { maxCols: 150 }], 'json-summary', 'html', 'lcov'],
       exclude: [
         'node_modules/**',
         'dist/**',


### PR DESCRIPTION
## Summary

- 既存 `test` ジョブに **SonarCloud Scan** ステップを追加し、Pull Request / push 時にコード品質スキャンを実行できるようにする
- Vitest のカバレッジに `lcov` レポーターを追加し、SonarCloud にカバレッジデータを連携
- `sonar-project.properties` を追加（`projectKey=genzouw_monopo`, `organization=genzouw` を仮設定）

## Why test ジョブに統合？

- カバレッジ生成直後の同一ジョブ内でスキャンするため artifact 経由の受け渡しが不要
- 別ジョブ + `needs:` 構成より構成がシンプル
- テストが落ちた状態のコードをスキャンしても意味がないため、`test` ジョブと運命を共にするのが合理的

## Action 選定

スクリーンショットでご指定の `antonioaversa/sonarcloud-github-action@v4.0.0` には **「For testing. Do not use this GitHub Action.」** という注意書きがあるため、公式メンテナの `SonarSource/sonarqube-scan-action@v6` を採用しました。

## ⚠️ Before merging — 事前作業

1. **SonarCloud 上でプロジェクトを作成**し、生成された Project Key / Organization を `sonar-project.properties` の値と一致させる（現在は仮値）
2. SonarCloud で発行した **`SONAR_TOKEN`** を本リポジトリの **Settings → Secrets → Actions** に登録

これらが未設定だと CI が SonarCloud Scan ステップで失敗します。

## Test plan

- [ ] SonarCloud 側でプロジェクトを作成
- [ ] `SONAR_TOKEN` シークレットを登録
- [ ] Push 後に CI の `Test (with coverage)` ジョブが成功することを確認
- [ ] SonarCloud ダッシュボードでカバレッジが連携されていることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * コード品質チェック機能を統合し、テスト実行時のカバレッジ分析とレポート生成を強化しました。CI/CDパイプラインの構成を更新し、テストのたびに自動でコード品質が監視される体制となりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/83)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->