### PR TITLE
⚡ Bolt: Replace O(N) array scans with cached O(1) space lookups in ActionDialogs

### DIFF
--- a/src/components/ActionDialog/BuildDialog.tsx
+++ b/src/components/ActionDialog/BuildDialog.tsx
@@ -52,7 +52,9 @@ export default function BuildDialog({
   onClose,
 }: BuildDialogProps) {
   const ownedProperties = currentPlayer.properties
-    .map((id) => getSpaceById(id, board))
+    .map(function (id: string) {
+      return getSpaceById(id, board)
+    })
     .filter(
       (s): s is BoardSpace => !!s && s.type === 'property' && !!s.houseCost,
     )

--- a/src/components/ActionDialog/BuildDialog.tsx
+++ b/src/components/ActionDialog/BuildDialog.tsx
@@ -52,9 +52,7 @@ export default function BuildDialog({
   onClose,
 }: BuildDialogProps) {
   const ownedProperties = currentPlayer.properties
-    .map(function (id: string) {
-      return getSpaceById(id, board)
-    })
+    .map((id: string) => getSpaceById(id, board))
     .filter(
       (s): s is BoardSpace => !!s && s.type === 'property' && !!s.houseCost,
     )

--- a/src/components/ActionDialog/BuildDialog.tsx
+++ b/src/components/ActionDialog/BuildDialog.tsx
@@ -4,7 +4,7 @@ import type {
   Player,
   PropertyState,
 } from '../../game/types'
-import { canBuildHouse, canSellHouse } from '../../game/rules'
+import { canBuildHouse, canSellHouse, getSpaceById } from '../../game/rules'
 import Dialog from '../common/Dialog'
 import Button from '../common/Button'
 import styles from './ActionDialog.module.css'
@@ -52,7 +52,7 @@ export default function BuildDialog({
   onClose,
 }: BuildDialogProps) {
   const ownedProperties = currentPlayer.properties
-    .map((id) => board.find((s) => s.id === id))
+    .map((id) => getSpaceById(id, board))
     .filter(
       (s): s is BoardSpace => !!s && s.type === 'property' && !!s.houseCost,
     )

--- a/src/components/ActionDialog/MortgageDialog.tsx
+++ b/src/components/ActionDialog/MortgageDialog.tsx
@@ -22,9 +22,7 @@ export default function MortgageDialog({
   onClose,
 }: MortgageDialogProps) {
   const ownedProperties = currentPlayer.properties
-    .map(function (id: string) {
-      return getSpaceById(id, board)
-    })
+    .map((id: string) => getSpaceById(id, board))
     .filter((s): s is BoardSpace => !!s && !!s.mortgageValue)
 
   return (

--- a/src/components/ActionDialog/MortgageDialog.tsx
+++ b/src/components/ActionDialog/MortgageDialog.tsx
@@ -22,7 +22,9 @@ export default function MortgageDialog({
   onClose,
 }: MortgageDialogProps) {
   const ownedProperties = currentPlayer.properties
-    .map((id) => getSpaceById(id, board))
+    .map(function (id: string) {
+      return getSpaceById(id, board)
+    })
     .filter((s): s is BoardSpace => !!s && !!s.mortgageValue)
 
   return (

--- a/src/components/ActionDialog/MortgageDialog.tsx
+++ b/src/components/ActionDialog/MortgageDialog.tsx
@@ -1,5 +1,5 @@
 import type { BoardSpace, Player, PropertyState } from '../../game/types'
-import { canMortgage, canUnmortgage } from '../../game/rules'
+import { canMortgage, canUnmortgage, getSpaceById } from '../../game/rules'
 import Dialog from '../common/Dialog'
 import Button from '../common/Button'
 import styles from './ActionDialog.module.css'
@@ -22,7 +22,7 @@ export default function MortgageDialog({
   onClose,
 }: MortgageDialogProps) {
   const ownedProperties = currentPlayer.properties
-    .map((id) => board.find((s) => s.id === id))
+    .map((id) => getSpaceById(id, board))
     .filter((s): s is BoardSpace => !!s && !!s.mortgageValue)
 
   return (

--- a/src/components/ActionDialog/SellDialog.tsx
+++ b/src/components/ActionDialog/SellDialog.tsx
@@ -53,7 +53,9 @@ export default function SellDialog({
   forced = false,
 }: SellDialogProps) {
   const ownedProperties = currentPlayer.properties
-    .map((id) => getSpaceById(id, board))
+    .map(function (id: string) {
+      return getSpaceById(id, board)
+    })
     .filter((s): s is BoardSpace => !!s)
     .sort((a, b) => {
       const ai = a.color ? COLOR_ORDER.indexOf(a.color) : COLOR_ORDER.length

--- a/src/components/ActionDialog/SellDialog.tsx
+++ b/src/components/ActionDialog/SellDialog.tsx
@@ -53,9 +53,7 @@ export default function SellDialog({
   forced = false,
 }: SellDialogProps) {
   const ownedProperties = currentPlayer.properties
-    .map(function (id: string) {
-      return getSpaceById(id, board)
-    })
+    .map((id: string) => getSpaceById(id, board))
     .filter((s): s is BoardSpace => !!s)
     .sort((a, b) => {
       const ai = a.color ? COLOR_ORDER.indexOf(a.color) : COLOR_ORDER.length

--- a/src/components/ActionDialog/SellDialog.tsx
+++ b/src/components/ActionDialog/SellDialog.tsx
@@ -4,6 +4,7 @@ import type {
   Player,
   PropertyState,
 } from '../../game/types'
+import { getSpaceById } from '../../game/rules'
 import Dialog from '../common/Dialog'
 import Button from '../common/Button'
 import styles from './ActionDialog.module.css'
@@ -52,7 +53,7 @@ export default function SellDialog({
   forced = false,
 }: SellDialogProps) {
   const ownedProperties = currentPlayer.properties
-    .map((id) => board.find((s) => s.id === id))
+    .map((id) => getSpaceById(id, board))
     .filter((s): s is BoardSpace => !!s)
     .sort((a, b) => {
       const ai = a.color ? COLOR_ORDER.indexOf(a.color) : COLOR_ORDER.length

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -10,6 +10,7 @@ import Dialog from '../common/Dialog'
 import Button from '../common/Button'
 import styles from './ActionDialog.module.css'
 import { clamp } from './tradeDialog.utils'
+import { getSpaceById } from '../../game/rules'
 
 const COLOR_MAP: Record<ColorGroup, string> = {
   brown: 'var(--color-brown)',
@@ -51,13 +52,13 @@ export default function TradeDialog({
   const [requestMoney, setRequestMoney] = useState(0)
 
   const myProperties = currentPlayer.properties
-    .map((id) => board.find((s) => s.id === id))
+    .map((id) => getSpaceById(id, board))
     .filter(
       (s): s is BoardSpace => !!s && (propertyStates[s.id]?.houses ?? 0) === 0,
     )
 
   const theirProperties = targetPlayer.properties
-    .map((id) => board.find((s) => s.id === id))
+    .map((id) => getSpaceById(id, board))
     .filter(
       (s): s is BoardSpace => !!s && (propertyStates[s.id]?.houses ?? 0) === 0,
     )

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -52,17 +52,13 @@ export default function TradeDialog({
   const [requestMoney, setRequestMoney] = useState(0)
 
   const myProperties = currentPlayer.properties
-    .map(function (id: string) {
-      return getSpaceById(id, board)
-    })
+    .map((id: string) => getSpaceById(id, board))
     .filter(
       (s): s is BoardSpace => !!s && (propertyStates[s.id]?.houses ?? 0) === 0,
     )
 
   const theirProperties = targetPlayer.properties
-    .map(function (id: string) {
-      return getSpaceById(id, board)
-    })
+    .map((id: string) => getSpaceById(id, board))
     .filter(
       (s): s is BoardSpace => !!s && (propertyStates[s.id]?.houses ?? 0) === 0,
     )

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -52,13 +52,17 @@ export default function TradeDialog({
   const [requestMoney, setRequestMoney] = useState(0)
 
   const myProperties = currentPlayer.properties
-    .map((id) => getSpaceById(id, board))
+    .map(function (id: string) {
+      return getSpaceById(id, board)
+    })
     .filter(
       (s): s is BoardSpace => !!s && (propertyStates[s.id]?.houses ?? 0) === 0,
     )
 
   const theirProperties = targetPlayer.properties
-    .map((id) => getSpaceById(id, board))
+    .map(function (id: string) {
+      return getSpaceById(id, board)
+    })
     .filter(
       (s): s is BoardSpace => !!s && (propertyStates[s.id]?.houses ?? 0) === 0,
     )


### PR DESCRIPTION
💡 **What:** Replaced `board.find((s) => s.id === id)` with `getSpaceById(id, board)` across `MortgageDialog`, `BuildDialog`, `TradeDialog`, and `SellDialog`.
🎯 **Why:** To prevent O(N) array scans during frequent React re-renders when mapping owned properties, aligning with Bolt's memory instructions to utilize the existing `WeakMap` cache mechanism.
📊 **Impact:** Reduces O(N) lookups to O(1) cached retrievals for property space details.
🔬 **Measurement:** Verification run via `pnpm lint`, `pnpm format`, `pnpm test`, and `pnpm typecheck` confirming no breaking changes and functional consistency.

---
*PR created automatically by Jules for task [561311064755292484](https://jules.google.com/task/561311064755292484) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 複数の物件操作ダイアログ（建築・抵当・売却・トレード）で保有不動産の取得処理を内部的に統一し、処理の一貫性と信頼性を向上しました。ユーザー向けの表示や操作の挙動に変更はありません。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->