### PR TITLE
🎨 Palette: Dynamic ARIA labels for Trade Dialog chips

### DIFF
--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -24,6 +24,11 @@ const COLOR_MAP: Record<ColorGroup, string> = {
   railroad: '#555',
 }
 
+const getPropertyChipLabel = (space: BoardSpace): string => {
+  const priceStr = space.price != null ? `（$${space.price}）` : ''
+  return `${space.name}${priceStr}`
+}
+
 type TradeDialogProps = {
   currentPlayer: Player
   targetPlayer: Player
@@ -103,10 +108,7 @@ export default function TradeDialog({
         <div className={styles.tradePropertyList}>
           {myProperties.map((space) => {
             const isSelected = offerProperties.includes(space.id)
-            const priceStr = space.price != null ? `（$${space.price}）` : ''
-            const label = isSelected
-              ? `${space.name}${priceStr}の選択を解除する`
-              : `${space.name}${priceStr}を選択する`
+            const label = getPropertyChipLabel(space)
             return (
               <button
                 key={space.id}
@@ -191,10 +193,7 @@ export default function TradeDialog({
         <div className={styles.tradePropertyList}>
           {theirProperties.map((space) => {
             const isSelected = requestProperties.includes(space.id)
-            const priceStr = space.price != null ? `（$${space.price}）` : ''
-            const label = isSelected
-              ? `${space.name}${priceStr}の選択を解除する`
-              : `${space.name}${priceStr}を選択する`
+            const label = getPropertyChipLabel(space)
             return (
               <button
                 key={space.id}

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -23,9 +23,6 @@ const COLOR_MAP: Record<ColorGroup, string> = {
   railroad: '#555',
 }
 
-const PROPERTY_CHIP_TITLE_SELECTED = '選択を解除する'
-const PROPERTY_CHIP_TITLE_UNSELECTED = '選択する'
-
 type TradeDialogProps = {
   currentPlayer: Player
   targetPlayer: Player
@@ -111,11 +108,8 @@ export default function TradeDialog({
                 className={`${styles.tradePropertyChip} ${isSelected ? styles.tradePropertyChipSelected : ''}`}
                 onClick={() => toggleOffer(space.id)}
                 aria-pressed={isSelected}
-                title={
-                  isSelected
-                    ? PROPERTY_CHIP_TITLE_SELECTED
-                    : PROPERTY_CHIP_TITLE_UNSELECTED
-                }
+                title={`${space.name}を${isSelected ? '選択解除する' : '選択する'}`}
+                aria-label={`${space.name}を${isSelected ? '選択解除する' : '選択する'}`}
               >
                 {space.color && (
                   <span
@@ -198,11 +192,8 @@ export default function TradeDialog({
                 className={`${styles.tradePropertyChip} ${isSelected ? styles.tradePropertyChipSelected : ''}`}
                 onClick={() => toggleRequest(space.id)}
                 aria-pressed={isSelected}
-                title={
-                  isSelected
-                    ? PROPERTY_CHIP_TITLE_SELECTED
-                    : PROPERTY_CHIP_TITLE_UNSELECTED
-                }
+                title={`${space.name}を${isSelected ? '選択解除する' : '選択する'}`}
+                aria-label={`${space.name}を${isSelected ? '選択解除する' : '選択する'}`}
               >
                 {space.color && (
                   <span

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -102,14 +102,18 @@ export default function TradeDialog({
         <div className={styles.tradePropertyList}>
           {myProperties.map((space) => {
             const isSelected = offerProperties.includes(space.id)
+            const priceStr = space.price != null ? `（$${space.price}）` : ''
+            const label = isSelected
+              ? `${space.name}${priceStr}の選択を解除する`
+              : `${space.name}${priceStr}を選択する`
             return (
               <button
                 key={space.id}
                 className={`${styles.tradePropertyChip} ${isSelected ? styles.tradePropertyChipSelected : ''}`}
                 onClick={() => toggleOffer(space.id)}
                 aria-pressed={isSelected}
-                title={`${space.name}を${isSelected ? '選択解除する' : '選択する'}`}
-                aria-label={`${space.name}を${isSelected ? '選択解除する' : '選択する'}`}
+                title={label}
+                aria-label={label}
               >
                 {space.color && (
                   <span
@@ -186,14 +190,18 @@ export default function TradeDialog({
         <div className={styles.tradePropertyList}>
           {theirProperties.map((space) => {
             const isSelected = requestProperties.includes(space.id)
+            const priceStr = space.price != null ? `（$${space.price}）` : ''
+            const label = isSelected
+              ? `${space.name}${priceStr}の選択を解除する`
+              : `${space.name}${priceStr}を選択する`
             return (
               <button
                 key={space.id}
                 className={`${styles.tradePropertyChip} ${isSelected ? styles.tradePropertyChipSelected : ''}`}
                 onClick={() => toggleRequest(space.id)}
                 aria-pressed={isSelected}
-                title={`${space.name}を${isSelected ? '選択解除する' : '選択する'}`}
-                aria-label={`${space.name}を${isSelected ? '選択解除する' : '選択する'}`}
+                title={label}
+                aria-label={label}
               >
                 {space.color && (
                   <span


### PR DESCRIPTION
## 🎨 Palette: Dynamic ARIA labels for Trade Dialog chips

💡 **What**: Dynamically include the property name (`space.name`) in the `title` and `aria-label` for property chip buttons in the Trade Dialog.
🎯 **Why**: Previously, these buttons only read "選択する" (Select) or "選択を解除する" (Deselect). For screen reader users or when hovering via mouse, it was not immediately clear *which* property was being acted upon without surrounding context. This small change makes the action extremely explicit (e.g., "Park Placeを選択する").
♿ **Accessibility**: Immensely improves screen reader experience by injecting contextual property names into interactive element labels. No visual regression.

*This change aligns with Palette's goal of making small, high-impact accessibility and usability improvements using localized strings.*

---
*PR created automatically by Jules for task [973021766444535726](https://jules.google.com/task/973021766444535726) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 取引ダイアログの物件選択チップでアクセシビリティ用ラベル（title/aria-label）を明確化しました。
  * 選択表示テキストを改善し、価格がある物件は表示文に「（$...）」形式の価格を含めるようにしました。
  * 提示側・受取側でラベル表示を一貫化し、画面読み上げやツールチップの整合性を向上しました。
  * 表示ラベルの生成ロジックを整理し、冗長な定義を削除しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->