### PR TITLE
🎨 Palette: Add tooltip explaining disabled start button state

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,8 +16,8 @@
 
 **Action:** When adding or reviewing interactive elements, ensure they provide visual feedback (like `title` tooltips) in addition to screen-reader accessibility (`aria-label`) to clarify their purpose to all users.
 
-## 2026-05-16 - Add tooltip to disabled start button
+## 2026-05-16 - Make the reason a disabled button is disabled accessible to everyone
 
-**Learning:** Found that the "Game Start!" button was disabled without explaining why when a player's name was missing, leaving users without clear direction on how to proceed.
+**Learning:** Found that the "Game Start!" button was disabled without explaining why when a player's name was missing, leaving users without clear direction on how to proceed. A `title` tooltip alone does not solve this: most browsers suppress hover events on `disabled` buttons, screen-reader handling of `title` is inconsistent, and touch users have no way to see it.
 
-**Action:** Whenever a button is disabled, ensure there is a clear visual cue (like a `title` tooltip) explaining why it's disabled and what the user needs to do to enable it.
+**Action:** Whenever a button is disabled, render the reason as a visible helper text near the button and reference it from the button via `aria-describedby`. `title` may be added as a supplementary hint, but never as the sole channel. Also reinforce the disabled state visually (e.g. lower `opacity` and `cursor: not-allowed`).

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,3 +15,9 @@
 **Learning:** Found that some interactive elements (like player chips and toggleable property chips) had descriptive `aria-label`s for screen readers but lacked visual tooltips (`title` attributes) for sighted users, making their interactivity or function less obvious.
 
 **Action:** When adding or reviewing interactive elements, ensure they provide visual feedback (like `title` tooltips) in addition to screen-reader accessibility (`aria-label`) to clarify their purpose to all users.
+
+## 2026-05-16 - Add tooltip to disabled start button
+
+**Learning:** Found that the "Game Start!" button was disabled without explaining why when a player's name was missing, leaving users without clear direction on how to proceed.
+
+**Action:** Whenever a button is disabled, ensure there is a clear visual cue (like a `title` tooltip) explaining why it's disabled and what the user needs to do to enable it.

--- a/src/components/Setup/Setup.module.css
+++ b/src/components/Setup/Setup.module.css
@@ -95,3 +95,13 @@
 .startButton {
   margin-top: 16px;
 }
+.startButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.startHint {
+  font-size: 14px;
+  color: var(--color-text-light);
+  text-align: center;
+  margin-top: 8px;
+}

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -22,6 +22,7 @@ const DEFAULT_NAMES = [
   'プレイヤー4',
 ]
 const DEFAULT_TOKENS: string[] = [TOKENS[0], TOKENS[1], TOKENS[2], TOKENS[3]]
+const START_GUIDE_MSG = 'すべてのプレイヤーのなまえを入力してね'
 
 export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
   const [initialConfig] = useState(() => loadSetupConfig())
@@ -151,7 +152,7 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
           )
         }
         disabled={!canStart}
-        title={!canStart ? 'すべてのプレイヤーのなまえを入力してね' : undefined}
+        title={!canStart ? START_GUIDE_MSG : undefined}
       >
         ゲームスタート！
       </Button>

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -153,9 +153,20 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
         }
         disabled={!canStart}
         title={!canStart ? START_GUIDE_MSG : undefined}
+        aria-describedby={!canStart ? 'start-hint' : undefined}
       >
         ゲームスタート！
       </Button>
+      {!canStart && (
+        <p
+          id="start-hint"
+          className={styles.startHint}
+          role="status"
+          aria-live="polite"
+        >
+          {START_GUIDE_MSG}
+        </p>
+      )}
     </div>
   )
 }

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -151,6 +151,7 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
           )
         }
         disabled={!canStart}
+        title={!canStart ? 'すべてのプレイヤーのなまえを入力してね' : undefined}
       >
         ゲームスタート！
       </Button>


### PR DESCRIPTION
💡 **What:** Added a tooltip (`title` attribute) to the "Game Start!" button that shows when it is disabled.
🎯 **Why:** Previously, the button would be disabled if a player's name was missing, but there was no explanation why. This tooltip provides a clear visual cue explaining what needs to be done to proceed.
📸 **Before/After:** Before, hovering over the disabled button showed nothing. After, hovering shows "すべてのプレイヤーのなまえを入力してね" (Please enter all players' names).
♿ **Accessibility:** The `title` attribute is accessible to screen readers, providing context for the disabled state.

---
*PR created automatically by Jules for task [12578941164926896538](https://jules.google.com/task/12578941164926896538) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ゲーム開始ボタンが無効な際、ボタン近くに可視の説明テキストを表示して理由（例：プレイヤー名未入力）を案内します。スクリーンリーダーにも配慮した通知が行われます。
  * 補助的なツールチップも追加され、視覚・支援技術両方で状態が分かりやすくなりました。
* **スタイル**
  * 無効状態のボタンを視覚的に強調（透過・カーソル変更）するよう改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->