### PR TITLE
🎨 Palette: Ensure disabled reasons on auction buttons are accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 **Learning:** Found that the "Game Start!" button was disabled without explaining why when a player's name was missing, leaving users without clear direction on how to proceed. A `title` tooltip alone does not solve this: most browsers suppress hover events on `disabled` buttons, screen-reader handling of `title` is inconsistent, and touch users have no way to see it.
 
 **Action:** Whenever a button is disabled, render the reason as a visible helper text near the button and reference it from the button via `aria-describedby`. `title` may be added as a supplementary hint, but never as the sole channel. Also reinforce the disabled state visually (e.g. lower `opacity` and `cursor: not-allowed`).
+
+## 2026-05-17 - Ensure disabled reasons are accessible to everyone, not just mouse users
+**Learning:** Found that the Auction Dialog bid buttons were disabled when a player had insufficient funds, but there was no immediate feedback explaining *why* they couldn't click the button. Sighted users might be confused about game rules or UI state. Previously, I incorrectly thought adding a `title` tooltip would fix this, but that violates our standards (since most browsers suppress hover events on disabled buttons, and screen reader/touch behavior is inconsistent).
+**Action:** When a button is conditionally disabled due to a specific rule or state (like insufficient funds), render the reason as visible helper text nearby and link it via `aria-describedby` so all users—whether visual, touch, or screen-reader reliant—can understand the UI state.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -23,5 +23,6 @@
 **Action:** Whenever a button is disabled, render the reason as a visible helper text near the button and reference it from the button via `aria-describedby`. `title` may be added as a supplementary hint, but never as the sole channel. Also reinforce the disabled state visually (e.g. lower `opacity` and `cursor: not-allowed`).
 
 ## 2026-05-17 - Ensure disabled reasons are accessible to everyone, not just mouse users
+
 **Learning:** Found that the Auction Dialog bid buttons were disabled when a player had insufficient funds, but there was no immediate feedback explaining *why* they couldn't click the button. Sighted users might be confused about game rules or UI state. Previously, I incorrectly thought adding a `title` tooltip would fix this, but that violates our standards (since most browsers suppress hover events on disabled buttons, and screen reader/touch behavior is inconsistent).
 **Action:** When a button is conditionally disabled due to a specific rule or state (like insufficient funds), render the reason as visible helper text nearby and link it via `aria-describedby` so all users—whether visual, touch, or screen-reader reliant—can understand the UI state.

--- a/src/components/ActionDialog/ActionDialog.module.css
+++ b/src/components/ActionDialog/ActionDialog.module.css
@@ -31,6 +31,12 @@
   justify-content: center;
   margin-top: 12px;
 }
+.noMoneyHint {
+  color: var(--color-danger);
+  font-size: 13px;
+  margin-top: 12px;
+  text-align: center;
+}
 .cardContent {
   text-align: center;
   padding: 16px 0;

--- a/src/components/ActionDialog/AuctionDialog.tsx
+++ b/src/components/ActionDialog/AuctionDialog.tsx
@@ -6,6 +6,7 @@ import Button from '../common/Button'
 import styles from './ActionDialog.module.css'
 
 const MAX_BID_INCREMENT = 100
+const NO_MONEY_HINT_TEXT = 'おかねがたりないよ'
 
 type AuctionDialogProps = {
   auction: AuctionState
@@ -103,7 +104,7 @@ export default function AuctionDialog({
             className={styles.noMoneyHint}
             role="status"
           >
-            おかねがたりないよ
+            {NO_MONEY_HINT_TEXT}
           </div>
         )}
     </Dialog>

--- a/src/components/ActionDialog/AuctionDialog.tsx
+++ b/src/components/ActionDialog/AuctionDialog.tsx
@@ -102,7 +102,6 @@ export default function AuctionDialog({
             textAlign: 'center',
           }}
           role="status"
-          aria-live="polite"
         >
           おかねがたりないよ
         </div>

--- a/src/components/ActionDialog/AuctionDialog.tsx
+++ b/src/components/ActionDialog/AuctionDialog.tsx
@@ -5,6 +5,8 @@ import Dialog from '../common/Dialog'
 import Button from '../common/Button'
 import styles from './ActionDialog.module.css'
 
+const MAX_BID_INCREMENT = 100
+
 type AuctionDialogProps = {
   auction: AuctionState
   players: Player[]
@@ -76,31 +78,34 @@ export default function AuctionDialog({
         </Button>
         <Button
           size="small"
-          onClick={() => onBid(100)}
+          onClick={() => onBid(MAX_BID_INCREMENT)}
           disabled={
-            !activePlayer || activePlayer.money < auction.currentBid + 100
+            !activePlayer ||
+            activePlayer.money < auction.currentBid + MAX_BID_INCREMENT
           }
           aria-describedby={
-            activePlayer && activePlayer.money < auction.currentBid + 100
+            activePlayer &&
+            activePlayer.money < auction.currentBid + MAX_BID_INCREMENT
               ? 'auction-no-money-hint'
               : undefined
           }
         >
-          +$100
+          +${MAX_BID_INCREMENT}
         </Button>
         <Button size="small" variant="secondary" onClick={onPass}>
           パス
         </Button>
       </div>
-      {activePlayer && activePlayer.money < auction.currentBid + 100 && (
-        <div
-          id="auction-no-money-hint"
-          className={styles.noMoneyHint}
-          role="status"
-        >
-          おかねがたりないよ
-        </div>
-      )}
+      {activePlayer &&
+        activePlayer.money < auction.currentBid + MAX_BID_INCREMENT && (
+          <div
+            id="auction-no-money-hint"
+            className={styles.noMoneyHint}
+            role="status"
+          >
+            おかねがたりないよ
+          </div>
+        )}
     </Dialog>
   )
 }

--- a/src/components/ActionDialog/AuctionDialog.tsx
+++ b/src/components/ActionDialog/AuctionDialog.tsx
@@ -95,12 +95,7 @@ export default function AuctionDialog({
       {activePlayer && activePlayer.money < auction.currentBid + 100 && (
         <div
           id="auction-no-money-hint"
-          style={{
-            color: 'var(--color-danger)',
-            fontSize: 13,
-            marginTop: 12,
-            textAlign: 'center',
-          }}
+          className={styles.noMoneyHint}
           role="status"
         >
           おかねがたりないよ

--- a/src/components/ActionDialog/AuctionDialog.tsx
+++ b/src/components/ActionDialog/AuctionDialog.tsx
@@ -52,6 +52,11 @@ export default function AuctionDialog({
           disabled={
             !activePlayer || activePlayer.money < auction.currentBid + 10
           }
+          aria-describedby={
+            activePlayer && activePlayer.money < auction.currentBid + 10
+              ? 'auction-no-money-hint'
+              : undefined
+          }
         >
           +$10
         </Button>
@@ -60,6 +65,11 @@ export default function AuctionDialog({
           onClick={() => onBid(50)}
           disabled={
             !activePlayer || activePlayer.money < auction.currentBid + 50
+          }
+          aria-describedby={
+            activePlayer && activePlayer.money < auction.currentBid + 50
+              ? 'auction-no-money-hint'
+              : undefined
           }
         >
           +$50
@@ -70,6 +80,11 @@ export default function AuctionDialog({
           disabled={
             !activePlayer || activePlayer.money < auction.currentBid + 100
           }
+          aria-describedby={
+            activePlayer && activePlayer.money < auction.currentBid + 100
+              ? 'auction-no-money-hint'
+              : undefined
+          }
         >
           +$100
         </Button>
@@ -77,6 +92,21 @@ export default function AuctionDialog({
           パス
         </Button>
       </div>
+      {activePlayer && activePlayer.money < auction.currentBid + 100 && (
+        <div
+          id="auction-no-money-hint"
+          style={{
+            color: 'var(--color-danger)',
+            fontSize: 13,
+            marginTop: 12,
+            textAlign: 'center',
+          }}
+          role="status"
+          aria-live="polite"
+        >
+          おかねがたりないよ
+        </div>
+      )}
     </Dialog>
   )
 }


### PR DESCRIPTION
This change addresses an accessibility gap where the reason for an auction bid button being disabled (insufficient funds) wasn't communicated clearly to all users. Relying on `title` attributes doesn't work for disabled buttons across most browsers, so a visible helper text is now rendered and linked via `aria-describedby` when a player lacks the funds to make a specific bid.

Also included is a journal entry in `.jules/palette.md` detailing this learning constraint about disabled state accessibility.

---
*PR created automatically by Jules for task [8137538788630561843](https://jules.google.com/task/8137538788630561843) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * オークション入札画面で、資金不足などで入札ボタンが無効になる際に、ボタン近くへ説明テキストを表示するようになりました。

* **Accessibility**
  * 表示テキストをスクリーンリーダーと紐付け（aria-describedby）し、非マウス利用者にも無効理由が伝わるよう改善しました。

* **Style**
  * 無効理由用の表示スタイルを追加し、視認性を向上させました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->