### PR TITLE
🎨 Palette: Improve TradeDialog UX with empty states and validation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -26,3 +26,7 @@
 
 **Learning:** Found that the Auction Dialog bid buttons were disabled when a player had insufficient funds, but there was no immediate feedback explaining *why* they couldn't click the button. Sighted users might be confused about game rules or UI state. Previously, I incorrectly thought adding a `title` tooltip would fix this, but that violates our standards (since most browsers suppress hover events on disabled buttons, and screen reader/touch behavior is inconsistent).
 **Action:** When a button is conditionally disabled due to a specific rule or state (like insufficient funds), render the reason as visible helper text nearby and link it via `aria-describedby` so all users—whether visual, touch, or screen-reader reliant—can understand the UI state.
+
+## 2026-05-18 - Add empty states to dynamic lists and disable empty submissions
+**Learning:** Found that the TradeDialog could be submitted without any items selected, and that empty property lists rendered as confusing blank spaces. Users might think the UI is broken or accidentally submit useless empty trades.
+**Action:** Always provide explicit, friendly empty states for dynamic lists (e.g., "わたせる土地がないよ") to reassure users. Additionally, disable submission buttons when the action is a no-op (like an empty trade) and use `aria-describedby` with visible helper text to explain why the button is disabled.

--- a/src/components/ActionDialog/ActionDialog.module.css
+++ b/src/components/ActionDialog/ActionDialog.module.css
@@ -171,3 +171,24 @@
   border: 2px solid #e0e0e0;
   color: var(--color-text-light);
 }
+.tradeActionArea {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+.tradeActionButtons {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+.tradeEmptyHint {
+  color: var(--color-danger);
+  font-size: 13px;
+}
+.tradeEmptyProperties {
+  font-size: 13px;
+  color: var(--color-text-light);
+  padding: 4px 8px;
+}

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -77,6 +77,12 @@ export default function TradeDialog({
     )
   }
 
+  const isTradeEmpty =
+    offerProperties.length === 0 &&
+    requestProperties.length === 0 &&
+    offerMoney === 0 &&
+    requestMoney === 0
+
   const handlePropose = () => {
     onPropose({
       fromPlayerId: currentPlayer.id,
@@ -95,17 +101,53 @@ export default function TradeDialog({
       title={`${targetPlayer.token} ${targetPlayer.name}とこうかん`}
       onClose={onClose}
       actions={
-        <>
-          <Button onClick={handlePropose}>ていあんする！</Button>
-          <Button variant="secondary" onClick={onClose}>
-            やめる
-          </Button>
-        </>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 8,
+            width: '100%',
+          }}
+        >
+          <div style={{ display: 'flex', gap: 12, justifyContent: 'center' }}>
+            <Button
+              onClick={handlePropose}
+              disabled={isTradeEmpty}
+              aria-describedby={isTradeEmpty ? 'trade-empty-hint' : undefined}
+            >
+              ていあんする！
+            </Button>
+            <Button variant="secondary" onClick={onClose}>
+              やめる
+            </Button>
+          </div>
+          {isTradeEmpty && (
+            <div
+              id="trade-empty-hint"
+              style={{ color: 'var(--color-danger)', fontSize: 13 }}
+              role="status"
+            >
+              こうかんするものをえらんでね
+            </div>
+          )}
+        </div>
       }
     >
       <div className={styles.tradeSection}>
         <div className={styles.tradeSectionTitle}>わたすもの</div>
         <div className={styles.tradePropertyList}>
+          {myProperties.length === 0 && (
+            <div
+              style={{
+                fontSize: 13,
+                color: 'var(--color-text-light)',
+                padding: '4px 8px',
+              }}
+            >
+              わたせる土地がないよ
+            </div>
+          )}
           {myProperties.map((space) => {
             const isSelected = offerProperties.includes(space.id)
             const label = getPropertyChipLabel(space)
@@ -191,6 +233,17 @@ export default function TradeDialog({
       <div className={styles.tradeSection}>
         <div className={styles.tradeSectionTitle}>もらうもの</div>
         <div className={styles.tradePropertyList}>
+          {theirProperties.length === 0 && (
+            <div
+              style={{
+                fontSize: 13,
+                color: 'var(--color-text-light)',
+                padding: '4px 8px',
+              }}
+            >
+              もらえる土地がないよ
+            </div>
+          )}
           {theirProperties.map((space) => {
             const isSelected = requestProperties.includes(space.id)
             const label = getPropertyChipLabel(space)

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -101,16 +101,8 @@ export default function TradeDialog({
       title={`${targetPlayer.token} ${targetPlayer.name}とこうかん`}
       onClose={onClose}
       actions={
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            gap: 8,
-            width: '100%',
-          }}
-        >
-          <div style={{ display: 'flex', gap: 12, justifyContent: 'center' }}>
+        <div className={styles.tradeActionArea}>
+          <div className={styles.tradeActionButtons}>
             <Button
               onClick={handlePropose}
               disabled={isTradeEmpty}
@@ -125,7 +117,7 @@ export default function TradeDialog({
           {isTradeEmpty && (
             <div
               id="trade-empty-hint"
-              style={{ color: 'var(--color-danger)', fontSize: 13 }}
+              className={styles.tradeEmptyHint}
               role="status"
             >
               こうかんするものをえらんでね
@@ -138,13 +130,7 @@ export default function TradeDialog({
         <div className={styles.tradeSectionTitle}>わたすもの</div>
         <div className={styles.tradePropertyList}>
           {myProperties.length === 0 && (
-            <div
-              style={{
-                fontSize: 13,
-                color: 'var(--color-text-light)',
-                padding: '4px 8px',
-              }}
-            >
+            <div className={styles.tradeEmptyProperties}>
               わたせる土地がないよ
             </div>
           )}
@@ -234,13 +220,7 @@ export default function TradeDialog({
         <div className={styles.tradeSectionTitle}>もらうもの</div>
         <div className={styles.tradePropertyList}>
           {theirProperties.length === 0 && (
-            <div
-              style={{
-                fontSize: 13,
-                color: 'var(--color-text-light)',
-                padding: '4px 8px',
-              }}
-            >
+            <div className={styles.tradeEmptyProperties}>
               もらえる土地がないよ
             </div>
           )}

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -12,6 +12,17 @@ import styles from './ActionDialog.module.css'
 import { clamp } from './tradeDialog.utils'
 import { getSpaceById } from '../../game/rules'
 
+const LABELS = {
+  propose: 'ていあんする！',
+  cancel: 'やめる',
+  emptyHint: 'こうかんするものをえらんでね',
+  offerSection: 'わたすもの',
+  requestSection: 'もらうもの',
+  noOfferProperties: 'わたせる土地がないよ',
+  noRequestProperties: 'もらえる土地がないよ',
+  moneyLabel: 'おかね: $',
+} as const
+
 const COLOR_MAP: Record<ColorGroup, string> = {
   brown: 'var(--color-brown)',
   lightblue: 'var(--color-lightblue)',
@@ -108,10 +119,10 @@ export default function TradeDialog({
               disabled={isTradeEmpty}
               aria-describedby={isTradeEmpty ? 'trade-empty-hint' : undefined}
             >
-              ていあんする！
+              {LABELS.propose}
             </Button>
             <Button variant="secondary" onClick={onClose}>
-              やめる
+              {LABELS.cancel}
             </Button>
           </div>
           {isTradeEmpty && (
@@ -120,18 +131,18 @@ export default function TradeDialog({
               className={styles.tradeEmptyHint}
               role="status"
             >
-              こうかんするものをえらんでね
+              {LABELS.emptyHint}
             </div>
           )}
         </div>
       }
     >
       <div className={styles.tradeSection}>
-        <div className={styles.tradeSectionTitle}>わたすもの</div>
+        <div className={styles.tradeSectionTitle}>{LABELS.offerSection}</div>
         <div className={styles.tradePropertyList}>
           {myProperties.length === 0 && (
             <div className={styles.tradeEmptyProperties}>
-              わたせる土地がないよ
+              {LABELS.noOfferProperties}
             </div>
           )}
           {myProperties.map((space) => {
@@ -165,7 +176,7 @@ export default function TradeDialog({
         </div>
         <div className={styles.moneyInputRow}>
           <label htmlFor={offerMoneyId} className={styles.moneyInputLabel}>
-            おかね: $
+            {LABELS.moneyLabel}
           </label>
           <input
             id={offerMoneyId}
@@ -217,11 +228,11 @@ export default function TradeDialog({
         </div>
       </div>
       <div className={styles.tradeSection}>
-        <div className={styles.tradeSectionTitle}>もらうもの</div>
+        <div className={styles.tradeSectionTitle}>{LABELS.requestSection}</div>
         <div className={styles.tradePropertyList}>
           {theirProperties.length === 0 && (
             <div className={styles.tradeEmptyProperties}>
-              もらえる土地がないよ
+              {LABELS.noRequestProperties}
             </div>
           )}
           {theirProperties.map((space) => {
@@ -255,7 +266,7 @@ export default function TradeDialog({
         </div>
         <div className={styles.moneyInputRow}>
           <label htmlFor={requestMoneyId} className={styles.moneyInputLabel}>
-            おかね: $
+            {LABELS.moneyLabel}
           </label>
           <input
             id={requestMoneyId}


### PR DESCRIPTION
* 💡 **What:** Added empty state messages to the offer/request property lists in the TradeDialog and disabled the "Propose!" button when the entire trade (both properties and money) is empty.
* 🎯 **Why:** Previously, an empty property list resulted in a confusing blank space that might appear broken. Furthermore, users could accidentally submit empty, no-op trades since the propose button remained active.
* ♿ **Accessibility:** Added visible helper text "こうかんするものをえらんでね" (Select something to trade) below the disabled propose button, which is correctly linked using `aria-describedby` so screen readers and all users understand why the action is blocked. Recorded this UX learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [17487602970178068587](https://jules.google.com/task/17487602970178068587) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 動的リストの空状態表示を追加し、受け取れる土地がない場合に案内文を表示するようにしました
  * 土地交換で入力が未選択（空）の場合、提案送信を無効化するようにしました

* **アクセシビリティ**
  * 無効状態の理由を可視のヘルパーテキストで表示し、スクリーンリーダー向けに説明を紐付けられるようにしました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->