### PR TITLE
chore: 🤖 CodeRabbit に request_changes_workflow を有効化

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,5 @@
 language: 'ja'
 reviews:
   poem: false
+  # ソロ運用でブランチ保護の承認必須要件を満たすため、全コメント resolve 時に CodeRabbit が approve に遷移するよう有効化
   request_changes_workflow: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,4 @@
 language: 'ja'
 reviews:
   poem: false
+  request_changes_workflow: true


### PR DESCRIPTION
## Summary

- `.coderabbit.yaml` の `reviews` に `request_changes_workflow: true` を追加。
- CodeRabbit が全コメントを resolve した時点で自動的に approve に遷移するよう設定する。
- 目的: ソロ運用において `main` ブランチ保護の `required_approving_review_count: 1` を満たすため、CodeRabbit による承認パスを開く。

## 背景

- 現状、`main` ブランチ保護で承認レビューが必須だが、ソロ運用のため別の人間レビュアーから approve を得られない。
- CodeRabbit/Gemini のレビューはすべて `COMMENTED` ステートのみで、`APPROVED` は出ない。
- `request_changes_workflow` を有効化すると、CodeRabbit のコメントが全て resolve された段階で approve に遷移する挙動が期待できる（公式設定リファレンス記載）。

## 注意点

- 公式ドキュメントの記述に曖昧さがあり、実際に GitHub の `APPROVED` review state が submit されるかは検証が必要。
- App による approve はブランチ保護の承認カウントに含まれない可能性がある。本 PR マージ後、後続 PR で実際の挙動を確認する。
- 期待通りに動かない場合は別途代替策（Admin マージ・保護ルール緩和等）を検討する。

## Test plan

- [ ] PR マージ後、新規 PR を作成して CodeRabbit のレビュー挙動を確認する
  - [ ] CodeRabbit 初回レビュー時に `REQUEST_CHANGES` 相当のステートが付くか
  - [ ] 全コメント resolve 後に `APPROVED` レビューが投稿されるか
  - [ ] 投稿された approve がブランチ保護の承認カウントに反映されるか

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * コードレビューの「変更要求」ワークフローを有効化する設定を追加しました（トップレベルのフラグを true に設定）。合わせて設定の意図を示すコメントを追記しました。existing 言語設定やレビュー関連の既存フラグには影響ありません。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->