### PR TITLE
🎨 Palette: explicitly link visual helper text to disabled buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -30,3 +30,7 @@
 ## 2026-05-18 - Add empty states to dynamic lists and disable empty submissions
 **Learning:** Found that the TradeDialog could be submitted without any items selected, and that empty property lists rendered as confusing blank spaces. Users might think the UI is broken or accidentally submit useless empty trades.
 **Action:** Always provide explicit, friendly empty states for dynamic lists (e.g., "わたせる土地がないよ") to reassure users. Additionally, disable submission buttons when the action is a no-op (like an empty trade) and use `aria-describedby` with visible helper text to explain why the button is disabled.
+
+## 2026-05-19 - Explicitly link visual helper text to disabled buttons
+**Learning:** Found that visible error messages explaining why a button is disabled (e.g. insufficient funds) were not programmatically associated with the button itself. Screen reader users would not understand why the action is blocked when focusing the button.
+**Action:** When providing visible helper text explaining a disabled state, always use `aria-describedby` on the button to link to the helper text's `id`, ensuring the reason is accessible to screen readers.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -33,4 +33,4 @@
 
 ## 2026-05-19 - Explicitly link visual helper text to disabled buttons
 **Learning:** Found that visible error messages explaining why a button is disabled (e.g. insufficient funds) were not programmatically associated with the button itself. Screen reader users would not understand why the action is blocked when focusing the button.
-**Action:** When providing visible helper text explaining a disabled state, always use `aria-describedby` on the button to link to the helper text's `id`, ensuring the reason is accessible to screen readers.
+**Action:** When providing visible helper text explaining a disabled state, always use `aria-describedby` on the button to link to the helper text's `id`, ensuring the reason is accessible to screen readers. Use `useId()` from React to generate unique IDs for the helper text elements, ensuring uniqueness when a component is rendered in multiple instances.

--- a/src/components/ActionDialog/JailDialog.tsx
+++ b/src/components/ActionDialog/JailDialog.tsx
@@ -1,6 +1,9 @@
+import { useId } from 'react'
 import type { Player } from '../../game/types'
 import Dialog from '../common/Dialog'
 import Button from '../common/Button'
+
+const JAIL_FINE = 50
 
 type JailDialogProps = {
   currentPlayer: Player
@@ -15,7 +18,8 @@ export default function JailDialog({
   onUseCard,
   onRollForJail,
 }: JailDialogProps) {
-  const canPayFine = currentPlayer.money >= 50
+  const noMoneyHintId = useId()
+  const canPayFine = currentPlayer.money >= JAIL_FINE
   const hasCards = currentPlayer.getOutOfJailCards > 0
   return (
     <Dialog
@@ -25,9 +29,9 @@ export default function JailDialog({
           <Button
             onClick={onPayFine}
             disabled={!canPayFine}
-            aria-describedby={!canPayFine ? 'jail-no-money-hint' : undefined}
+            aria-describedby={!canPayFine ? noMoneyHintId : undefined}
           >
-            $50はらって出る
+            ${JAIL_FINE}はらって出る
           </Button>
           {hasCards && (
             <Button variant="secondary" onClick={onUseCard}>
@@ -45,11 +49,11 @@ export default function JailDialog({
         <div>どうやってでる？</div>
         {!canPayFine && (
           <div
-            id="jail-no-money-hint"
+            id={noMoneyHintId}
             role="status"
             style={{ color: 'var(--color-danger)', fontSize: 13, marginTop: 4 }}
           >
-            おかねがたりないよ（$50ひつよう）
+            おかねがたりないよ（${JAIL_FINE}ひつよう）
           </div>
         )}
         {hasCards && (

--- a/src/components/ActionDialog/JailDialog.tsx
+++ b/src/components/ActionDialog/JailDialog.tsx
@@ -22,7 +22,11 @@ export default function JailDialog({
       title="🔒 刑務所にいるよ"
       actions={
         <>
-          <Button onClick={onPayFine} disabled={!canPayFine}>
+          <Button
+            onClick={onPayFine}
+            disabled={!canPayFine}
+            aria-describedby={!canPayFine ? 'jail-no-money-hint' : undefined}
+          >
             $50はらって出る
           </Button>
           {hasCards && (
@@ -41,6 +45,8 @@ export default function JailDialog({
         <div>どうやってでる？</div>
         {!canPayFine && (
           <div
+            id="jail-no-money-hint"
+            role="status"
             style={{ color: 'var(--color-danger)', fontSize: 13, marginTop: 4 }}
           >
             おかねがたりないよ（$50ひつよう）

--- a/src/components/ActionDialog/PurchaseDialog.tsx
+++ b/src/components/ActionDialog/PurchaseDialog.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react'
 import type { BoardSpace, Player } from '../../game/types'
 import Dialog from '../common/Dialog'
 import Button from '../common/Button'
@@ -16,6 +17,7 @@ export default function PurchaseDialog({
   onBuy,
   onDecline,
 }: PurchaseDialogProps) {
+  const noMoneyHintId = useId()
   const canAfford = currentPlayer.money >= (space.price ?? 0)
   return (
     <Dialog
@@ -26,7 +28,7 @@ export default function PurchaseDialog({
           <Button
             onClick={onBuy}
             disabled={!canAfford}
-            aria-describedby={!canAfford ? 'purchase-no-money-hint' : undefined}
+            aria-describedby={!canAfford ? noMoneyHintId : undefined}
           >
             ${space.price}で買う！
           </Button>
@@ -44,7 +46,7 @@ export default function PurchaseDialog({
         </div>
         {!canAfford && (
           <div
-            id="purchase-no-money-hint"
+            id={noMoneyHintId}
             role="status"
             style={{ color: 'var(--color-danger)', fontSize: 13, marginTop: 4 }}
           >

--- a/src/components/ActionDialog/PurchaseDialog.tsx
+++ b/src/components/ActionDialog/PurchaseDialog.tsx
@@ -23,7 +23,11 @@ export default function PurchaseDialog({
       onClose={onDecline}
       actions={
         <>
-          <Button onClick={onBuy} disabled={!canAfford}>
+          <Button
+            onClick={onBuy}
+            disabled={!canAfford}
+            aria-describedby={!canAfford ? 'purchase-no-money-hint' : undefined}
+          >
             ${space.price}で買う！
           </Button>
           <Button variant="secondary" onClick={onDecline}>
@@ -40,6 +44,8 @@ export default function PurchaseDialog({
         </div>
         {!canAfford && (
           <div
+            id="purchase-no-money-hint"
+            role="status"
             style={{ color: 'var(--color-danger)', fontSize: 13, marginTop: 4 }}
           >
             おかねがたりないよ


### PR DESCRIPTION
This PR improves the accessibility of action dialogs by explicitly linking the visible error messages ("insufficient funds") to their respective disabled buttons.

### 💡 What
- Added `id` and `role="status"` to the visible error messages in `PurchaseDialog.tsx` and `JailDialog.tsx`.
- Linked these messages to the corresponding disabled `<Button>` elements using the `aria-describedby` attribute.
- Documented this learning in `.jules/palette.md` to establish a convention for future disabled button patterns.

### 🎯 Why
Previously, sighted users could read the text below the button explaining why it was disabled (e.g., "おかねがたりないよ"), but screen reader users focusing the button would only hear that it was disabled without context. Linking the helper text ensures an equitable experience for all users.

### ♿ Accessibility
- Improves WCAG 2.1 SC 3.3.2 (Labels or Instructions) compliance by ensuring the reason for the disabled state is programmatically available.
- Added `role="status"` to the hints so they are announced appropriately by assistive tech when they appear.

---
*PR created automatically by Jules for task [2296512506136856553](https://jules.google.com/task/2296512506136856553) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **アクセシビリティ改善**
  * 複数のダイアログで、無効化されたボタンに対して「無効の理由を説明するヘルパーテキスト」を関連付けました。スクリーンリーダー等でボタンが無効な理由をより明確に伝えます。
  * 無効時のヘルプ文は補助技術に向けてステータスとして通知されるようになりました。
* **ドキュメント**
  * ボタン無効時のヘルパーテキスト関連付けの運用ルールを追記しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->