### PR TITLE
🎨 Palette: Add tooltip to mini board spaces

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -34,3 +34,7 @@
 ## 2026-05-19 - Explicitly link visual helper text to disabled buttons
 **Learning:** Found that visible error messages explaining why a button is disabled (e.g. insufficient funds) were not programmatically associated with the button itself. Screen reader users would not understand why the action is blocked when focusing the button.
 **Action:** When providing visible helper text explaining a disabled state, always use `aria-describedby` on the button to link to the helper text's `id`, ensuring the reason is accessible to screen readers. Use `useId()` from React to generate unique IDs for the helper text elements, ensuring uniqueness when a component is rendered in multiple instances.
+
+## 2026-05-22 - Mirror aria-label in visible tooltips for interactive board elements
+**Learning:** Found that the mini map spaces (`MemoizedMiniSpace`) had rich, dynamically generated descriptive information in their `aria-label` (including property name, owner, number of houses, and players present) that was completely inaccessible to sighted mouse users. The UI lacked visual cues for this detailed state unless clicked to open a dialog.
+**Action:** Always provide visual tooltips (e.g., using the `title` attribute) that mirror the information provided in `aria-label` for interactive board elements or densely packed UI components, ensuring that sighted users have the same quick access to state information as screen-reader users without requiring additional clicks.

--- a/src/components/Board/MemoizedMiniSpace.tsx
+++ b/src/components/Board/MemoizedMiniSpace.tsx
@@ -141,6 +141,7 @@ export const MemoizedMiniSpace = memo(function MemoizedMiniSpace({
       }}
       onClick={() => onSpaceClick(space.position)}
       aria-label={ariaLabel}
+      title={ariaLabel}
     >
       {space.color && (
         <div

--- a/src/components/Board/MemoizedMiniSpace.tsx
+++ b/src/components/Board/MemoizedMiniSpace.tsx
@@ -36,6 +36,22 @@ function getSpaceIcon(space: BoardSpace): string | null {
   return null;
 }
 
+function getSpaceLabel(
+  space: BoardSpace,
+  ownerName: string | undefined,
+  houses: number,
+  playerCount: number,
+): string {
+  return [
+    space.name,
+    ownerName && `所有者: ${ownerName}`,
+    houses > 0 && (houses === 5 ? 'ホテル' : `家${houses}軒`),
+    playerCount > 0 && `プレイヤー${playerCount}人滞在中`,
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
 function getColorBarPosition(position: number): React.CSSProperties {
   if (position <= 10) return { top: 0, left: 0, right: 0 };
   if (position <= 20) return { top: 0, bottom: 0, right: 0 };
@@ -115,14 +131,7 @@ export const MemoizedMiniSpace = memo(function MemoizedMiniSpace({
     ? allPlayers.find((p) => p.id === ownerId)?.name
     : undefined;
   const houses = propState?.houses ?? 0;
-  const ariaLabel = [
-    space.name,
-    ownerName && `所有者: ${ownerName}`,
-    houses > 0 && (houses === 5 ? 'ホテル' : `家${houses}軒`),
-    playersHere.length > 0 && `プレイヤー${playersHere.length}人滞在中`,
-  ]
-    .filter(Boolean)
-    .join(' ');
+  const ariaLabel = getSpaceLabel(space, ownerName, houses, playersHere.length);
 
   return (
     <button


### PR DESCRIPTION
💡 **What**: Added `title={ariaLabel}` to the `<button>` element in `MemoizedMiniSpace`.
🎯 **Why**: The mini map board spaces contain dynamically generated, descriptive information in their `aria-label` (including property name, owner, houses, and players present). This information is completely inaccessible to sighted mouse users without clicking the space to open a dialog. Adding a native tooltip mirrors this information visually.
📸 **Before/After**: Sighted users can now hover over the mini map board spaces and see a native tooltip summarizing the space's current game state.
♿ **Accessibility**: Provides equivalent access to rich game state context for sighted mouse users that was previously exclusively available to screen-reader users via `aria-label`.

---
*PR created automatically by Jules for task [11832102973365229605](https://jules.google.com/task/11832102973365229605) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ミニマップ上のインタラクティブ要素にツールチップ（title属性）を追加し、プロパティ名、所有者、建物数、参加プレイヤーなどの詳細をマウスホバーで視覚的に確認できるようにしました。スクリーンリーダー向けのラベルと同じ情報を視覚ツールチップで提示することで、情報取得が容易になり操作が直感的になります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->