### PR TITLE
refactor(ai): 💡 AIツール設定ファイルの重複コンテンツを共通テンプレート化 (#102)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,22 +1,38 @@
+<!--
+  ⚠️ このファイルは自動生成されています。直接編集しないでください。
+  対象ツール: Cursor
+  マスタ: docs/ai-guidelines.md
+  同期: bun run sync:ai-guidelines
+-->
+
 # monopo AIコーディングガイドライン
 
+> 本ファイルは AI コーディングアシスタント（Cursor / GitHub Copilot など）共通のマスタガイドラインです。
+> 各 AI ツール固有の設定ファイル（`.cursorrules` / `.github/copilot-instructions.md` など）は本ファイルから自動生成されます。
+> 変更時は本ファイルのみを編集し、`bun run sync:ai-guidelines` を実行して同期してください。
+
 ## 言語ルール
+
 - ユーザーインターフェースのテキスト、ソースコードのコメント、プルリクエストの説明、およびプロジェクトのドキュメントファイルはすべて日本語で記述し、維持してください。
 - 商標上の理由により、コードベース全体で「monopoly（モノポリ）」の代わりに「monopo（モノポ）」という名称を厳密に使用してください。
 
 ## 技術スタック
+
 - フロントエンド: React, Vite, TypeScript, CSS Modules
 - パッケージマネージャー / ランタイム: Bun (npm, yarn, pnpm は使用しないでください)
 
 ## コード品質とアーキテクチャ
+
 - AIコードレビュー（PR-Agent / CodeRabbit など）のドックストリングカバレッジチェックを満たすため、新規または変更された関数やコンポーネントには適切なJSDocコメントを含めてください。
 - AIツール関連のPRを作成する際は、タイトルを `chore(ai): 🤖 AIツール設定の最適化` などのフォーマットに従ってください。
 - 動的なリストをレンダリングする際は、空の要素についての状態を明示してください。
 
 ## セキュリティ
+
 - ゲームロジック（サイコロのロールやシャッフルなど）における安全な乱数生成には、`src/game/random.ts` でラップされた Web Crypto API（`crypto.getRandomValues()`）の `getSecureRandomInt` を使用してください。`Math.random()` は使用しないでください。
 - `localStorage` から読み込まれるデータは信頼できない入力として扱います。アプリケーションの状態に適用する前に、構造を深く検証してください。
 
 ## テストと CI/CD
+
 - GitHub ActionsのCI/CDワークフローでは、`actions/setup-node` の代わりに `oven-sh/setup-bun` を利用して環境を構築してください。
 - 乱数生成に依存するテストを作成または更新する際は、`Math.random()` の代わりに `src/game/random.ts` の `getSecureRandomInt` をモックしてください。

--- a/.cursorrules
+++ b/.cursorrules
@@ -7,9 +7,9 @@
 
 # monopo AIコーディングガイドライン
 
-> 本ファイルは AI コーディングアシスタント（Cursor / GitHub Copilot など）共通のマスタガイドラインです。
+> 本ファイルは AI コーディングアシスタント（Cursor / GitHub Copilot 等）共通のマスタガイドラインです。
 > 各 AI ツール固有の設定ファイル（`.cursorrules` / `.github/copilot-instructions.md` など）は本ファイルから自動生成されます。
-> 変更時は本ファイルのみを編集し、`bun run sync:ai-guidelines` を実行して同期してください。
+> 変更時はマスタファイル (`docs/ai-guidelines.md`) のみを編集し、`bun run sync:ai-guidelines` を実行して同期してください。
 
 ## 言語ルール
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,9 +7,9 @@
 
 # monopo AIコーディングガイドライン
 
-> 本ファイルは AI コーディングアシスタント（Cursor / GitHub Copilot など）共通のマスタガイドラインです。
+> 本ファイルは AI コーディングアシスタント（Cursor / GitHub Copilot 等）共通のマスタガイドラインです。
 > 各 AI ツール固有の設定ファイル（`.cursorrules` / `.github/copilot-instructions.md` など）は本ファイルから自動生成されます。
-> 変更時は本ファイルのみを編集し、`bun run sync:ai-guidelines` を実行して同期してください。
+> 変更時はマスタファイル (`docs/ai-guidelines.md`) のみを編集し、`bun run sync:ai-guidelines` を実行して同期してください。
 
 ## 言語ルール
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.2.14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,3 +94,14 @@ jobs:
       # NOTE: `bun audit` は bun 1.2.21 以降で追加されたため、pin している 1.2.14 では未対応。
       # 脆弱性チェックは当面 Dependabot に委ね、bun-version を引き上げる際に audit を再追加する。
       - run: bun pm untrusted
+
+  ai-guidelines-sync:
+    name: AI Guidelines Sync Verification
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.2.14
+      - run: bun run sync:ai-guidelines:check

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ bun run dev
 - `bun run lint`: ESLint を使用してコードの静的解析を行います
 - `bun run format`: Prettier を使用してコードのフォーマットを行います
 - `bun run typecheck`: TypeScript の型チェックを実行します
+- `bun run sync:ai-guidelines`: AI コーディングアシスタント向け設定ファイル（`.cursorrules` / `.github/copilot-instructions.md` など）を `docs/ai-guidelines.md` から再生成します
+- `bun run sync:ai-guidelines:check`: 上記の同期状態を検証します（CI で利用、差分があれば非 0 終了）
+
+## AI コーディングアシスタント設定 (AI Coding Assistant Configuration)
+
+本プロジェクトでは Cursor / GitHub Copilot 等の AI コーディングアシスタント向け設定ファイルが複数存在しますが、内容は `docs/ai-guidelines.md` をマスタとして自動生成されています。
+
+ガイドラインを更新する際は次の手順に従ってください:
+
+1. `docs/ai-guidelines.md` を編集
+2. `bun run sync:ai-guidelines` を実行して各設定ファイルを再生成
+3. 生成された差分も含めてコミット
+
+新しい AI ツールへ対応する場合は `scripts/sync-ai-guidelines.ts` の `TARGETS` 配列にエントリを追加してください。
 
 ## 貢献について (Contributing)
 

--- a/docs/ai-guidelines.md
+++ b/docs/ai-guidelines.md
@@ -1,8 +1,8 @@
 # monopo AIコーディングガイドライン
 
-> 本ファイルは AI コーディングアシスタント（Cursor / GitHub Copilot など）共通のマスタガイドラインです。
+> 本ファイルは AI コーディングアシスタント（Cursor / GitHub Copilot 等）共通のマスタガイドラインです。
 > 各 AI ツール固有の設定ファイル（`.cursorrules` / `.github/copilot-instructions.md` など）は本ファイルから自動生成されます。
-> 変更時は本ファイルのみを編集し、`bun run sync:ai-guidelines` を実行して同期してください。
+> 変更時はマスタファイル (`docs/ai-guidelines.md`) のみを編集し、`bun run sync:ai-guidelines` を実行して同期してください。
 
 ## 言語ルール
 

--- a/docs/ai-guidelines.md
+++ b/docs/ai-guidelines.md
@@ -1,10 +1,3 @@
-<!--
-  ⚠️ このファイルは自動生成されています。直接編集しないでください。
-  対象ツール: GitHub Copilot
-  マスタ: docs/ai-guidelines.md
-  同期: bun run sync:ai-guidelines
--->
-
 # monopo AIコーディングガイドライン
 
 > 本ファイルは AI コーディングアシスタント（Cursor / GitHub Copilot など）共通のマスタガイドラインです。

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "test": "vitest run",
     "test:coverage": "vitest --run --coverage",
     "test:watch": "vitest",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "sync:ai-guidelines": "bun run scripts/sync-ai-guidelines.ts",
+    "sync:ai-guidelines:check": "bun run scripts/sync-ai-guidelines.ts --check"
   },
   "dependencies": {
     "howler": "^2.2.4",

--- a/scripts/sync-ai-guidelines.ts
+++ b/scripts/sync-ai-guidelines.ts
@@ -14,6 +14,9 @@
  *   下記 `TARGETS` 配列に出力先を追加するだけで対応可能です。
  */
 
+import { mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
 interface SyncTarget {
   name: string;
   dest: string;
@@ -76,6 +79,11 @@ async function main(): Promise<void> {
         console.log(`✅ 同期OK: ${target.dest}`);
       }
     } else {
+      // 出力先ディレクトリが存在しない場合に備え事前作成（Bun.write は自動作成しない）
+      const dir = dirname(target.dest);
+      if (dir && dir !== '.') {
+        await mkdir(dir, { recursive: true });
+      }
       await Bun.write(target.dest, expected);
       console.log(`✅ 生成: ${target.dest}`);
     }

--- a/scripts/sync-ai-guidelines.ts
+++ b/scripts/sync-ai-guidelines.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env bun
+/**
+ * AI コーディングアシスタント向け設定ファイル同期スクリプト。
+ *
+ * マスタドキュメント `docs/ai-guidelines.md` から、各 AI ツールが要求する
+ * 固定パスの設定ファイル（`.cursorrules` / `.github/copilot-instructions.md` など）
+ * を生成します。各ツール固有のヘッダー（自動生成警告）を付与した上で本文を結合します。
+ *
+ * 使い方:
+ *   bun run scripts/sync-ai-guidelines.ts            # 各ターゲットを書き込み
+ *   bun run scripts/sync-ai-guidelines.ts --check    # CI 同期検証モード（書き込まず差分があれば非0終了）
+ *
+ * 新規 AI ツールへの対応:
+ *   下記 `TARGETS` 配列に出力先を追加するだけで対応可能です。
+ */
+
+interface SyncTarget {
+  name: string;
+  dest: string;
+}
+
+const MASTER_PATH = 'docs/ai-guidelines.md';
+
+const TARGETS: readonly SyncTarget[] = [
+  { name: 'Cursor', dest: '.cursorrules' },
+  { name: 'GitHub Copilot', dest: '.github/copilot-instructions.md' },
+] as const;
+
+const AUTO_GENERATED_HEADER = (toolName: string): string =>
+  [
+    '<!--',
+    `  ⚠️ このファイルは自動生成されています。直接編集しないでください。`,
+    `  対象ツール: ${toolName}`,
+    `  マスタ: ${MASTER_PATH}`,
+    `  同期: bun run sync:ai-guidelines`,
+    '-->',
+    '',
+    '',
+  ].join('\n');
+
+/** マスタ本文と各ツール用ヘッダーから、ターゲットファイルに書き込む完全な文字列を生成する。 */
+function buildContent(master: string, toolName: string): string {
+  return `${AUTO_GENERATED_HEADER(toolName)}${master}`;
+}
+
+/** ファイルを読み込む。存在しない場合は空文字列を返す（--check モードで初回実行を許容するため）。 */
+async function readFileOrEmpty(path: string): Promise<string> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) {
+    return '';
+  }
+  return await file.text();
+}
+
+async function main(): Promise<void> {
+  const isCheck = process.argv.includes('--check');
+
+  const masterFile = Bun.file(MASTER_PATH);
+  if (!(await masterFile.exists())) {
+    console.error(`❌ マスタファイルが見つかりません: ${MASTER_PATH}`);
+    process.exit(1);
+  }
+  const master = await masterFile.text();
+
+  const drift: string[] = [];
+
+  for (const target of TARGETS) {
+    const expected = buildContent(master, target.name);
+
+    if (isCheck) {
+      const actual = await readFileOrEmpty(target.dest);
+      if (actual !== expected) {
+        drift.push(target.dest);
+        console.error(`❌ 同期ずれ検出: ${target.dest}`);
+      } else {
+        console.log(`✅ 同期OK: ${target.dest}`);
+      }
+    } else {
+      await Bun.write(target.dest, expected);
+      console.log(`✅ 生成: ${target.dest}`);
+    }
+  }
+
+  if (isCheck && drift.length > 0) {
+    console.error('');
+    console.error('以下のファイルがマスタと同期されていません:');
+    for (const path of drift) {
+      console.error(`  - ${path}`);
+    }
+    console.error('');
+    console.error('復旧手順:');
+    console.error(`  1. ${MASTER_PATH} を確認・編集`);
+    console.error('  2. ローカルで `bun run sync:ai-guidelines` を実行');
+    console.error('  3. 生成された差分をコミットして再度プッシュ');
+    process.exit(1);
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary

- `.cursorrules` と `.github/copilot-instructions.md` の内容重複（PR #101 のレビュー指摘）を解消するため、マスタドキュメント `docs/ai-guidelines.md` から両ファイルを自動生成する Bun + TypeScript ベースの同期スクリプトを導入しました
- 将来 `CLAUDE.md` 等を追加する際は `scripts/sync-ai-guidelines.ts` の `TARGETS` 配列にエントリを 1 行追加するだけで対応可能な拡張可能設計
- CI 上で同期ずれを検証する `ai-guidelines-sync` ジョブを追加（差分時は復旧手順を出力して非 0 終了）

## 変更ファイル

| ファイル | 種別 | 説明 |
|---|---|---|
| `docs/ai-guidelines.md` | 新規 | AI ツール共通のマスタガイドライン |
| `scripts/sync-ai-guidelines.ts` | 新規 | Bun + TypeScript 同期スクリプト（`--check` モード対応） |
| `.cursorrules` | 更新 | マスタから再生成（先頭に自動生成警告ヘッダー付与） |
| `.github/copilot-instructions.md` | 更新 | 同上 |
| `.github/workflows/ci.yml` | 更新 | `ai-guidelines-sync` ジョブを追加 |
| `package.json` | 更新 | `sync:ai-guidelines` / `sync:ai-guidelines:check` スクリプト追加 |
| `README.md` | 更新 | 編集手順を追記 |

## 設計判断

- **Bun + TypeScript 採用理由**: プロジェクトの主要スタックと整合性が高く、型安全に `TARGETS` 配列の拡張ができるため
- **マスタを 1 ファイルに集約**: Issue 想定では `docs/ai-guidelines/` ディレクトリ階層もあり得たが、現時点ではツール固有差分がないためシンプルな単一マスタとした（将来必要になった時点で `overrides/` を追加すれば足りる）
- **pre-commit フックには組み込まない**: 既存 `lint-staged` との競合や CI との二重実行を避けるため、CI 検証＋手動実行で運用

## Test plan

- [x] `bun run sync:ai-guidelines` を実行し `.cursorrules` / `.github/copilot-instructions.md` が再生成されることを確認
- [x] `bun run sync:ai-guidelines:check` が同期状態で `exit 0` を返すことを確認
- [x] `bun run lint` / `bun run format:check` / `bun run typecheck` がすべて通過
- [x] `actionlint .github/workflows/ci.yml` 通過
- [ ] CI で `AI Guidelines Sync Verification` ジョブが緑になることを確認

Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * AIコーディングアシスタント向けのガイドライン文書を追加し、設定・運用手順やベストプラクティスを明記。
  * READMEに同期および同期検証コマンドと手順を追記。

* **Chores**
  * マスター文書から対象ファイルを自動生成／同期する仕組みを導入。
  * 自動生成ヘッダーを追加して編集不可を明示。
  * 同期状態を検証するCIジョブを追加し自動チェックを実行。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->