### PR TITLE
🎨 Palette: プレイヤー名入力欄の文字数表示とアクセシビリティ改善

### DIFF
--- a/src/components/Setup/Setup.module.css
+++ b/src/components/Setup/Setup.module.css
@@ -105,3 +105,10 @@
   text-align: center;
   margin-top: 8px;
 }
+.charCount {
+  font-size: 13px;
+  color: var(--color-text-light);
+  font-variant-numeric: tabular-nums;
+  min-width: 3.5em;
+  text-align: right;
+}

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -24,6 +24,17 @@ const DEFAULT_NAMES = [
 const DEFAULT_TOKENS: string[] = [TOKENS[0], TOKENS[1], TOKENS[2], TOKENS[3]];
 const START_GUIDE_MSG = 'すべてのプレイヤーのなまえを入力してね';
 
+/**
+ * ゲーム開始前の初期設定画面コンポーネント。
+ *
+ * プレイヤー人数の増減、各プレイヤーのなまえ入力（文字数カウンター付き）、
+ * コマの選択、および保存済みゲームの再開導線を提供する。
+ *
+ * @param onStart - 入力済みの名前一覧とコマ一覧でゲームを開始するコールバック。
+ * @param onResume - 保存済みゲームを再開するコールバック。`savedGame` がある場合のみ表示。
+ * @param savedGame - 直前に保存されたゲーム状態。存在すれば「つづきからあそぶ」UI を表示する。
+ * @returns セットアップ画面の JSX 要素。
+ */
 export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
   const baseId = useId();
   const [initialConfig] = useState(() => loadSetupConfig());

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -126,7 +126,7 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
                 handleTokenChange(i, nextToken);
               }}
               aria-label={`${names[i] || DEFAULT_NAMES[i]}のコマを変更する（現在のコマ: ${selectedTokens[i]}）`}
-              title={`${names[i] || DEFAULT_NAMES[i]}のコマを変更する`}
+              title={`${names[i] || DEFAULT_NAMES[i]}のコマを変更する（現在のコマ: ${selectedTokens[i]}）`}
             >
               {selectedTokens[i]}
             </button>
@@ -135,9 +135,14 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
               value={names[i]}
               onChange={(e) => handleNameChange(i, e.target.value)}
               placeholder={`プレイヤー${i + 1}のなまえ`}
-              aria-label={`プレイヤー${i + 1}のなまえ`}
+              aria-label={`プレイヤー${i + 1}のなまえ（最大${MAX_NAME_LENGTH}文字）`}
               maxLength={MAX_NAME_LENGTH}
+              aria-required="true"
+              aria-invalid={names[i].trim().length === 0}
             />
+            <span className={styles.charCount} aria-hidden="true">
+              {[...names[i]].length}/{MAX_NAME_LENGTH}
+            </span>
           </div>
         ))}
       </div>

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useId } from 'react';
 import {
   TOKENS,
   MIN_PLAYERS,
@@ -25,6 +25,7 @@ const DEFAULT_TOKENS: string[] = [TOKENS[0], TOKENS[1], TOKENS[2], TOKENS[3]];
 const START_GUIDE_MSG = 'すべてのプレイヤーのなまえを入力してね';
 
 export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
+  const baseId = useId();
   const [initialConfig] = useState(() => loadSetupConfig());
   const [playerCount, setPlayerCount] = useState(
     initialConfig?.playerCount ?? MIN_PLAYERS,
@@ -139,8 +140,13 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
               maxLength={MAX_NAME_LENGTH}
               aria-required="true"
               aria-invalid={names[i].trim().length === 0}
+              aria-describedby={`${baseId}-char-count-${i}`}
             />
-            <span className={styles.charCount} aria-hidden="true">
+            <span
+              id={`${baseId}-char-count-${i}`}
+              className={styles.charCount}
+              role="status"
+            >
               {[...names[i]].length}/{MAX_NAME_LENGTH}
             </span>
           </div>


### PR DESCRIPTION
💡 **What:** 
- `Setup.tsx` のプレイヤー名入力欄に、現在の文字数と最大文字数を表示するカウンターを追加しました。
- 入力欄に `aria-required="true"` と、未入力時に `aria-invalid={true}` となるよう設定しました。
- `aria-label` に最大文字数の情報を追加しました。
- アイコンのみのコマ変更ボタンについて、`title` 属性を `aria-label` と完全に一致させ、視覚的なツールチップでも同じリッチな情報（現在のコマ情報など）が表示されるように改善しました。
- Unicode/絵文字を正しくカウントするため、`[...names[i]].length` を使用しています。

🎯 **Why:** 
- プレイヤー名が最大20文字 (`MAX_NAME_LENGTH`) に制限されているにもかかわらず、画面上にその上限や現在の文字数が表示されておらず、ユーザーが突然入力できなくなる体験（UXの悪化）を防ぐためです。
- 入力必須項目であることがスクリーンリーダーにも伝わるようにするためです。
- リッチな `aria-label` 情報が視覚的な `title` にも反映されるようにする、プロジェクトのアクセシビリティルールを遵守するためです。

📸 **Before/After:**
- 入力欄の右端に `(入力文字数)/20` が表示されるようになりました。レイアウトが崩れないよう、既存の Flex row を活用しスタイルを調整しています。

♿ **Accessibility:**
- `aria-required`, `aria-invalid` の付与。
- `aria-label` と `title` の一貫性確保（スクリーンリーダーを使わないキーボードユーザーやマウスユーザーにも情報を提示）。

---
*PR created automatically by Jules for task [9594183850117484483](https://jules.google.com/task/9594183850117484483) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * プレイヤー名入力時に現在の文字数（サロゲート/絵文字対応）と最大文字数を画面表示
  * トークン変更ボタンに現在選択中のコマ情報を表示

* **改善**
  * プレイヤー名入力フィールドのアクセシビリティ強化（説明ラベル紐付け、必須/無効状態の明示）
  * 文字数表示の視認性向上（フォント・等幅数字・配置調整）

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->