### PR TITLE
feat(game): 1000年先の文明視点に基づきエコシステム・タックス（循環税）を導入

### DIFF
--- a/src/game/__tests__/reducer-actions.test.ts
+++ b/src/game/__tests__/reducer-actions.test.ts
@@ -127,14 +127,7 @@ describe('FINISH_MOVING - handleLanding 各種マス', () => {
   it('他のプレイヤーの物件にとまると家賃を払う', () => {
     let state = startedGame(); // By default has 2 players
     // baltic (price=60, base rent=4) を player-1 が所有
-    state = withPropertyOwner(state, 'baltic', 'player-1');
-    state = {
-      ...state,
-      propertyStates: {
-        ...state.propertyStates,
-        baltic: { ...state.propertyStates['baltic'], houses: 1 },
-      },
-    };
+    state = withPropertyOwner(state, 'baltic', 'player-1', { houses: 1 });
     // There are only 2 players (index 0 and 1). Make player-1 the poorest.
     state.players[1].money = 500;
 

--- a/src/game/__tests__/reducer-actions.test.ts
+++ b/src/game/__tests__/reducer-actions.test.ts
@@ -129,7 +129,12 @@ describe('FINISH_MOVING - handleLanding 各種マス', () => {
     // baltic (price=60, base rent=4) を player-1 が所有
     state = withPropertyOwner(state, 'baltic', 'player-1', { houses: 1 });
     // There are only 2 players (index 0 and 1). Make player-1 the poorest.
-    state.players[1].money = 500;
+    state = {
+      ...state,
+      players: state.players.map((p) =>
+        p.id === 'player-1' ? { ...p, money: 500 } : p,
+      ),
+    };
 
     state = withCurrentPlayer(state, { position: 0 });
     state = {

--- a/src/game/__tests__/reducer-actions.test.ts
+++ b/src/game/__tests__/reducer-actions.test.ts
@@ -125,9 +125,19 @@ describe('FINISH_MOVING - handleLanding 各種マス', () => {
   });
 
   it('他のプレイヤーの物件にとまると家賃を払う', () => {
-    let state = startedGame();
-    // baltic (price=60, base rent=4) を player-1 が所有（カラーグループ未制覇）
+    let state = startedGame(); // By default has 2 players
+    // baltic (price=60, base rent=4) を player-1 が所有
     state = withPropertyOwner(state, 'baltic', 'player-1');
+    state = {
+      ...state,
+      propertyStates: {
+        ...state.propertyStates,
+        baltic: { ...state.propertyStates['baltic'], houses: 1 },
+      },
+    };
+    // There are only 2 players (index 0 and 1). Make player-1 the poorest.
+    state.players[1].money = 500;
+
     state = withCurrentPlayer(state, { position: 0 });
     state = {
       ...state,
@@ -135,8 +145,12 @@ describe('FINISH_MOVING - handleLanding 各種マス', () => {
       turnPhase: 'moving',
     };
     const next = gameReducer(state, { type: 'FINISH_MOVING' });
-    expect(next.players[0].money).toBe(1496); // -4 (rent)
-    expect(next.players[1].money).toBe(1504); // +4 (rent)
+    // rent is 20. ecosystemTax = 2. ownerRevenue = 18.
+    // poorest is player-1.
+    // player-0 pays 20 -> 1500 - 20 = 1480
+    // player-1 receives 18 + 2 (ecosystem tax) = 20. -> 500 + 20 = 520
+    expect(next.players[0].money).toBe(1480);
+    expect(next.players[1].money).toBe(520);
   });
 
   it('抵当に入った物件にとまっても家賃は払わない', () => {

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -230,20 +230,23 @@ function handleLanding(state: GameState): GameState {
       const ownerRevenue = rent - ecosystemTax;
 
       const activePlayers = state.players.filter((p) => !p.isBankrupt);
-      const poorestPlayer = activePlayers.reduce((prev, curr) =>
-        curr.money < prev.money ? curr : prev,
-      );
+      const poorestPlayer =
+        activePlayers.length > 0
+          ? activePlayers.reduce((prev, curr) =>
+              curr.money < prev.money ? curr : prev,
+            )
+          : null;
 
       const newPlayers = state.players.map((p) => {
         let diff = 0;
         if (p.id === player.id) diff -= rent;
         if (p.id === owner.id) diff += ownerRevenue;
-        if (p.id === poorestPlayer.id) diff += ecosystemTax;
+        if (poorestPlayer && p.id === poorestPlayer.id) diff += ecosystemTax;
         return { ...p, money: p.money + diff };
       });
 
       let rentMsg = `${owner.name}に$${rent}のとまり賃をはらったよ`;
-      if (ecosystemTax > 0 && poorestPlayer.id !== owner.id) {
+      if (ecosystemTax > 0 && poorestPlayer && poorestPlayer.id !== owner.id) {
         rentMsg = `${owner.name}に$${ownerRevenue}をはらい、$${ecosystemTax}が社会(${poorestPlayer.name})に還元されたよ`;
       } else if (ecosystemTax > 0) {
         rentMsg = `${owner.name}に$${rent}のとまり賃をはらったよ(エコ還元なし)`;

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -221,11 +221,30 @@ function handleLanding(state: GameState): GameState {
         state.dice.values,
       );
 
+      // 1000年先の文明の洞察: 富の集中を防ぎ、ゲームの流動性を高める「エコシステム・タックス（循環税）」
+      // 家賃の10%は、自動的にその時点で最も貧しいプレイヤーに還元される。
+      const ecosystemTax = Math.floor(rent * 0.1);
+      const ownerRevenue = rent - ecosystemTax;
+
+      const activePlayers = state.players.filter((p) => !p.isBankrupt);
+      const poorestPlayer = activePlayers.reduce((prev, curr) =>
+        curr.money < prev.money ? curr : prev,
+      );
+
       const newPlayers = state.players.map((p) => {
-        if (p.id === player.id) return { ...p, money: p.money - rent };
-        if (p.id === owner.id) return { ...p, money: p.money + rent };
-        return p;
+        let diff = 0;
+        if (p.id === player.id) diff -= rent;
+        if (p.id === owner.id) diff += ownerRevenue;
+        if (p.id === poorestPlayer.id) diff += ecosystemTax;
+        return { ...p, money: p.money + diff };
       });
+
+      let rentMsg = `${owner.name}に$${rent}のとまり賃をはらったよ`;
+      if (ecosystemTax > 0 && poorestPlayer.id !== owner.id) {
+        rentMsg = `${owner.name}に$${ownerRevenue}をはらい、$${ecosystemTax}が社会(${poorestPlayer.name})に還元されたよ`;
+      } else if (ecosystemTax > 0) {
+        rentMsg = `${owner.name}に$${rent}のとまり賃をはらったよ(エコ還元なし)`;
+      }
 
       // 5倍買い可能かチェック（所持金が足りる場合のみ提示）
       const forceBuyCost = (space.price ?? 0) * 5;
@@ -235,7 +254,7 @@ function handleLanding(state: GameState): GameState {
           ...state,
           players: newPlayers,
           turnPhase: 'forceBuy',
-          message: `${owner.name}に$${rent}のとまり賃をはらったよ。$${forceBuyCost}で5ばいがいする？`,
+          message: `${rentMsg}。$${forceBuyCost}で5ばいがいする？`,
         };
       }
 
@@ -243,7 +262,7 @@ function handleLanding(state: GameState): GameState {
         ...state,
         players: newPlayers,
         turnPhase: 'endTurn',
-        message: `${owner.name}に$${rent}のとまり賃をはらったよ`,
+        message: rentMsg,
       };
     }
 

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -26,6 +26,9 @@ export const MAX_JAIL_TURNS = 3;
 /** 刑務所から出るための罰金額（PAY_JAIL_FINE / 強制出獄時に支払う） */
 export const JAIL_FINE = 50;
 
+/** エコシステム・タックス（循環税）の税率：家賃の何%を最貧プレイヤーに還元するか */
+export const ECOSYSTEM_TAX_RATE = 0.1;
+
 // ── ヘルパー関数 ──
 
 export function rollDice(): [number, number] {
@@ -222,8 +225,8 @@ function handleLanding(state: GameState): GameState {
       );
 
       // 1000年先の文明の洞察: 富の集中を防ぎ、ゲームの流動性を高める「エコシステム・タックス（循環税）」
-      // 家賃の10%は、自動的にその時点で最も貧しいプレイヤーに還元される。
-      const ecosystemTax = Math.floor(rent * 0.1);
+      // 家賃の一定割合は、自動的にその時点で最も貧しいプレイヤーに還元される。
+      const ecosystemTax = Math.floor(rent * ECOSYSTEM_TAX_RATE);
       const ownerRevenue = rent - ecosystemTax;
 
       const activePlayers = state.players.filter((p) => !p.isBankrupt);


### PR DESCRIPTION
1000年先の文明の視座から見た場合、現在のモノポリーは「初期にできた格差がそのまま富の集中を生み、敗者がすぐに出る」という初歩的な構造的欠陥を持っています。
これを解消し、ゲームの流動性を高めつつプレイヤー全員で長期的に価値を循環させるための第一歩として、「エコシステム・タックス（循環税）」の概念を導入しました。

### 変更内容
- プレイヤーが他人の物件に止まって家賃を支払う際、支払額の10%が自動的に「社会還元（エコシステム・タックス）」として徴収されます。
- 徴収されたエコシステム・タックスは、その時点で最も所持金が少ないアクティブプレイヤーに自動的に支払われます（再分配）。
- `reducer-actions.test.ts` にて、エコシステム・タックスが正しく徴収・分配されることを検証するようテストを修正しました。

この変更により、現在の道具や知識の範囲内でも「富の偏在を防ぎ、ゲーム全体の寿命と参加者のモチベーションを維持する」という未来水準のアプローチを実現しています。

---
*PR created automatically by Jules for task [14337825238489374978](https://jules.google.com/task/14337825238489374978) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ゲーム内に新しい還元システムを導入。物件の家賃支払い時に、支払い額の一部が最も資金が少ないプレイヤーに自動還元されます。

* **テスト**
  * 家賃計算ロジックに関するテストを更新し、新たな計算方式に対応させました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->