### PR TITLE
chore(security): 🔒 コミット前フックの gitleaks 必須化とローカル防御強化

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,14 @@
 # 秘密情報を含む可能性のあるファイルの diff を非表示にし、意図せぬ表示を防ぐ
-.env* -diff export-ignore
+.env -diff export-ignore
+.env.* -diff export-ignore
+# テンプレートはレビュー可能にする（.gitignore の !.env.example と同様）
+.env.example diff !export-ignore
 *.pem -diff export-ignore
 *.key -diff export-ignore
-*credentials* -diff export-ignore
-*service-account* -diff export-ignore
-*serviceaccount* -diff export-ignore
+*credentials*.json -diff export-ignore
+*credentials*.yml -diff export-ignore
+*credentials*.yaml -diff export-ignore
+*credentials*.env -diff export-ignore
+*service-account*.json -diff export-ignore
+*serviceaccount*.json -diff export-ignore
 *.tfstate* -diff export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# 秘密情報を含む可能性のあるファイルの diff を非表示にし、意図せぬ表示を防ぐ
+.env* -diff export-ignore
+*.pem -diff export-ignore
+*.key -diff export-ignore
+*credentials* -diff export-ignore
+*service-account* -diff export-ignore
+*serviceaccount* -diff export-ignore
+*.tfstate* -diff export-ignore

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,12 +4,15 @@ set -e
 # Run lint-staged using bunx
 bunx lint-staged
 
-# Run gitleaks local check if installed to prevent committing secrets
+# Run gitleaks local check to prevent committing secrets
 if command -v gitleaks > /dev/null 2>&1; then
   echo "🔒 Running local gitleaks check..."
   gitleaks protect --staged --verbose
 else
-  echo "⚠️ gitleaks is not installed locally. Skipping local secret scan. (Highly recommended: brew install gitleaks)"
+  echo "❌ Error: gitleaks is not installed locally."
+  echo "To prevent accidental secret leaks, gitleaks is REQUIRED for commits."
+  echo "Please install it: (e.g., 'brew install gitleaks' or download from https://github.com/gitleaks/gitleaks/releases)"
+  exit 1
 fi
 
 # Run typecheck and test for changed files in the project

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -9,9 +9,11 @@ if command -v gitleaks > /dev/null 2>&1; then
   echo "🔒 Running local gitleaks check..."
   gitleaks protect --staged --verbose
 else
-  echo "❌ Error: gitleaks is not installed locally."
-  echo "To prevent accidental secret leaks, gitleaks is REQUIRED for commits."
-  echo "Please install it: (e.g., 'brew install gitleaks' or download from https://github.com/gitleaks/gitleaks/releases)"
+  {
+    echo "❌ Error: gitleaks is not installed locally."
+    echo "To prevent accidental secret leaks, gitleaks is REQUIRED for commits."
+    echo "Please install it: (e.g., 'brew install gitleaks' or download from https://github.com/gitleaks/gitleaks/releases)"
+  } >&2
   exit 1
 fi
 

--- a/docs/security/leak-prevention.md
+++ b/docs/security/leak-prevention.md
@@ -13,7 +13,7 @@
   - `.env`, `.env.*` (ただし `.env.example` は除く)
   - `*.pem`, `*.key`, `id_rsa`, `id_ed25519`, `id_ecdsa`, `id_dsa`, `*credentials*.json` 等
   - AI エージェントの作業跡（`.cursor/`, `.claude/`, `.aider*` 等）はローカル環境特有の秘密情報が含まれるリスクがあるため除外しています。
-  - **さらに、`.gitattributes` により、これらの秘密情報ファイルが誤って `git add` された場合でも、diff が画面上やログに出力されないように（`-diff`）、またリポジトリのアーカイブに含まれないように（`export-ignore`）設定し、二重に保護しています。**
+  - **さらに、`.gitattributes` により、これらの秘密情報ファイルが誤って `git add` された場合でも、diff の中身がレビュー画面・ログ・PR 上で表示されない（`-diff` によりバイナリ扱いとなり `Binary files differ` 表示）よう、またリポジトリのアーカイブに含まれないよう（`export-ignore`）設定し、二重に保護しています。**
 
 ## 2. CI 検知（リポジトリ防御）
 

--- a/docs/security/leak-prevention.md
+++ b/docs/security/leak-prevention.md
@@ -7,12 +7,13 @@
 開発者が自身のローカル環境で誤って秘密情報をコミットするのを防ぎます。
 
 - **`gitleaks` フック**: コミット時に `.husky/pre-commit` フックを通してローカルで `gitleaks` が実行され、秘密情報を検知した場合はコミットをブロックします。
-  - **⚠️ 注意**: `gitleaks` が未インストールの場合、フックはスキャンをスキップします（コミットはブロックされません）。この場合、ローカルでの秘密情報検知は行われません。
-  - **必須**: 開発環境には [gitleaks](https://github.com/gitleaks/gitleaks) をインストールしてください。（例: `brew install gitleaks`）インストールしない場合、ローカル防御は機能しません。
-- **`.gitignore` による除外**:
+  - **⚠️ 注意**: `gitleaks` が未インストールの場合、コミットは自動的にブロックされます。意図せぬ秘密情報の混入を防ぐため、gitleaks のインストールが**必須**となっています。
+  - **必須**: 開発環境には [gitleaks](https://github.com/gitleaks/gitleaks) をインストールしてください。（例: `brew install gitleaks` または GitHub のリリースページからダウンロード）
+- **`.gitignore` と `.gitattributes` による除外・保護**:
   - `.env`, `.env.*` (ただし `.env.example` は除く)
   - `*.pem`, `*.key`, `id_rsa`, `id_ed25519`, `id_ecdsa`, `id_dsa`, `*credentials*.json` 等
   - AI エージェントの作業跡（`.cursor/`, `.claude/`, `.aider*` 等）はローカル環境特有の秘密情報が含まれるリスクがあるため除外しています。
+  - **さらに、`.gitattributes` により、これらの秘密情報ファイルが誤って `git add` された場合でも、diff が画面上やログに出力されないように（`-diff`）、またリポジトリのアーカイブに含まれないように（`export-ignore`）設定し、二重に保護しています。**
 
 ## 2. CI 検知（リポジトリ防御）
 


### PR DESCRIPTION
## 背景

現状のリポジトリでは `.husky/pre-commit` にて `gitleaks` によるコミット前スキャンが設定されていますが、開発者のローカル環境に `gitleaks` がインストールされていない場合は単に警告を出すだけでコミットを許可してしまっています。また、意図せずシークレットファイルがステージングされた場合の表示制御（`-diff`等）が行われていませんでした。

## 現状認識（事前調査結果のサマリー）

- 既存防御策: `gitleaks.yml`, `trivy.yml`, `codeql.yml` などの CI 検知、および `.husky/pre-commit`（ソフトバリデーション）
- 未カバー領域: 開発者のローカル環境での `gitleaks` 必須化、および誤 commit 時の diff 非表示等のローカルフェイルセーフ層
- 直近の漏洩リスク兆候: コミット前フックがスキップされることで、開発環境から API キーや credentials が漏れる経路が残存していました

## このPRで導入・強化するもの

- 対象: 既存の `.husky/pre-commit` の挙動変更 と 新規 `.gitattributes` の追加
- ツール名とバージョン: gitleaks（既存ツールの厳格化）、Git ネイティブ機能（gitattributes）
- 期待される効果: 開発者が `gitleaks` をインストールしていない状態でシークレットを含む可能性のあるコードをコミットすることを確実にブロックします。また、秘密ファイルに対する意図せぬ差分表示やアーカイブ出力（`export-ignore`）を防ぎます。

## 検知漏れリスクと補完策

- 検知できないケース: gitleaks のデフォルトルールに合致しない全く独自の形式のパスワード等
- 補完策: 既存の `trivy` や GitHub ネイティブの Secret Scanning (Push Protection) での検知を重ねてカバーします。

## マージ前に必要な手動作業（チェックリスト）

レビュアーは PR をマージする前に必ず以下を実施してください。
本 PR の CI は手動作業完了を前提に通る設計です。

- [ ] 開発者全員のローカル環境に `gitleaks` がインストールされていることを周知（未インストールの場合は今後コミットできなくなります）

## マージ後の確認手順

- [ ] 任意のファイルを編集し、`gitleaks` がインストールされていない環境で `git commit` がエラー（exit 1）で弾かれることを確認
- [ ] `gitleaks` がインストールされている環境で正常にコミットが通ることを確認

## ロールバック手順

もし開発効率に著しい支障が出る場合は、本 PR で変更した `.husky/pre-commit` の `exit 1` の行を削除し、元の警告表示のみに戻してください。

## 参考情報

- 公式ドキュメント: https://github.com/gitleaks/gitleaks
- 比較検討した他案: `pre-commit` フレームワークへの移行（Python依存が増えるため、既存の husky 構成を維持して厳格化する方針を採用）

---
*PR created automatically by Jules for task [15798390948352249192](https://jules.google.com/task/15798390948352249192) started by @genzouw*