### PR TITLE
refactor: 💡 "しゃほうカードをもってるよ！" インラインスタイルを CSS module に集約 (#118)

### DIFF
--- a/src/components/ActionDialog/ActionDialog.module.css
+++ b/src/components/ActionDialog/ActionDialog.module.css
@@ -45,6 +45,13 @@
   margin-top: 4px;
   text-align: center;
 }
+/* 強制イベントを回避できる手段の所持を伝える緑ヒント。インラインのテキスト直下用。 */
+.hasCardHint {
+  color: var(--color-success);
+  font-size: 13px;
+  margin-top: 4px;
+  text-align: center;
+}
 .cardContent {
   text-align: center;
   padding: 16px 0;

--- a/src/components/ActionDialog/JailDialog.tsx
+++ b/src/components/ActionDialog/JailDialog.tsx
@@ -58,15 +58,7 @@ export default function JailDialog({
           </div>
         )}
         {hasCards && (
-          <div
-            style={{
-              color: 'var(--color-success)',
-              fontSize: 13,
-              marginTop: 4,
-            }}
-          >
-            しゃほうカードをもってるよ！
-          </div>
+          <div className={styles.hasCardHint}>しゃほうカードをもってるよ！</div>
         )}
       </div>
     </Dialog>

--- a/src/components/ActionDialog/JailDialog.tsx
+++ b/src/components/ActionDialog/JailDialog.tsx
@@ -58,7 +58,9 @@ export default function JailDialog({
           </div>
         )}
         {hasCards && (
-          <div className={styles.hasCardHint}>しゃほうカードをもってるよ！</div>
+          <div role="status" className={styles.hasCardHint}>
+            しゃほうカードをもってるよ！
+          </div>
         )}
       </div>
     </Dialog>

--- a/src/components/ActionDialog/JailDialog.tsx
+++ b/src/components/ActionDialog/JailDialog.tsx
@@ -13,6 +13,13 @@ type JailDialogProps = {
   onRollForJail: () => void;
 };
 
+/**
+ * 刑務所滞在中のプレイヤー向けアクションダイアログ。
+ * 「罰金を払って出る」「釈放カードを使う」「ゾロ目チャレンジ」の 3 つの脱出手段を提示し、
+ * 所持金が不足している場合は罰金ボタンを無効化したうえで
+ * `aria-describedby` で結び付けた補助メッセージから理由を伝える。
+ * 釈放カードを所持している場合は、その旨をヒントとして併記する。
+ */
 export default function JailDialog({
   currentPlayer,
   onPayFine,


### PR DESCRIPTION
## Summary

- Issue #118 の対応方針に沿って、`JailDialog.tsx` に残っていた「しゃほうカードをもってるよ！」のインラインスタイルを CSS module 化
- `ActionDialog.module.css` に `.hasCardHint`（緑系ヒント、インラインテキスト直下用）を追加し、`.noMoneyHintTight`（赤系ヒント）と対称な定義に揃えた
- 同一ファイル内で片方だけ CSS module 化されている非対称を解消

## 背景

PR #117 で `.noMoneyHintTight` に置換した「おかねがたりないよ」と構造的に完全に同じパターン（`fontSize: 13` / `marginTop: 4`、色だけ `--color-danger` ↔ `--color-success`）のインラインスタイルが残存していたため、フォローアップ Issue #118 として独立対応。

## 変更内容

- `src/components/ActionDialog/ActionDialog.module.css`: `.hasCardHint` を新規追加
- `src/components/ActionDialog/JailDialog.tsx`: 該当 `<div style={{...}}>` を `<div className={styles.hasCardHint}>` に置換

## Test plan

- [x] `bun run typecheck` 通過
- [x] `bun run lint` 通過
- [x] `bun run format:check` 通過
- [x] `bun run test`（9 files / 205 tests）全通過
- [ ] 開発サーバで「刑務所ダイアログでカード所持時に緑のヒントが表示される」見た目に差分がないことを目視確認

Closes #118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * 強制イベント回避カード所持を示すヒント表示のスタイルを改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->