### PR TITLE
fix: 💬 "しゃほう" → "しゃくほう" のタイポを修正

### DIFF
--- a/src/components/ActionDialog/JailDialog.tsx
+++ b/src/components/ActionDialog/JailDialog.tsx
@@ -65,7 +65,7 @@ export default function JailDialog({
               marginTop: 4,
             }}
           >
-            しゃほうカードをもってるよ！
+            しゃくほうカードをもってるよ！
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- 刑務所ダイアログに表示される「しゃほうカードをもってるよ！」を「しゃくほうカードをもってるよ！」に修正
- 本来は「**釈放（しゃくほう）カード**」の意で、`Player.getOutOfJailCards`（Get Out of Jail Card）に対応する平仮名表記
- 「しゃほう」だと日本語として意味が通らないため、子ども向け平仮名表記のままで正しい綴りに揃える

## 変更内容

- `src/components/ActionDialog/JailDialog.tsx`: ヒント文言を1箇所修正

該当箇所はこの1ファイルのみ（`coverage/` 配下は生成物なので対象外）。

## Note

PR #121 と同じ行に触れます。PR #121 が先にマージされた場合は本PRをリベース、本PRが先にマージされた場合は #121 をリベースする想定です（変更点は独立しており解消は機械的）。

## Test plan

- [x] `bun run typecheck` 通過
- [x] `bun run lint` 通過
- [x] `bun run format:check` 通過
- [x] `bun run test`（9 files / 205 tests）全通過
- [ ] 開発サーバで刑務所ダイアログ＋カード所持時に「しゃくほうカードをもってるよ！」と表示されることを目視確認