### PR TITLE
🎨 Palette: Setup画面の人数変更ボタンにツールチップを追加

### DIFF
--- a/src/components/Setup/Setup.module.css
+++ b/src/components/Setup/Setup.module.css
@@ -112,3 +112,8 @@
   min-width: 3.5em;
   text-align: right;
 }
+.countDesc {
+  font-size: 14px;
+  color: var(--color-text-light);
+  text-align: center;
+}

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -112,10 +112,10 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
           onClick={() => setPlayerCount((c) => c - 1)}
           disabled={playerCount <= MIN_PLAYERS}
           aria-label="プレイヤーを減らす"
-          title={
+          aria-describedby={
             playerCount <= MIN_PLAYERS
-              ? 'これ以上減らせません'
-              : 'プレイヤーを減らす'
+              ? `${baseId}-min-players-desc`
+              : undefined
           }
         >
           −
@@ -126,15 +126,35 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
           onClick={() => setPlayerCount((c) => c + 1)}
           disabled={playerCount >= MAX_PLAYERS}
           aria-label="プレイヤーを増やす"
-          title={
+          aria-describedby={
             playerCount >= MAX_PLAYERS
-              ? 'これ以上増やせません'
-              : 'プレイヤーを増やす'
+              ? `${baseId}-max-players-desc`
+              : undefined
           }
         >
           ＋
         </button>
       </div>
+      {playerCount <= MIN_PLAYERS && (
+        <span
+          id={`${baseId}-min-players-desc`}
+          className={styles.countDesc}
+          role="status"
+          aria-live="polite"
+        >
+          これ以上減らせません
+        </span>
+      )}
+      {playerCount >= MAX_PLAYERS && (
+        <span
+          id={`${baseId}-max-players-desc`}
+          className={styles.countDesc}
+          role="status"
+          aria-live="polite"
+        >
+          これ以上増やせません
+        </span>
+      )}
       <div className={styles.playerList}>
         {Array.from({ length: playerCount }).map((_, i) => (
           <div key={i} className={styles.playerRow}>

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -112,6 +112,11 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
           onClick={() => setPlayerCount((c) => c - 1)}
           disabled={playerCount <= MIN_PLAYERS}
           aria-label="プレイヤーを減らす"
+          title={
+            playerCount <= MIN_PLAYERS
+              ? 'これ以上減らせません'
+              : 'プレイヤーを減らす'
+          }
         >
           −
         </button>
@@ -121,6 +126,11 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
           onClick={() => setPlayerCount((c) => c + 1)}
           disabled={playerCount >= MAX_PLAYERS}
           aria-label="プレイヤーを増やす"
+          title={
+            playerCount >= MAX_PLAYERS
+              ? 'これ以上増やせません'
+              : 'プレイヤーを増やす'
+          }
         >
           ＋
         </button>


### PR DESCRIPTION
### 💡 What
Setup画面（初期設定）におけるプレイヤー人数の増減ボタン（`+`, `-`）に、現在の状態を説明するツールチップ (`title` 属性) を追加しました。

### 🎯 Why
人数が最小（2人）または最大（4人）に達するとボタンが disabled 状態になりますが、視覚的に薄くなるだけで理由が明示されていませんでした。「これ以上減らせません」「これ以上増やせません」というツールチップを追加することで、なぜ操作できないのかをユーザーに明確に伝えるためです。

### ♿ Accessibility
既存の `aria-label` に加えてネイティブの `title` 属性を活用することで、マウスホバー時にも視覚的に意味と理由が伝わるようになり、インタラクションのフィードバックが向上しました。

---
*PR created automatically by Jules for task [9610004066292099206](https://jules.google.com/task/9610004066292099206) started by @genzouw*