### PR TITLE
⚡ Bolt: Replace O(N) array scans in MemoizedMiniSpace with O(1) dictionary lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,7 +23,7 @@
 **Learning:** コアゲームルール評価（例: `ownsFullColorGroup`, `canMortgage`, `validateTradeOffer`）において、`.every` や `.some` などの関数型配列メソッドを使用すると、一時的な関数と配列が割り当てられ、React レンダーやアクションディスパッチなどの頻繁な評価時に中間的なアロケーションが発生し、ガベージコレクションに悪影響を与えます。
 **Action:** プロパティのチェックやコアゲームルールの評価を行う際は、`.every` や `.some` のようなチェーン操作を常に明示的な `for...of` ループとアキュムレータ/フラグ変数に置き換えてください。
 
-## 2024-11-20 - Replace O(N) array scans in list renders with O(1) dictionary lookups
+## 2024-11-20 - リスト描画における O(N) 配列スキャンを O(1) 辞書ルックアップに置き換える
 
-**Learning:** When rendering lists of components (e.g., board spaces in `MiniMap`), passing entire arrays (`allPlayers`) to child components and performing O(N) `.find()` lookups inside the child's render function and `React.memo` equality checks creates a significant performance bottleneck ($O(N)$ operations invoked $N$ times, resulting in $O(N^2)$). Additionally, using array literals with `.filter(Boolean).join(' ')` in frequently executed UI helpers (like `getSpaceLabel`) introduces unnecessary garbage collection overhead.
-**Action:** Always precompute O(1) lookup dictionaries (like `playersById`) in the parent using `useMemo` and pass only the specific entity (e.g., `owner`) to the child component as a prop. Replace intermediate array allocations and chained methods in hot paths with standard string concatenation or template literals.
+**Learning:** コンポーネントのリスト（例: `MiniMap` のボードマス）を描画する際、子コンポーネントに配列全体（`allPlayers`）を渡して子の描画関数や `React.memo` の等価チェック内で O(N) の `.find()` ルックアップを行うと、O(N) の操作が N 回実行され O(N²) となる深刻なパフォーマンスボトルネックになる。また、頻繁に呼ばれる UI ヘルパー（`getSpaceLabel` など）で `.filter(Boolean).join(' ')` のような配列リテラルを使用すると、不要なガベージコレクションのオーバーヘッドが発生する。
+**Action:** 親コンポーネントで `useMemo` を使って O(1) のルックアップ辞書（`playersById` など）を事前に計算し、子コンポーネントには特定のエンティティ（`owner` など）のみをプロパティとして渡すこと。ホットパスでは中間配列の割り当てやチェーン操作を避け、標準的な文字列結合またはテンプレートリテラルに置き換えること。

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -22,3 +22,8 @@
 
 **Learning:** コアゲームルール評価（例: `ownsFullColorGroup`, `canMortgage`, `validateTradeOffer`）において、`.every` や `.some` などの関数型配列メソッドを使用すると、一時的な関数と配列が割り当てられ、React レンダーやアクションディスパッチなどの頻繁な評価時に中間的なアロケーションが発生し、ガベージコレクションに悪影響を与えます。
 **Action:** プロパティのチェックやコアゲームルールの評価を行う際は、`.every` や `.some` のようなチェーン操作を常に明示的な `for...of` ループとアキュムレータ/フラグ変数に置き換えてください。
+
+## 2024-11-20 - Replace O(N) array scans in list renders with O(1) dictionary lookups
+
+**Learning:** When rendering lists of components (e.g., board spaces in `MiniMap`), passing entire arrays (`allPlayers`) to child components and performing O(N) `.find()` lookups inside the child's render function and `React.memo` equality checks creates a significant performance bottleneck ($O(N)$ operations invoked $N$ times, resulting in $O(N^2)$). Additionally, using array literals with `.filter(Boolean).join(' ')` in frequently executed UI helpers (like `getSpaceLabel`) introduces unnecessary garbage collection overhead.
+**Action:** Always precompute O(1) lookup dictionaries (like `playersById`) in the parent using `useMemo` and pass only the specific entity (e.g., `owner`) to the child component as a prop. Replace intermediate array allocations and chained methods in hot paths with standard string concatenation or template literals.

--- a/src/components/Board/MemoizedMiniSpace.tsx
+++ b/src/components/Board/MemoizedMiniSpace.tsx
@@ -155,7 +155,9 @@ export const MemoizedMiniSpace = memo(function MemoizedMiniSpace({
           {icon}
         </span>
       )}
-      {ownerId && <span className={styles.miniOwnerToken}>{owner?.token}</span>}
+      {owner?.token && (
+        <span className={styles.miniOwnerToken}>{owner.token}</span>
+      )}
       {propState && propState.houses > 0 && (
         <span className={styles.miniHouses}>
           {propState.houses === 5 ? '🏨' : '🏠'.repeat(propState.houses)}

--- a/src/components/Board/MemoizedMiniSpace.tsx
+++ b/src/components/Board/MemoizedMiniSpace.tsx
@@ -42,14 +42,11 @@ function getSpaceLabel(
   houses: number,
   playerCount: number,
 ): string {
-  return [
-    space.name,
-    ownerName && `所有者: ${ownerName}`,
-    houses > 0 && (houses === 5 ? 'ホテル' : `家${houses}軒`),
-    playerCount > 0 && `プレイヤー${playerCount}人滞在中`,
-  ]
-    .filter(Boolean)
-    .join(' ');
+  let label = space.name;
+  if (ownerName) label += ` 所有者: ${ownerName}`;
+  if (houses > 0) label += houses === 5 ? ' ホテル' : ` 家${houses}軒`;
+  if (playerCount > 0) label += ` プレイヤー${playerCount}人滞在中`;
+  return label;
 }
 
 function getColorBarPosition(position: number): React.CSSProperties {
@@ -69,7 +66,7 @@ type MemoizedMiniSpaceProps = {
   col: number;
   playersHere: Player[];
   propState?: PropertyState;
-  allPlayers: Player[];
+  owner?: Player;
   onSpaceClick: (position: number) => void;
 };
 
@@ -99,17 +96,11 @@ const areEqual = (
     }
   }
 
-  const prevOwnerId = prevPropState?.ownerId;
-  const nextOwnerId = nextPropState?.ownerId;
-  if (prevOwnerId && nextOwnerId && prevOwnerId === nextOwnerId) {
-    const prevOwner = prevProps.allPlayers.find((p) => p.id === prevOwnerId);
-    const nextOwner = nextProps.allPlayers.find((p) => p.id === nextOwnerId);
-    if (
-      prevOwner?.name !== nextOwner?.name ||
-      prevOwner?.token !== nextOwner?.token
-    ) {
-      return false;
-    }
+  if (
+    prevProps.owner?.name !== nextProps.owner?.name ||
+    prevProps.owner?.token !== nextProps.owner?.token
+  ) {
+    return false;
   }
 
   return true;
@@ -121,15 +112,13 @@ export const MemoizedMiniSpace = memo(function MemoizedMiniSpace({
   col,
   playersHere,
   propState,
-  allPlayers,
+  owner,
   onSpaceClick,
 }: MemoizedMiniSpaceProps) {
   const icon = getSpaceIcon(space);
   const ownerId = propState?.ownerId;
   const ownerBg = ownerId ? getOwnerBg(ownerId) : undefined;
-  const ownerName = ownerId
-    ? allPlayers.find((p) => p.id === ownerId)?.name
-    : undefined;
+  const ownerName = owner?.name;
   const houses = propState?.houses ?? 0;
   const ariaLabel = getSpaceLabel(space, ownerName, houses, playersHere.length);
 
@@ -166,11 +155,7 @@ export const MemoizedMiniSpace = memo(function MemoizedMiniSpace({
           {icon}
         </span>
       )}
-      {ownerId && (
-        <span className={styles.miniOwnerToken}>
-          {allPlayers.find((p) => p.id === ownerId)?.token}
-        </span>
-      )}
+      {ownerId && <span className={styles.miniOwnerToken}>{owner?.token}</span>}
       {propState && propState.houses > 0 && (
         <span className={styles.miniHouses}>
           {propState.houses === 5 ? '🏨' : '🏠'.repeat(propState.houses)}

--- a/src/components/Board/MiniMap.tsx
+++ b/src/components/Board/MiniMap.tsx
@@ -40,6 +40,15 @@ const MiniMap = memo(function MiniMap({
     return grouped;
   }, [players, board]);
 
+  // ⚡ Bolt: group players by ID once (O(N)) to avoid O(N) find lookups per space.
+  const playersById = useMemo(() => {
+    const dict: Record<string, Player> = {};
+    for (const p of players) {
+      dict[p.id] = p;
+    }
+    return dict;
+  }, [players]);
+
   return (
     <div className={styles.miniMap}>
       <div className={styles.miniMapBoard}>
@@ -47,6 +56,9 @@ const MiniMap = memo(function MiniMap({
           const { row, col } = getGridPosition(space.position);
           const playersHere = playersByPosition[space.position];
           const propState = propertyStates[space.id];
+          const owner = propState?.ownerId
+            ? playersById[propState.ownerId]
+            : undefined;
 
           return (
             <MemoizedMiniSpace
@@ -56,7 +68,7 @@ const MiniMap = memo(function MiniMap({
               col={col}
               playersHere={playersHere}
               propState={propState}
-              allPlayers={players}
+              owner={owner}
               onSpaceClick={onSpaceClick}
             />
           );

--- a/src/components/Board/MiniMap.tsx
+++ b/src/components/Board/MiniMap.tsx
@@ -40,7 +40,7 @@ const MiniMap = memo(function MiniMap({
     return grouped;
   }, [players, board]);
 
-  // ⚡ Bolt: group players by ID once (O(N)) to avoid O(N) find lookups per space.
+  // ⚡ Bolt: 各マスでの O(N) 探索を避けるため、プレイヤーID辞書を一度だけ構築する。
   const playersById = useMemo(() => {
     const dict: Record<string, Player> = {};
     for (const p of players) {


### PR DESCRIPTION
💡 **What:** 
- Precomputed a `playersById` dictionary via `useMemo` in `src/components/Board/MiniMap.tsx`.
- Refactored `MemoizedMiniSpace` to accept an `owner` prop directly instead of scanning the `allPlayers` array during both rendering and `areEqual` memoization checks.
- Refactored `getSpaceLabel` to use string concatenation rather than allocating arrays and mapping/joining.

🎯 **Why:** 
For every space rendered in the `MiniMap` component and on every evaluation of the `areEqual` function for `MemoizedMiniSpace`, the application was scanning the entire `allPlayers` array using `.find()` multiple times to locate the owner's information, creating an O(N^2) bottleneck. Additionally, `getSpaceLabel` was allocating intermediate arrays per space.

📊 **Impact:** 
- Reduces $O(N)$ `.find()` lookups per space to $O(1)$ dictionary lookups, saving approximately 160 `.find()` calls per render cycle of the board.
- Reduces garbage collection overhead by eliminating 40 temporary array allocations per render.

🔬 **Measurement:** 
- Execute `bun run test` to verify the logic remains functionally equivalent and no rendering regressions were introduced.
- Play through the UI, ensuring space labels and owner backgrounds render accurately as properties are bought and sold.

---
*PR created automatically by Jules for task [14307415361477451578](https://jules.google.com/task/14307415361477451578) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * リスト描画とUIヘルパーのパフォーマンス改善ガイドを追記しました。

* **Bug Fixes**
  * ボード/ミニマップ周りの描画効率を改善し、再描画や検索処理の負荷を低減しました。
  * サブコンポーネントへの受け渡しを最適化して描画安定性と応答性を向上させました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->