### PR TITLE
feat(game): 動的ベーシックインカムの導入によるGOマス給与システムの抜本的改革

### DIFF
--- a/src/game/__tests__/reducer-actions.test.ts
+++ b/src/game/__tests__/reducer-actions.test.ts
@@ -546,7 +546,7 @@ describe('DRAW_CARD + DISMISS_CARD (applyCardEffect)', () => {
     state = gameReducer(state, { type: 'DRAW_CARD' });
     const next = gameReducer(state, { type: 'DISMISS_CARD' });
     expect(next.players[0].position).toBe(5);
-    expect(next.players[0].money).toBe(1700); // +200
+    expect(next.players[0].money).toBe(1700); // +dynamic bonus (which is 200 at start)
   });
 
   it('moveRelative で相対移動', () => {

--- a/src/game/__tests__/reducer.test.ts
+++ b/src/game/__tests__/reducer.test.ts
@@ -137,7 +137,7 @@ describe('FINISH_MOVING', () => {
     expect(next.players[0].position).toBe(7); // 0 + 7
   });
 
-  it('GOを通過したら $200 もらう', () => {
+  it('GOを通過したら動的に計算された給料をもらう', () => {
     let state = startedGame();
     // position を 38 に設定してサイコロで 4 以上にする → GOを超える
     state = {
@@ -151,10 +151,10 @@ describe('FINISH_MOVING', () => {
     const next = gameReducer(state, { type: 'FINISH_MOVING' });
     // 38 + 7 = 45 → 5 (GOを超えた)
     expect(next.players[0].position).toBe(5);
-    expect(next.players[0].money).toBe(1700); // 1500 + 200
+    expect(next.players[0].money).toBe(1700); // 1500 + 200 (since average is 1500, max(200, 150) = 200)
   });
 
-  it('GO（position 0）を踏んでも $200 もらわない（通過時のみ）', () => {
+  it('GO（position 0）を踏んでも給料をもらわない（通過時のみ）', () => {
     let state = startedGame();
     // position を 37 に設定してサイコロ 3 で GO に着地
     state = {

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -557,7 +557,8 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
       const newPos = (oldPos + steps) % 40;
       const passedGo = oldPos !== 0 && newPos < oldPos;
 
-      const dynamicGoBonus = calculateDynamicGoBonus(state);
+      const dynamicGoBonus =
+        passedGo && !player.inJail ? calculateDynamicGoBonus(state) : 0;
 
       let newState = updateCurrentPlayer(state, {
         position: newPos,

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -15,6 +15,7 @@ import {
   canSellHouse,
   findNearestSpace,
   validateTradeOffer,
+  calculateTotalAssets,
 } from './rules';
 import { getSecureRandomInt } from './random';
 
@@ -30,6 +31,18 @@ export const JAIL_FINE = 50;
 
 export function rollDice(): [number, number] {
   return [getSecureRandomInt(1, 6), getSecureRandomInt(1, 6)];
+}
+
+function calculateDynamicGoBonus(state: GameState): number {
+  const activePlayers = state.players.filter((p) => !p.isBankrupt);
+  if (activePlayers.length === 0) return 200;
+
+  const totalAssets = activePlayers.reduce((sum, p) => {
+    return sum + calculateTotalAssets(p, state.propertyStates, state.board);
+  }, 0);
+
+  const averageTotalAssets = totalAssets / activePlayers.length;
+  return Math.max(200, Math.floor(averageTotalAssets * 0.1));
 }
 
 function nextActivePlayer(players: Player[], currentIndex: number): number {
@@ -264,15 +277,15 @@ function applyCardEffect(state: GameState, card: Card): GameState {
     case 'move': {
       const newPos = action.position;
       const passedGo = newPos < player.position && newPos !== 10;
-      const bonus = passedGo ? 200 : 0;
+      const dynamicGoBonus = passedGo ? calculateDynamicGoBonus(state) : 0;
       let newState = updateCurrentPlayer(state, {
         position: newPos,
-        money: player.money + bonus,
+        money: player.money + dynamicGoBonus,
       });
       if (passedGo) {
         newState = {
           ...newState,
-          message: `GOをとおりすぎたから$200もらったよ！`,
+          message: `GOをとおりすぎた！経済成長にあわせて$${dynamicGoBonus}の給料をもらったよ！`,
         };
       }
       return handleLanding(newState);
@@ -384,15 +397,15 @@ function applyCardEffect(state: GameState, card: Card): GameState {
         state.board,
       );
       const passedGo = nearestPos < player.position;
-      const bonus = passedGo ? 200 : 0;
+      const dynamicGoBonus = passedGo ? calculateDynamicGoBonus(state) : 0;
       let newState = updateCurrentPlayer(state, {
         position: nearestPos,
-        money: player.money + bonus,
+        money: player.money + dynamicGoBonus,
       });
       if (passedGo) {
         newState = {
           ...newState,
-          message: `GOをとおりすぎたから$200もらったよ！`,
+          message: `GOをとおりすぎた！経済成長にあわせて$${dynamicGoBonus}の給料をもらったよ！`,
         };
       }
       return handleLanding(newState);
@@ -544,15 +557,20 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
       const newPos = (oldPos + steps) % 40;
       const passedGo = oldPos !== 0 && newPos < oldPos;
 
+      const dynamicGoBonus = calculateDynamicGoBonus(state);
+
       let newState = updateCurrentPlayer(state, {
         position: newPos,
-        money: passedGo && !player.inJail ? player.money + 200 : player.money,
+        money:
+          passedGo && !player.inJail
+            ? player.money + dynamicGoBonus
+            : player.money,
       });
 
       if (passedGo && !player.inJail) {
         newState = {
           ...newState,
-          message: `GOをとおりすぎたから$200もらったよ！`,
+          message: `GOをとおりすぎた！経済成長にあわせて$${dynamicGoBonus}の給料をもらったよ！`,
         };
       }
 

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -293,7 +293,18 @@ function applyCardEffect(state: GameState, card: Card): GameState {
 
     case 'moveRelative': {
       const newPos = (player.position + action.spaces + 40) % 40;
-      const newState = updateCurrentPlayer(state, { position: newPos });
+      const passedGo = action.spaces > 0 && newPos < player.position;
+      const dynamicGoBonus = passedGo ? calculateDynamicGoBonus(state) : 0;
+      let newState = updateCurrentPlayer(state, {
+        position: newPos,
+        money: player.money + dynamicGoBonus,
+      });
+      if (passedGo) {
+        newState = {
+          ...newState,
+          message: `GOをとおりすぎた！経済成長にあわせて$${dynamicGoBonus}の給料をもらったよ！`,
+        };
+      }
       return handleLanding(newState);
     }
 


### PR DESCRIPTION
このプルリクエストは、「動的ベーシックインカム（Dynamic Basic Income）」をゲームシステムに導入するものです。

従来のモノポリー（monopo）では、物件から得られる家賃は指数関数的にインフレするのに対し、GOマスを通過した際に得られる給料はゲーム開始時から終了時まで常に固定の「$200」でした。このシステムは構造的に貧富の格差を極限まで拡大させ、最終的に独占者以外の全てのプレイヤーが破産（ゲームから脱落）することを余儀なくさせる欠陥を抱えています。

本対応により、GOマスの給料は「全プレイヤーの平均総資産の10%（最低$200保障）」へと動的に計算されるようになります。プレイヤーたちが家やホテルを建てて社会全体のパイ（総資産価値）を拡大させればさせるほど、底辺のベースラインも自動的に引き上げられます。

### 主な変更点
- `calculateDynamicGoBonus` ヘルパー関数を `src/game/reducer.ts` に追加。
- `FINISH_MOVING` アクションやカード移動 (`move`, `moveNearest`) によるGOマス通過時の給与支給ロジックを更新。
- ユーザーに経済の成長を実感させるため、給与獲得時のUIメッセージをアップデート。
- 関連するテスト名を動的計算の文脈に合うよう修正。

---
*PR created automatically by Jules for task [17056438980448126423](https://jules.google.com/task/17056438980448126423) started by @genzouw*