### PR TITLE
🎨 Palette: 抵当ダイアログのアクセシビリティ向上

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,3 +42,7 @@
 ## 2026-05-25 - Missing Accessibility on Disabled Force Buy Button
 **Learning:** Found a missing disabled state and accessibility hints in the `ForceBuyDialog` component when a player tries to buy but cannot afford the cost. While other dialogs like `PurchaseDialog` handled this well, `ForceBuyDialog` missed the `disabled` prop and `aria-describedby` hint, which could cause a confusing user experience for both keyboard/screen-reader users and sighted users.
 **Action:** Applied a similar pattern used in `PurchaseDialog` by calculating `canAfford` before rendering, disabling the primary button, and presenting an accessible `role="status"` hint linked to the button via `aria-describedby`. Always ensure all purchasing dialogs handle "insufficient funds" explicitly.
+## 2026-05-28 - Missing Accessibility on Disabled Mortgage/Unmortgage Buttons
+**Learning:** Found a missing disabled state accessibility hint in the `MortgageDialog` component. The `かえす` and `かりる` buttons disabled states were not accessible via screen reader. This pattern must be used across all components in the `ActionDialog` folder to ensure standard and accessible experiences.
+**Action:** Applied the `aria-describedby` pattern with an accessible hint when disabled on the buttons inside `MortgageDialog`, completing the pattern usage across `ActionDialogs`.
+

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,7 +42,7 @@
 ## 2026-05-25 - Missing Accessibility on Disabled Force Buy Button
 **Learning:** Found a missing disabled state and accessibility hints in the `ForceBuyDialog` component when a player tries to buy but cannot afford the cost. While other dialogs like `PurchaseDialog` handled this well, `ForceBuyDialog` missed the `disabled` prop and `aria-describedby` hint, which could cause a confusing user experience for both keyboard/screen-reader users and sighted users.
 **Action:** Applied a similar pattern used in `PurchaseDialog` by calculating `canAfford` before rendering, disabling the primary button, and presenting an accessible `role="status"` hint linked to the button via `aria-describedby`. Always ensure all purchasing dialogs handle "insufficient funds" explicitly.
-## 2026-05-28 - Missing Accessibility on Disabled Mortgage/Unmortgage Buttons
-**Learning:** Found a missing disabled state accessibility hint in the `MortgageDialog` component. The `かえす` and `かりる` buttons disabled states were not accessible via screen reader. This pattern must be used across all components in the `ActionDialog` folder to ensure standard and accessible experiences.
-**Action:** Applied the `aria-describedby` pattern with an accessible hint when disabled on the buttons inside `MortgageDialog`, completing the pattern usage across `ActionDialogs`.
+## 2026-05-28 - 抵当/抵当解除ボタンの無効状態にアクセシビリティ対応を追加
+**学び:** `MortgageDialog` コンポーネントで、無効状態のボタンに対するアクセシビリティヒントが実装されていなかった。`かえす` および `かりる` ボタンが無効になった理由をスクリーンリーダーが読み上げられない状態だった。このパターンは `ActionDialog` フォルダ内のすべてのコンポーネントで一貫して使用する必要がある。
+**対応:** `MortgageDialog` 内のボタンに対して、無効状態のとき `aria-describedby` で補助ヒントを関連付けるパターンを適用し、全 `ActionDialog` へのパターン適用を完成させた。
 

--- a/src/components/ActionDialog/ActionDialog.module.css
+++ b/src/components/ActionDialog/ActionDialog.module.css
@@ -77,6 +77,17 @@
   background: #f8f8f8;
   border-radius: var(--radius-sm);
 }
+.buildItemContent {
+  flex: 1;
+}
+.buildItemActions {
+  margin-left: auto;
+  align-self: center;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+}
 .buildItemName {
   display: flex;
   align-items: center;

--- a/src/components/ActionDialog/MortgageDialog.tsx
+++ b/src/components/ActionDialog/MortgageDialog.tsx
@@ -68,7 +68,7 @@ export default function MortgageDialog({
           const unmortgageCost = Math.floor((space.mortgageValue ?? 0) * 1.1);
           return (
             <div key={space.id} className={styles.buildItem}>
-              <div style={{ flex: 1 }}>
+              <div className={styles.buildItemContent}>
                 <div className={styles.buildItemName}>
                   {isMortgaged ? '🔒 ' : ''}
                   {space.name}
@@ -79,16 +79,7 @@ export default function MortgageDialog({
                     : `かりられるがく: $${space.mortgageValue}`}
                 </div>
               </div>
-              <div
-                style={{
-                  marginLeft: 'auto',
-                  alignSelf: 'center',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'flex-end',
-                  gap: 4,
-                }}
-              >
+              <div className={styles.buildItemActions}>
                 {isMortgaged ? (
                   <>
                     <Button
@@ -108,7 +99,6 @@ export default function MortgageDialog({
                         id={`${hintIdBase}-unmortgage-${space.id}`}
                         role="status"
                         className={styles.noMoneyHintTight}
-                        style={{ fontSize: 11, marginTop: 2 }}
                       >
                         おかねがたりないよ
                       </div>
@@ -134,7 +124,6 @@ export default function MortgageDialog({
                         id={`${hintIdBase}-mortgage-${space.id}`}
                         role="status"
                         className={styles.noMoneyHintTight}
-                        style={{ fontSize: 11, marginTop: 2 }}
                       >
                         家があるグループだよ
                       </div>

--- a/src/components/ActionDialog/MortgageDialog.tsx
+++ b/src/components/ActionDialog/MortgageDialog.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import type { BoardSpace, Player, PropertyState } from '../../game/types';
 import { canMortgage, canUnmortgage, getSpaceById } from '../../game/rules';
 import Dialog from '../common/Dialog';
@@ -21,6 +22,7 @@ export default function MortgageDialog({
   onUnmortgage,
   onClose,
 }: MortgageDialogProps) {
+  const hintIdBase = useId();
   const ownedProperties = currentPlayer.properties
     .map((id: string) => getSpaceById(id, board))
     .filter((s): s is BoardSpace => !!s && !!s.mortgageValue);
@@ -66,7 +68,7 @@ export default function MortgageDialog({
           const unmortgageCost = Math.floor((space.mortgageValue ?? 0) * 1.1);
           return (
             <div key={space.id} className={styles.buildItem}>
-              <div>
+              <div style={{ flex: 1 }}>
                 <div className={styles.buildItemName}>
                   {isMortgaged ? '🔒 ' : ''}
                   {space.name}
@@ -77,24 +79,69 @@ export default function MortgageDialog({
                     : `かりられるがく: $${space.mortgageValue}`}
                 </div>
               </div>
-              {isMortgaged ? (
-                <Button
-                  size="small"
-                  onClick={() => onUnmortgage(space.id)}
-                  disabled={!canDoUnmortgage}
-                >
-                  かえす
-                </Button>
-              ) : (
-                <Button
-                  size="small"
-                  variant="danger"
-                  onClick={() => onMortgage(space.id)}
-                  disabled={!canDoMortgage}
-                >
-                  かりる
-                </Button>
-              )}
+              <div
+                style={{
+                  marginLeft: 'auto',
+                  alignSelf: 'center',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'flex-end',
+                  gap: 4,
+                }}
+              >
+                {isMortgaged ? (
+                  <>
+                    <Button
+                      size="small"
+                      onClick={() => onUnmortgage(space.id)}
+                      disabled={!canDoUnmortgage}
+                      aria-describedby={
+                        !canDoUnmortgage
+                          ? `${hintIdBase}-unmortgage-${space.id}`
+                          : undefined
+                      }
+                    >
+                      かえす
+                    </Button>
+                    {!canDoUnmortgage && (
+                      <div
+                        id={`${hintIdBase}-unmortgage-${space.id}`}
+                        role="status"
+                        className={styles.noMoneyHintTight}
+                        style={{ fontSize: 11, marginTop: 2 }}
+                      >
+                        おかねがたりないよ
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    <Button
+                      size="small"
+                      variant="danger"
+                      onClick={() => onMortgage(space.id)}
+                      disabled={!canDoMortgage}
+                      aria-describedby={
+                        !canDoMortgage
+                          ? `${hintIdBase}-mortgage-${space.id}`
+                          : undefined
+                      }
+                    >
+                      かりる
+                    </Button>
+                    {!canDoMortgage && (
+                      <div
+                        id={`${hintIdBase}-mortgage-${space.id}`}
+                        role="status"
+                        className={styles.noMoneyHintTight}
+                        style={{ fontSize: 11, marginTop: 2 }}
+                      >
+                        家があるグループだよ
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
             </div>
           );
         })}


### PR DESCRIPTION
💡 What: 抵当ダイアログ（MortgageDialog）で、「かりる」「かえす」ボタンが非活性の際に、その理由を伝えるヘルパーテキストを追加しました。
🎯 Why: これまではお金が足りない場合や、家が建っているグループの土地を抵当に入れようとした際にボタンが非活性になるだけで、理由が明示されておらず、ユーザーが混乱する可能性がありました。
♿ Accessibility: 非活性のボタンに対し `aria-describedby` と `role="status"` を用いてヘルパーテキストを紐付けることで、スクリーンリーダーを利用するユーザーを含むすべてのユーザーに状態をわかりやすく伝えます。

---
*PR created automatically by Jules for task [1910699192081624879](https://jules.google.com/task/1910699192081624879) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 無効なローン操作ボタンで「無効の理由」を支援技術に明示表示するようにしました（読み上げ対応を強化）。
  * 物件カードのボタン表示を右寄せで縦積みに変更し、見た目と操作性を調整しました。

* **ドキュメント**
  * アクセシビリティ関連の仕様説明を更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->