### PR TITLE
fix(ci): 🐛 PR Agent Action の参照先を The-PR-Agent/pr-agent に再修正

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -22,7 +22,7 @@ jobs:
              github.event.comment.author_association == 'COLLABORATOR'))) }}
     steps:
       - name: PR Agent action step
-        uses: qodo-ai/pr-agent@main
+        uses: The-PR-Agent/pr-agent@0bd56c0508504c718cc03d504cd4ceb6725ba3c7 # v0.35.0
         env:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- `qodo-ai/pr-agent` リポジトリは `The-PR-Agent/pr-agent` にリネーム済みだが、PR #119 で `uses:` 参照が `qodo-ai/pr-agent@main` に巻き戻ってしまい、PR Agent ワークフローが全実行で `startup_failure` になっていた（[該当 Run](https://github.com/genzouw/monopo/actions/runs/26615747974)）。
- GitHub Actions は `uses:` のリポジトリ名のリダイレクトを追跡しないため、リネーム後の正規名 `The-PR-Agent/pr-agent` を直接指定する。
- 併せて PR #108 と同じく v0.35.0 (`0bd56c0508504c718cc03d504cd4ceb6725ba3c7`) のコミット SHA でピン留めし、`@main` 追跡による供給網リスクも排除する。

## 原因の特定根拠

- `curl -I https://github.com/qodo-ai/pr-agent` が `301` で `The-PR-Agent/pr-agent` にリダイレクトされる。
- `gh api repos/qodo-ai/pr-agent` が `The-PR-Agent/pr-agent` を返す（リポジトリ実体はリネーム先）。
- 同ワークフローの直近 10 実行が actor を問わず全て `startup_failure`（jobs 配列が空）であることから、Action 参照解決の失敗が確実。

## Test plan

- [ ] マージ後、PR Agent ワークフローが新規 PR / `issue_comment` イベントで `startup_failure` にならずジョブが起動することを確認
- [ ] `pull_request: opened` 時に PR Agent のレビューコメントが投稿されるか確認