### PR TITLE
chore(ci): 🔧 Action SHA ピン留めを CI で強制し AI ガイドラインに明記

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -36,7 +36,7 @@
 
 - GitHub ActionsのCI/CDワークフローでは、`actions/setup-node` の代わりに `oven-sh/setup-bun` を利用して環境を構築してください。
 - 乱数生成に依存するテストを作成または更新する際は、`Math.random()` の代わりに `src/game/random.ts` の `getSecureRandomInt` をモックしてください。
-- GitHub Actions ワークフロー（`.github/workflows/**`）で外部 Action を参照する際は、必ず 40 桁のコミット SHA でピン留めし、可変ブランチ参照（`@main` / `@master` / `@develop` / `@HEAD`）は使用しないでください。バージョン名は SHA の隣に行末コメントで併記してください（例: `uses: owner/repo@<40桁SHA> # v1.2.3`）。リポジトリリネームによる参照解決失敗（`startup_failure`）や、上流の不意な破壊的変更の取り込みを防ぐためです。既存の Action を更新する際は、コミット SHA とコメントを同時に書き換えてください。
+- GitHub Actions ワークフロー（`.github/workflows/**`）で外部 Action を参照する際は、必ず 40 桁のコミット SHA でピン留めし、可変ブランチ参照（`@main` / `@master` / `@develop` / `@trunk` / `@HEAD` 等）は使用しないでください。バージョン名は SHA の隣に行末コメントで併記してください（例: `uses: owner/repo@<40桁SHA> # v1.2.3`）。リポジトリリネームによる参照解決失敗（`startup_failure`）や、上流の不意な破壊的変更の取り込みを防ぐためです。既存の Action を更新する際は、コミット SHA とコメントを同時に書き換えてください。なお禁止対象のブランチ名一覧は `.github/workflows/actionlint.yml` の CI ガードと同期しているため、ガード側を更新した際は本ガイドラインも併せて更新してください。
 
 ## ツール・拡張機能
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -36,6 +36,7 @@
 
 - GitHub ActionsのCI/CDワークフローでは、`actions/setup-node` の代わりに `oven-sh/setup-bun` を利用して環境を構築してください。
 - 乱数生成に依存するテストを作成または更新する際は、`Math.random()` の代わりに `src/game/random.ts` の `getSecureRandomInt` をモックしてください。
+- GitHub Actions ワークフロー（`.github/workflows/**`）で外部 Action を参照する際は、必ず 40 桁のコミット SHA でピン留めし、可変ブランチ参照（`@main` / `@master` / `@develop` / `@HEAD`）は使用しないでください。バージョン名は SHA の隣に行末コメントで併記してください（例: `uses: owner/repo@<40桁SHA> # v1.2.3`）。リポジトリリネームによる参照解決失敗（`startup_failure`）や、上流の不意な破壊的変更の取り込みを防ぐためです。既存の Action を更新する際は、コミット SHA とコメントを同時に書き換えてください。
 
 ## ツール・拡張機能
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,7 +36,7 @@
 
 - GitHub ActionsのCI/CDワークフローでは、`actions/setup-node` の代わりに `oven-sh/setup-bun` を利用して環境を構築してください。
 - 乱数生成に依存するテストを作成または更新する際は、`Math.random()` の代わりに `src/game/random.ts` の `getSecureRandomInt` をモックしてください。
-- GitHub Actions ワークフロー（`.github/workflows/**`）で外部 Action を参照する際は、必ず 40 桁のコミット SHA でピン留めし、可変ブランチ参照（`@main` / `@master` / `@develop` / `@HEAD`）は使用しないでください。バージョン名は SHA の隣に行末コメントで併記してください（例: `uses: owner/repo@<40桁SHA> # v1.2.3`）。リポジトリリネームによる参照解決失敗（`startup_failure`）や、上流の不意な破壊的変更の取り込みを防ぐためです。既存の Action を更新する際は、コミット SHA とコメントを同時に書き換えてください。
+- GitHub Actions ワークフロー（`.github/workflows/**`）で外部 Action を参照する際は、必ず 40 桁のコミット SHA でピン留めし、可変ブランチ参照（`@main` / `@master` / `@develop` / `@trunk` / `@HEAD` 等）は使用しないでください。バージョン名は SHA の隣に行末コメントで併記してください（例: `uses: owner/repo@<40桁SHA> # v1.2.3`）。リポジトリリネームによる参照解決失敗（`startup_failure`）や、上流の不意な破壊的変更の取り込みを防ぐためです。既存の Action を更新する際は、コミット SHA とコメントを同時に書き換えてください。なお禁止対象のブランチ名一覧は `.github/workflows/actionlint.yml` の CI ガードと同期しているため、ガード側を更新した際は本ガイドラインも併せて更新してください。
 
 ## ツール・拡張機能
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,6 +36,7 @@
 
 - GitHub ActionsのCI/CDワークフローでは、`actions/setup-node` の代わりに `oven-sh/setup-bun` を利用して環境を構築してください。
 - 乱数生成に依存するテストを作成または更新する際は、`Math.random()` の代わりに `src/game/random.ts` の `getSecureRandomInt` をモックしてください。
+- GitHub Actions ワークフロー（`.github/workflows/**`）で外部 Action を参照する際は、必ず 40 桁のコミット SHA でピン留めし、可変ブランチ参照（`@main` / `@master` / `@develop` / `@HEAD`）は使用しないでください。バージョン名は SHA の隣に行末コメントで併記してください（例: `uses: owner/repo@<40桁SHA> # v1.2.3`）。リポジトリリネームによる参照解決失敗（`startup_failure`）や、上流の不意な破壊的変更の取り込みを防ぐためです。既存の Action を更新する際は、コミット SHA とコメントを同時に書き換えてください。
 
 ## ツール・拡張機能
 

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -43,3 +43,22 @@ jobs:
       - name: Run actionlint
         run: |
           "${{ steps.actionlint.outputs.executable }}" -color
+
+      - name: Reject mutable branch references in `uses:`
+        # 外部 Action を `@main` 等のブランチ追跡で参照すると、上流のリポジトリ
+        # リネーム時に `startup_failure` を起こす（cf. PR #137 で発生）ほか、
+        # 不意な破壊的変更を取り込むリスクがある。可変ブランチ参照を禁止し、
+        # コミット SHA でのピン留めを CI で強制する。
+        # （タグ参照 `@v1` の検出は zizmor 等の専用ツールに任せ、ここでは
+        #  実害の大きいブランチ参照のみを最小コストで弾く方針）
+        run: |
+          set -euo pipefail
+          violations=$(grep -rEn 'uses:[[:space:]]+[^@[:space:]]+@(main|master|develop|trunk|HEAD)([[:space:]]|$)' .github/workflows || true)
+          if [ -n "$violations" ]; then
+            echo "::error::外部 Action 参照に可変ブランチが使われています。コミット SHA でピン留めしてください:"
+            echo "$violations"
+            echo ""
+            echo "修正方法: \`uses: owner/repo@<40桁SHA> # v1.2.3\` の形式に書き換える。"
+            exit 1
+          fi
+          echo "✅ 全ての外部 Action 参照がブランチ追跡を回避できています。"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -51,9 +51,19 @@ jobs:
         # コミット SHA でのピン留めを CI で強制する。
         # （タグ参照 `@v1` の検出は zizmor 等の専用ツールに任せ、ここでは
         #  実害の大きいブランチ参照のみを最小コストで弾く方針）
+        #
+        # grep のパターンには 2 つの工夫を入れている:
+        #  1. `u[s]es:` で `uses:` リテラルを文字クラスに分解 → 本ステップ自身
+        #     が自分の検出パターンに hit するのを防ぐ（self-match 回避）。
+        #  2. 行頭アンカー `^[[:space:]]*-?[[:space:]]*` で YAML キー位置に
+        #     限定し、コメントや文字列内の偶発的な `uses:` を除外。加えて
+        #     `--include='*.yml' --include='*.yaml'` で対象拡張子を絞る。
         run: |
           set -euo pipefail
-          violations=$(grep -rEn 'uses:[[:space:]]+[^@[:space:]]+@(main|master|develop|trunk|HEAD)([[:space:]]|$)' .github/workflows || true)
+          violations=$(grep -rEn \
+            --include='*.yml' --include='*.yaml' \
+            '^[[:space:]]*-?[[:space:]]*u[s]es:[[:space:]]+[^@[:space:]]+@(main|master|develop|trunk|HEAD)([[:space:]]|$)' \
+            .github/workflows || true)
           if [ -n "$violations" ]; then
             echo "::error::外部 Action 参照に可変ブランチが使われています。コミット SHA でピン留めしてください:"
             echo "$violations"

--- a/.github/workflows/ai-release-notes.yml
+++ b/.github/workflows/ai-release-notes.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Generate release notes
         id: notes
         if: steps.refs.outputs.base_ref != ''
-        uses: github/copilot-release-notes@4406c0a9da86eee94820b8329856f3f5a6527c48 # main HEAD as of 2026-04-06
+        uses: github/copilot-release-notes@a334b927dc0db44c0358a0221928c2d9204ad7cc # v1.0.1
         with:
           base-ref: ${{ steps.refs.outputs.base_ref }}
           head-ref: ${{ steps.refs.outputs.head_ref }}

--- a/.github/workflows/ai-release-notes.yml
+++ b/.github/workflows/ai-release-notes.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Generate release notes
         id: notes
         if: steps.refs.outputs.base_ref != ''
-        uses: github/copilot-release-notes@main
+        uses: github/copilot-release-notes@4406c0a9da86eee94820b8329856f3f5a6527c48 # main HEAD as of 2026-04-06
         with:
           base-ref: ${{ steps.refs.outputs.base_ref }}
           head-ref: ${{ steps.refs.outputs.head_ref }}

--- a/docs/ai-guidelines.md
+++ b/docs/ai-guidelines.md
@@ -29,6 +29,7 @@
 
 - GitHub ActionsのCI/CDワークフローでは、`actions/setup-node` の代わりに `oven-sh/setup-bun` を利用して環境を構築してください。
 - 乱数生成に依存するテストを作成または更新する際は、`Math.random()` の代わりに `src/game/random.ts` の `getSecureRandomInt` をモックしてください。
+- GitHub Actions ワークフロー（`.github/workflows/**`）で外部 Action を参照する際は、必ず 40 桁のコミット SHA でピン留めし、可変ブランチ参照（`@main` / `@master` / `@develop` / `@HEAD`）は使用しないでください。バージョン名は SHA の隣に行末コメントで併記してください（例: `uses: owner/repo@<40桁SHA> # v1.2.3`）。リポジトリリネームによる参照解決失敗（`startup_failure`）や、上流の不意な破壊的変更の取り込みを防ぐためです。既存の Action を更新する際は、コミット SHA とコメントを同時に書き換えてください。
 
 ## ツール・拡張機能
 

--- a/docs/ai-guidelines.md
+++ b/docs/ai-guidelines.md
@@ -29,7 +29,7 @@
 
 - GitHub ActionsのCI/CDワークフローでは、`actions/setup-node` の代わりに `oven-sh/setup-bun` を利用して環境を構築してください。
 - 乱数生成に依存するテストを作成または更新する際は、`Math.random()` の代わりに `src/game/random.ts` の `getSecureRandomInt` をモックしてください。
-- GitHub Actions ワークフロー（`.github/workflows/**`）で外部 Action を参照する際は、必ず 40 桁のコミット SHA でピン留めし、可変ブランチ参照（`@main` / `@master` / `@develop` / `@HEAD`）は使用しないでください。バージョン名は SHA の隣に行末コメントで併記してください（例: `uses: owner/repo@<40桁SHA> # v1.2.3`）。リポジトリリネームによる参照解決失敗（`startup_failure`）や、上流の不意な破壊的変更の取り込みを防ぐためです。既存の Action を更新する際は、コミット SHA とコメントを同時に書き換えてください。
+- GitHub Actions ワークフロー（`.github/workflows/**`）で外部 Action を参照する際は、必ず 40 桁のコミット SHA でピン留めし、可変ブランチ参照（`@main` / `@master` / `@develop` / `@trunk` / `@HEAD` 等）は使用しないでください。バージョン名は SHA の隣に行末コメントで併記してください（例: `uses: owner/repo@<40桁SHA> # v1.2.3`）。リポジトリリネームによる参照解決失敗（`startup_failure`）や、上流の不意な破壊的変更の取り込みを防ぐためです。既存の Action を更新する際は、コミット SHA とコメントを同時に書き換えてください。なお禁止対象のブランチ名一覧は `.github/workflows/actionlint.yml` の CI ガードと同期しているため、ガード側を更新した際は本ガイドラインも併せて更新してください。
 
 ## ツール・拡張機能
 


### PR DESCRIPTION
## Summary

PR #137 で行った PR Agent ワークフローの即時修正に続き、**同じ巻き戻し（`@main` 参照への退行）が今後再発しないための CI ガードと AI ガイドライン整備** を行います。

- **既存違反の解消**: `github/copilot-release-notes@main` → 同リポジトリ main HEAD (`4406c0a9` / 2026-04-06) の SHA に固定（残っていた唯一のブランチ参照）
- **CI ガード追加**: `actionlint` ワークフローに grep ベースのステップを追加し、`uses: owner/repo@(main|master|develop|trunk|HEAD)` の混入を CI で弾く
- **AI ガイドライン明記**: `docs/ai-guidelines.md` に「外部 Action は 40 桁 SHA でピン留め必須」のルールを追加し、`bun run sync:ai-guidelines` で `.cursorrules` / `.github/copilot-instructions.md` を再生成

## なぜブランチ参照のみを禁止するか

PR #137 で起きた `startup_failure` の直接原因は「リネーム後のリポジトリ名 + ブランチ参照」の組み合わせです。タグ参照 `@v1` は (1) 実害が比較的小さく、(2) より広域の検出は `zizmor` 等の専用ツールに任せる方がコスパが良いため、本 PR では **「実害が大きいブランチ参照のみを最小コストで弾く」** スコープに留めました。

## 関連

- PR #137: 直接修正（マージ済み）
- 該当 Run: https://github.com/genzouw/monopo/actions/runs/26615747974

## Test plan

- [ ] 本 PR の actionlint ジョブが緑になることを確認（新規ガードがセルフ違反を起こさない）
- [ ] 試しに別ブランチで `uses: foo/bar@main` を含む workflow を追加し、actionlint ジョブが赤になることを確認
- [ ] マージ後、AI Release Notes ワークフローを `workflow_dispatch` で空打ちし、`Generate release notes` ステップが少なくとも Action 解決まで進むことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions ワークフロー内で参照する外部 Action をコミット SHA でピン留めする運用ルールを確立しました
  * 可変ブランチ参照（`@main` など）の使用を検出・禁止する検証ステップを追加しました
  * 開発ガイドラインとドキュメントに新運用ルールを追記しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/monopo/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->