### PR TITLE
fix: 🎨 Palette: BuildDialogで片方のボタン無効化時のレイアウトズレを修正 (#143)

### DIFF
--- a/src/components/ActionDialog/ActionDialog.module.css
+++ b/src/components/ActionDialog/ActionDialog.module.css
@@ -88,6 +88,21 @@
   align-items: flex-end;
   gap: 4px;
 }
+/* 横並びアクションペア（例: たてる/うる）の外側コンテナ。
+   片方の列にだけヒントが出てもボタン Y 位置が揃うよう align-items は flex-start。 */
+.buildItemActionPair {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+  align-items: flex-start;
+}
+/* アクションペアの各列。ボタンの下にヒントを縦積みする。 */
+.buildItemActionColumn {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+}
 .buildItemName {
   display: flex;
   align-items: center;

--- a/src/components/ActionDialog/ActionDialog.module.css
+++ b/src/components/ActionDialog/ActionDialog.module.css
@@ -95,6 +95,7 @@
   gap: 4px;
   margin-left: auto;
   align-items: flex-start;
+  flex-shrink: 0;
 }
 /* アクションペアの各列。ボタンの下にヒントを縦積みする。 */
 .buildItemActionColumn {

--- a/src/components/ActionDialog/BuildDialog.tsx
+++ b/src/components/ActionDialog/BuildDialog.tsx
@@ -120,22 +120,8 @@ export default function BuildDialog({
                   {HOUSE_LABELS[houses]} たてるコスト: ${space.houseCost}
                 </div>
               </div>
-              <div
-                style={{
-                  display: 'flex',
-                  gap: 4,
-                  marginLeft: 'auto',
-                  alignItems: 'center',
-                }}
-              >
-                <div
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'flex-end',
-                    gap: 4,
-                  }}
-                >
+              <div className={styles.buildItemActionPair}>
+                <div className={styles.buildItemActionColumn}>
                   <Button
                     size="small"
                     onClick={() => onBuild(space.id)}
@@ -158,14 +144,7 @@ export default function BuildDialog({
                     </div>
                   )}
                 </div>
-                <div
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'flex-end',
-                    gap: 4,
-                  }}
-                >
+                <div className={styles.buildItemActionColumn}>
                   <Button
                     size="small"
                     variant="secondary"


### PR DESCRIPTION
## Summary

Closes #143

BuildDialog で「たてる」「うる」ボタンのうち片方のみが無効化されたとき、ヒント表示の有無で各列の高さが変わり、ボタンの上下位置がズレる問題を修正しました。

### 🎯 Why

外側の flex コンテナが `alignItems: 'center'` だったため、片方の列にだけヒントが表示されて高さが増すと、もう一方の列の中身（ボタン）が中央寄せになり Y 位置がズレていました。

### 🎨 What

- 外側コンテナの `alignItems` を `flex-start` に変更し、両ボタンを常に上端揃えに。
- 重複していたインラインスタイルを `ActionDialog.module.css` に集約し、汎用名 `.buildItemActionPair` / `.buildItemActionColumn` で定義（将来 BuildDialog 以外でも再利用可）。

### 🤔 Plan A vs Plan B 検討

| 案 | アプローチ | 評価 |
|----|----------|------|
| min-height (当初Plan A) | 列に固定高さを与える | マジックナンバー化、将来のサイズ変更に弱い |
| CSS Grid (Plan B) | グリッドで構造化 | 堅牢だが DOM 構造変更が大きく低優先度の Issue には過剰 |
| **alignItems: flex-start (採用)** | 外側 flex の整列方向を変更 | **最小コードで根本解決、マジックナンバー不要** |

### 📋 スコープ判定

| ダイアログ | ペアボタン構成 | 本Issue該当 |
|-----------|---------------|------------|
| BuildDialog | ✅ 左右ペア | ✅ 修正対象 |
| MortgageDialog | ❌ 1行1ボタン | 対象外 |
| Jail/Purchase/ForceBuy | ❌ 縦積み | 対象外 |
| AuctionDialog | 横並びだが共有ヒント | 対象外 |
| TradeDialog | ❌ 単一実行ボタン | 対象外 |

横展開が必要となる将来のダイアログは、新設した `.buildItemActionPair` / `.buildItemActionColumn` をそのまま流用できます。

## Test plan

- [x] `bun run typecheck` パス
- [x] `bun run lint` パス
- [x] `bun run test` 全 205 件パス
- [x] `bun run format:check` パス
- [ ] 実機: BuildDialog で「たてる」のみ無効化 / 「うる」のみ無効化 / 両方無効化 / 両方有効 の 4 パターンでボタンが上端に揃うことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)