### PR TITLE
chore(security): 🔒 permissions-audit による CI 最小権限原則の定期監査強化

### DIFF
--- a/.github/workflows/permissions-audit.yml
+++ b/.github/workflows/permissions-audit.yml
@@ -1,0 +1,34 @@
+name: Default Permissions Audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * 0' # 毎週日曜日に実行
+
+permissions:
+  contents: read
+
+jobs:
+  audit-permissions:
+    name: Audit Workflow Permissions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Check for workflows without explicit permissions
+        run: |
+          echo "🔍 Scanning workflows for missing permissions..."
+          VIOLATIONS=$(grep -rEL '^permissions:' .github/workflows/*.yml || true)
+          if [ -n "$VIOLATIONS" ]; then
+            echo "::error::❌ The following workflows do not have explicit top-level permissions set:"
+            echo "$VIOLATIONS"
+            echo "To enforce least privilege, all workflows must have explicit top-level 'permissions'."
+            false
+          else
+            echo "✅ All workflows have explicit top-level permissions."
+          fi

--- a/docs/security/leak-prevention.md
+++ b/docs/security/leak-prevention.md
@@ -42,3 +42,9 @@
 - **推奨（リポジトリ管理者向け）**: リポジトリ設定 (Settings > Code security and analysis) から、GitHub ネイティブの **Secret Scanning** と **Push Protection** を有効化することを強く推奨します。これにより、プッシュ時の検知がさらに強化されます（※この設定はリポジトリ管理者のみが変更できます）。
 - 本番のシークレットや接続情報（DB、SaaS）を直接コードにハードコードせず、必ず環境変数を使用してください。
 - PR 作成時など、誤って秘密情報を含めてしまったことに気づいた場合は、速やかに管理者に連絡し、必要に応じて該当シークレットの無効化（ローテーション）を行ってください。
+
+### GitHub Actionsの権限(Permissions)最小化
+
+CIの各ワークフロー (`.github/workflows/*.yml`) では、予期せぬスクリプト実行や悪意あるActionからリポジトリを保護するため、**トップレベルでの `permissions` の明示を必須**としています。
+未指定の場合、GitHubのデフォルト設定によっては過剰な権限（例: リポジトリの書き換え権限）が与えられる可能性があります。
+CIの監査ワークフロー (`.github/workflows/permissions-audit.yml`) にて、全ワークフローファイルが `permissions:` を明示しているかを検査し、漏洩防止の基盤として「最小権限の原則 (Principle of Least Privilege)」を徹底しています。

--- a/docs/security/leak-prevention.md
+++ b/docs/security/leak-prevention.md
@@ -43,8 +43,8 @@
 - 本番のシークレットや接続情報（DB、SaaS）を直接コードにハードコードせず、必ず環境変数を使用してください。
 - PR 作成時など、誤って秘密情報を含めてしまったことに気づいた場合は、速やかに管理者に連絡し、必要に応じて該当シークレットの無効化（ローテーション）を行ってください。
 
-### GitHub Actionsの権限(Permissions)最小化
+### GitHub Actions の権限 (Permissions) の最小化
 
-CIの各ワークフロー (`.github/workflows/*.yml`) では、予期せぬスクリプト実行や悪意あるActionからリポジトリを保護するため、**トップレベルでの `permissions` の明示を必須**としています。
-未指定の場合、GitHubのデフォルト設定によっては過剰な権限（例: リポジトリの書き換え権限）が与えられる可能性があります。
-CIの監査ワークフロー (`.github/workflows/permissions-audit.yml`) にて、全ワークフローファイルが `permissions:` を明示しているかを検査し、漏洩防止の基盤として「最小権限の原則 (Principle of Least Privilege)」を徹底しています。
+CI の各ワークフロー (`.github/workflows/*.yml`) では、予期せぬスクリプト実行や悪意ある Action からリポジトリを保護するため、**トップレベルでの `permissions` の明示を必須**としています。
+未指定の場合、GitHub のデフォルト設定によっては過剰な権限（例: リポジトリの書き換え権限）が与えられる可能性があります。
+CI の監査ワークフロー (`.github/workflows/permissions-audit.yml`) にて、全ワークフローファイルが `permissions:` を明示しているかを検査し、漏洩防止の基盤として「最小権限の原則 (Principle of Least Privilege)」を徹底しています。


### PR DESCRIPTION
## 背景

現在のリポジトリには `gitleaks.yml`, `trivy.yml`, `codeql.yml` などの CI 検知、および pre-commit hook でのローカル検知など多層的な防御がすでに構築されています。
各 CI ワークフローはトップレベルで `permissions` を明示して最小権限に設定されていますが、それが新規追加ワークフローでも将来にわたって継続的に守られることを保証する仕組み（定期監査）がありません。
`permissions` が明示されていないワークフローが存在すると、リポジトリへの不要な書き込み権限が与えられるリスク（意図しない改ざんやシークレットの流出等）があります。

## 現状認識（事前調査結果のサマリー）

- 既存防御策: `gitleaks.yml`, `trivy.yml`, `codeql.yml`, `trufflehog.yml` および `.husky/pre-commit` (gitleaks) 導入済み。各既存ワークフローで `permissions` は設定済み。
- 未カバー領域: ワークフローに対する設定忘れ（`permissions` の未記載）を自動検知する仕組みが存在しない。
- 直近の漏洩リスク兆候: 特になし（既存の CI で防御できている）。

## このPRで導入・強化するもの

- 対象: 新規 `.github/workflows/permissions-audit.yml` 追加と `docs/security/leak-prevention.md` への追記。
- ツール名とバージョン: Bash (`grep`) を利用したカスタムスクリプト。
- 期待される効果: 全ての GitHub Actions ワークフローに対して、トップレベルの `permissions:` が明記されているかを PR / Push / 定期監査（週次）で検査し、未設定（過剰権限の可能性）がある場合に CI をブロックする。

## 検知漏れリスクと補完策

- 検知できないケース: 意図的に `permissions: write-all` などの過剰な権限が明記されているケース。
- 補完策: PR レビュー時に Code Review（人間または AI エージェント）によって、権限のスコープが適切かをチェックする。

## マージ前に必要な手動作業（チェックリスト）

レビュアーは PR をマージする前に必ず以下を実施してください。
本 PR の CI は手動作業完了を前提に通る設計です。

- [x] 手動設定は不要です。既存の GitHub Actions 機能のみを使用しています。

## マージ後の確認手順

- [ ] 次の push / PR で導入した `permissions-audit.yml` が green になることを確認。

## ロールバック手順

問題が発生した場合は、当該ワークフローファイルを削除するか、`schedule` トリガーなどを無効化して revert してください。

## 参考情報

- 公式ドキュメント: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- 直近の関連 PR / Issue: なし

---
*PR created automatically by Jules for task [5970606457979758699](https://jules.google.com/task/5970606457979758699) started by @genzouw*