### PR TITLE
🎨 Palette: サウンドトグルボタンのアクセシビリティ改善

### DIFF
--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -394,6 +394,7 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
         type="button"
         className={styles.muteButton}
         onClick={toggleMute}
+        aria-pressed={muted}
         aria-label={muted ? 'サウンドをオンにする' : 'サウンドをオフにする'}
         title={muted ? 'サウンドをオンにする' : 'サウンドをオフにする'}
       >


### PR DESCRIPTION
💡 What:
`src/components/GameBoard/GameBoard.tsx`のサウンドのON/OFFを切り替えるミュートボタンに `aria-pressed={muted}` 属性を追加しました。

🎯 Why:
このボタンは状態（サウンドON/OFF）を持つトグルボタンですが、`aria-label`と`title`しか設定されておらず、スクリーンリーダーを利用するユーザーにとって現在のトグル状態が明確に伝わらないアクセシビリティの課題がありました。`aria-pressed` を追加することで、スクリーンリーダーユーザーに対して適切に状態を伝えることができるようになります。

♿ Accessibility:
アイコンのみのトグルボタンに対して `aria-pressed` 属性を付与することで、スクリーンリーダー向けのキーボードナビゲーションおよび状態フィードバックのアクセシビリティを改善しました。

---
*PR created automatically by Jules for task [8475385100904274024](https://jules.google.com/task/8475385100904274024) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ミュート切替ボタンがスクリーンリーダーなどのアクセシビリティツールに対して、正しくミュート状態を報告するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->