### PR TITLE
chore(security): 🔒 手動 による TradeDialogの入力文字数制限 強化

### DIFF
--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -203,6 +203,7 @@ export default function TradeDialog({
             placeholder="0"
             onChange={(e) => {
               const raw = e.target.value;
+              if (raw.length > 6) return;
               if (raw === '') {
                 setOfferMoney(0);
                 return;
@@ -293,6 +294,7 @@ export default function TradeDialog({
             placeholder="0"
             onChange={(e) => {
               const raw = e.target.value;
+              if (raw.length > 6) return;
               if (raw === '') {
                 setRequestMoney(0);
                 return;

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -12,6 +12,8 @@ import styles from './ActionDialog.module.css';
 import { clamp } from './tradeDialog.utils';
 import { getSpaceById } from '../../game/rules';
 
+const MAX_MONEY_INPUT_LENGTH = 6;
+
 const LABELS = {
   propose: 'ていあんする！',
   cancel: 'やめる',
@@ -203,7 +205,7 @@ export default function TradeDialog({
             placeholder="0"
             onChange={(e) => {
               const raw = e.target.value;
-              if (raw.length > 6) return;
+              if (raw.length > MAX_MONEY_INPUT_LENGTH) return;
               if (raw === '') {
                 setOfferMoney(0);
                 return;
@@ -294,7 +296,7 @@ export default function TradeDialog({
             placeholder="0"
             onChange={(e) => {
               const raw = e.target.value;
-              if (raw.length > 6) return;
+              if (raw.length > MAX_MONEY_INPUT_LENGTH) return;
               if (raw === '') {
                 setRequestMoney(0);
                 return;


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** `TradeDialog.tsx` のお金入力（`<input type="number">`）において、ユーザーが巨大な文字列を入力/ペーストした際に、生の文字列をそのまま `Number()` でパースしようとする処理がありました。HTMLの `max` 属性はパース後に評価されるため、極端に長い文字列が入力された場合に一時的なCPU負荷の増大やメモリ消費（DoSライクな状態）を引き起こす可能性がありました。
🎯 **Impact:** 悪意のある極端に長い入力文字列（例: 巨大なコピペ）により、クライアント側のブラウザタブがフリーズまたはクラッシュする可能性がありました。
🔧 **Fix:** `e.target.value` (raw) を `Number(raw)` で数値に変換する前に、`if (raw.length > 6) return;` の文字数制限を追加し、処理を早期リターンするようにしました。通常のゲームプレイで必要な金額（最大数万ドル）を十分にカバーしつつ、極端に長い入力を防ぎます。
✅ **Verification:**
- `bun run test` により既存のユニットテストがすべて通過することを確認しました。
- `bun run lint` および `bun run format:check` による静的解析エラーがないことを確認しました。

---
*PR created automatically by Jules for task [17166670790715933972](https://jules.google.com/task/17166670790715933972) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 取引ダイアログのお金入力フィールドで、入力可能な文字数を制限する検証を追加しました。これにより、過度に長い入力が確実に拒否されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->