### PR TITLE
feat(economy): 🎸 変動金利ローン・クレジットスコア（Phase 3-a）

### DIFF
--- a/src/game/__tests__/loan.test.ts
+++ b/src/game/__tests__/loan.test.ts
@@ -1,0 +1,379 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BASE_RATE_INITIAL,
+  BASE_RATE_MIN,
+  BASE_RATE_MAX,
+  LOAN_SPREAD,
+  LOAN_PERIODS,
+  calculateCreditScoreFactor,
+  calculateLoanInterestRate,
+  calculateMaxLoan,
+  calculateMonthlyPayment,
+  calculateNextBaseRate,
+  liquidateNonPropertyAssets,
+} from '../systems/loan';
+import { createInitialGameState, gameReducer } from '../reducer';
+import type { GameState } from '../types';
+
+function startGame(features?: {
+  loan?: boolean;
+  altAssets?: boolean;
+}): GameState {
+  return gameReducer(createInitialGameState(), {
+    type: 'START_GAME',
+    playerNames: ['たろう', 'はなこ'],
+    playerTokens: ['🚗', '🎩'],
+    features,
+  });
+}
+
+// ── クレジットスコアファクター ──
+
+describe('calculateCreditScoreFactor', () => {
+  it('所有25%未満でファクター1.5になる', () => {
+    expect(calculateCreditScoreFactor(0)).toBe(1.5);
+    expect(calculateCreditScoreFactor(0.1)).toBe(1.5);
+    expect(calculateCreditScoreFactor(0.249)).toBe(1.5);
+  });
+
+  it('所有25〜50%でファクター1.0になる', () => {
+    expect(calculateCreditScoreFactor(0.25)).toBe(1.0);
+    expect(calculateCreditScoreFactor(0.4)).toBe(1.0);
+    expect(calculateCreditScoreFactor(0.5)).toBe(1.0);
+  });
+
+  it('所有50%超でファクター0.7になる', () => {
+    expect(calculateCreditScoreFactor(0.501)).toBe(0.7);
+    expect(calculateCreditScoreFactor(1.0)).toBe(0.7);
+  });
+});
+
+// ── 借入金利計算 ──
+
+describe('calculateLoanInterestRate', () => {
+  it('借入金利 = base_rate + spread * credit_score_factor', () => {
+    // base=5%, spread=2%, factor=1.5 → 5%+3%=8%
+    expect(calculateLoanInterestRate(0.05, 1.5)).toBeCloseTo(0.08);
+    // base=5%, spread=2%, factor=1.0 → 5%+2%=7%
+    expect(calculateLoanInterestRate(0.05, 1.0)).toBeCloseTo(0.07);
+    // base=5%, spread=2%, factor=0.7 → 5%+1.4%=6.4%
+    expect(calculateLoanInterestRate(0.05, 0.7)).toBeCloseTo(0.064);
+  });
+});
+
+// ── 借入上限 ──
+
+describe('calculateMaxLoan', () => {
+  it('借入上限は総資産の50%（切り捨て）', () => {
+    expect(calculateMaxLoan(1000)).toBe(500);
+    expect(calculateMaxLoan(3000)).toBe(1500);
+    expect(calculateMaxLoan(101)).toBe(50);
+    expect(calculateMaxLoan(1500)).toBe(750);
+  });
+});
+
+// ── 元利均等返済額 ──
+
+describe('calculateMonthlyPayment', () => {
+  it('元利均等返済額を正確に計算する', () => {
+    // P=1000, r=7%, n=10: PMT ≈ 142 (切り上げ)
+    const pmt = calculateMonthlyPayment(1000, 0.07, 10);
+    expect(pmt).toBeGreaterThanOrEqual(142);
+    expect(pmt).toBeLessThanOrEqual(145);
+  });
+
+  it('金利ゼロの場合は元本を均等分割する（切り上げ）', () => {
+    expect(calculateMonthlyPayment(1000, 0, 10)).toBe(100);
+    expect(calculateMonthlyPayment(1001, 0, 10)).toBe(101);
+  });
+
+  it('元本ゼロの場合は返済額ゼロ', () => {
+    expect(calculateMonthlyPayment(0, 0.07, 10)).toBe(0);
+  });
+});
+
+// ── 基準金利変動 ──
+
+describe('calculateNextBaseRate', () => {
+  it('5の倍数ターンでのみ変動する', () => {
+    const rate = BASE_RATE_INITIAL;
+    expect(calculateNextBaseRate(rate, 1)).toBe(rate);
+    expect(calculateNextBaseRate(rate, 2)).toBe(rate);
+    expect(calculateNextBaseRate(rate, 3)).toBe(rate);
+    expect(calculateNextBaseRate(rate, 4)).toBe(rate);
+    const newRate = calculateNextBaseRate(rate, 5);
+    expect(newRate).not.toBe(rate);
+  });
+
+  it('変動後も1%〜30%の範囲に収まる', () => {
+    let rate = BASE_RATE_INITIAL;
+    for (let turn = 1; turn <= 100; turn++) {
+      rate = calculateNextBaseRate(rate, turn);
+      expect(rate).toBeGreaterThanOrEqual(BASE_RATE_MIN);
+      expect(rate).toBeLessThanOrEqual(BASE_RATE_MAX);
+    }
+  });
+
+  it('同じターン数・同じ金利では同じ結果になる（再現性）', () => {
+    const r1 = calculateNextBaseRate(0.05, 5);
+    const r2 = calculateNextBaseRate(0.05, 5);
+    expect(r1).toBe(r2);
+  });
+
+  it('変動幅は±1〜3%', () => {
+    const initial = 0.05;
+    const newRate = calculateNextBaseRate(initial, 5);
+    const diff = Math.abs(newRate - initial);
+    expect(diff).toBeGreaterThanOrEqual(0.01 - 1e-10);
+    expect(diff).toBeLessThanOrEqual(0.03 + 1e-10);
+  });
+});
+
+// ── 破産時の非不動産資産清算（優先順位テスト） ──
+
+describe('liquidateNonPropertyAssets', () => {
+  const basePlayer = {
+    id: 'player-0',
+    name: 'たろう',
+    token: '🚗' as const,
+    money: 0,
+    position: 0,
+    properties: [] as string[],
+    inJail: false,
+    jailTurns: 0,
+    getOutOfJailCards: 0,
+    isBankrupt: false,
+  };
+
+  it('①暗号資産が清算される', () => {
+    const player = {
+      ...basePlayer,
+      cryptoHolding: { units: 1.0, initialPrice: 1000, currentPrice: 1200 },
+    };
+    const { updatedPlayer, proceeds } = liquidateNonPropertyAssets(
+      player,
+      undefined,
+    );
+    expect(proceeds).toBe(1200);
+    expect(updatedPlayer.cryptoHolding).toBeUndefined();
+    expect(updatedPlayer.money).toBe(1200);
+  });
+
+  it('②VC投資が清算される（投資額を回収）', () => {
+    const player = {
+      ...basePlayer,
+      vcInvestments: [
+        { amount: 300, investedTurn: 0 },
+        { amount: 200, investedTurn: 1 },
+      ],
+    };
+    const { updatedPlayer, proceeds } = liquidateNonPropertyAssets(
+      player,
+      undefined,
+    );
+    expect(proceeds).toBe(500);
+    expect(updatedPlayer.vcInvestments).toBeUndefined();
+    expect(updatedPlayer.money).toBe(500);
+  });
+
+  it('③株式が市場価格で清算される', () => {
+    const player = {
+      ...basePlayer,
+      stocks: { brown: 5 } as Record<string, number>,
+    };
+    const stockMarket = {
+      brown: {
+        color: 'brown' as const,
+        pricePerShare: 100,
+        totalShares: 100,
+        bankShares: 95,
+      },
+    };
+    const { updatedPlayer, proceeds } = liquidateNonPropertyAssets(
+      player,
+      stockMarket,
+    );
+    expect(proceeds).toBe(500);
+    expect(updatedPlayer.stocks).toBeUndefined();
+    expect(updatedPlayer.money).toBe(500);
+  });
+
+  it('清算後にすべての非不動産資産が削除される', () => {
+    const player = {
+      ...basePlayer,
+      money: 100,
+      cryptoHolding: { units: 1.0, initialPrice: 1000, currentPrice: 500 },
+      vcInvestments: [{ amount: 200, investedTurn: 0 }],
+    };
+    const { updatedPlayer } = liquidateNonPropertyAssets(player, undefined);
+    expect(updatedPlayer.cryptoHolding).toBeUndefined();
+    expect(updatedPlayer.vcInvestments).toBeUndefined();
+    expect(updatedPlayer.money).toBe(800); // 100 + 500 + 200
+  });
+
+  it('非不動産資産がなければ proceeds=0 を返す', () => {
+    const { proceeds } = liquidateNonPropertyAssets(basePlayer, undefined);
+    expect(proceeds).toBe(0);
+  });
+});
+
+// ── Reducer 統合テスト: TAKE_LOAN ──
+
+describe('reducer: TAKE_LOAN', () => {
+  it('ローンを借り入れると資金が増えてLoanStateが設定される', () => {
+    const state = startGame({ loan: true });
+    const after = gameReducer(state, { type: 'TAKE_LOAN', amount: 500 });
+    expect(after.players[0].money).toBe(2000); // 1500 + 500
+    expect(after.players[0].loan).toBeDefined();
+    expect(after.players[0].loan!.principal).toBe(500);
+    expect(after.players[0].loan!.remainingPayments).toBe(LOAN_PERIODS);
+  });
+
+  it('loan機能がOFFならTAKE_LOANが無視される', () => {
+    const state = startGame();
+    const after = gameReducer(state, { type: 'TAKE_LOAN', amount: 500 });
+    expect(after.players[0].loan).toBeUndefined();
+    expect(after.players[0].money).toBe(1500);
+  });
+
+  it('借入上限（総資産の50%）を超える場合は無視される', () => {
+    const state = startGame({ loan: true });
+    // 初期資産 $1500 → 上限 $750
+    const after = gameReducer(state, { type: 'TAKE_LOAN', amount: 10000 });
+    expect(after.players[0].loan).toBeUndefined();
+    expect(after.players[0].money).toBe(1500);
+  });
+
+  it('クレジットスコアに応じた借入金利が設定される（物件なし=最高金利）', () => {
+    const state = startGame({ loan: true });
+    // 物件なし → 所有率0% → factor=1.5 → rate = 5% + 2%×1.5 = 8%
+    const after = gameReducer(state, { type: 'TAKE_LOAN', amount: 500 });
+    expect(after.players[0].loan!.annualRate).toBeCloseTo(0.08);
+  });
+
+  it('既存ローンがある場合は追加借入できない', () => {
+    const state = startGame({ loan: true });
+    const withLoan = gameReducer(state, { type: 'TAKE_LOAN', amount: 300 });
+    const again = gameReducer(withLoan, { type: 'TAKE_LOAN', amount: 200 });
+    // ローン状態は変わらない
+    expect(again.players[0].loan!.principal).toBe(300);
+    expect(again.players[0].money).toBe(withLoan.players[0].money);
+  });
+});
+
+// ── Reducer 統合テスト: REPAY_LOAN ──
+
+describe('reducer: REPAY_LOAN', () => {
+  it('REPAY_LOANで1回分の返済が行われる', () => {
+    const state = startGame({ loan: true });
+    const withLoan = gameReducer(state, { type: 'TAKE_LOAN', amount: 500 });
+    const before = withLoan.players[0];
+    const after = gameReducer(withLoan, { type: 'REPAY_LOAN' });
+    const player = after.players[0];
+
+    expect(player.money).toBeLessThan(before.money);
+    expect(player.loan).toBeDefined();
+    expect(player.loan!.remainingPayments).toBe(
+      before.loan!.remainingPayments - 1,
+    );
+  });
+
+  it('ローンがなければREPAY_LOANが無視される', () => {
+    const state = startGame({ loan: true });
+    const after = gameReducer(state, { type: 'REPAY_LOAN' });
+    expect(after.players[0].money).toBe(1500);
+  });
+
+  it('loan機能がOFFならREPAY_LOANが無視される', () => {
+    const state = startGame();
+    const after = gameReducer(state, { type: 'REPAY_LOAN' });
+    expect(after.players[0].money).toBe(1500);
+  });
+});
+
+// ── Reducer 統合テスト: 変動金利が5ターンごとに変化する ──
+
+describe('reducer: 変動金利が5ターンごとに変化する', () => {
+  it('ゲーム開始時にbaseRateが初期値(5%)で設定される', () => {
+    const state = startGame({ loan: true });
+    expect(state.baseRate).toBe(BASE_RATE_INITIAL);
+  });
+
+  it('5ターン後にbaseRateが変動する', () => {
+    let state = startGame({ loan: true });
+
+    for (let i = 0; i < 5; i++) {
+      state = gameReducer(state, { type: 'END_TURN' });
+    }
+
+    const expectedRate = calculateNextBaseRate(BASE_RATE_INITIAL, 5);
+    expect(state.baseRate).toBeCloseTo(expectedRate);
+    expect(state.baseRate).not.toBe(BASE_RATE_INITIAL);
+  });
+
+  it('5の倍数でないターンはbaseRateが変動しない', () => {
+    let state = startGame({ loan: true });
+    const initialRate = state.baseRate!;
+
+    for (let i = 0; i < 4; i++) {
+      state = gameReducer(state, { type: 'END_TURN' });
+    }
+
+    expect(state.baseRate).toBe(initialRate);
+  });
+});
+
+// ── Reducer 統合テスト: END_TURNでローン返済が自動実行される ──
+
+describe('reducer: END_TURNで現在プレイヤーのローンが自動返済される', () => {
+  it('END_TURN後に残返済回数が1減る', () => {
+    let state = startGame({ loan: true });
+    state = gameReducer(state, { type: 'TAKE_LOAN', amount: 500 });
+    const loanBefore = state.players[0].loan!;
+
+    state = gameReducer(state, { type: 'END_TURN' });
+
+    const player0 = state.players.find((p) => p.id === 'player-0')!;
+    expect(player0.loan).toBeDefined();
+    expect(player0.loan!.remainingPayments).toBe(
+      loanBefore.remainingPayments - 1,
+    );
+  });
+
+  it('返済完了後にloanがundefinedになる', () => {
+    let state = startGame({ loan: true });
+    state = gameReducer(state, { type: 'TAKE_LOAN', amount: 100 });
+
+    // LOAN_PERIODS 回 END_TURN（2プレイヤーなのでプレイヤー0は LOAN_PERIODS * 2 回分）
+    for (let i = 0; i < LOAN_PERIODS * 2; i++) {
+      state = gameReducer(state, { type: 'END_TURN' });
+    }
+
+    const player0 = state.players.find((p) => p.id === 'player-0')!;
+    expect(player0.loan).toBeUndefined();
+  });
+});
+
+// ── 定数の確認 ──
+
+describe('loan 定数', () => {
+  it('基準金利の初期値は5%', () => {
+    expect(BASE_RATE_INITIAL).toBeCloseTo(0.05);
+  });
+
+  it('基準金利の下限は1%', () => {
+    expect(BASE_RATE_MIN).toBeCloseTo(0.01);
+  });
+
+  it('基準金利の上限は30%', () => {
+    expect(BASE_RATE_MAX).toBeCloseTo(0.3);
+  });
+
+  it('スプレッドは2%', () => {
+    expect(LOAN_SPREAD).toBeCloseTo(0.02);
+  });
+
+  it('返済回数は10回', () => {
+    expect(LOAN_PERIODS).toBe(10);
+  });
+});

--- a/src/game/actions.ts
+++ b/src/game/actions.ts
@@ -48,4 +48,7 @@ export type GameAction =
   | { type: 'SELL_CRYPTO' }
   | { type: 'INVEST_VC'; amount: number }
   | { type: 'BUY_ESG'; amount: number }
-  | { type: 'SELL_ESG'; index: number };
+  | { type: 'SELL_ESG'; index: number }
+  // P3-a 拡張: 変動金利ローン
+  | { type: 'TAKE_LOAN'; amount: number }
+  | { type: 'REPAY_LOAN' };

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -42,6 +42,12 @@ import {
   calculateESGDividend,
   isESGDividendTurn,
 } from './systems/altAssets';
+import {
+  BASE_RATE_INITIAL,
+  applyLoanAction,
+  applyLoanEndTurn,
+  liquidateNonPropertyAssets,
+} from './systems/loan';
 
 // ── 定数 ──
 
@@ -93,6 +99,7 @@ function checkWinner(players: Player[]): string | null {
 
 /**
  * 所持金がマイナスのプレイヤーを検出し:
+ * - P3-a 拡張: まず非不動産資産（①暗号資産→②VC→③株式）を自動清算
  * - 物件あり → forceSellフェーズに遷移（強制売りだし）
  * - 物件なし → 自動破産
  */
@@ -104,32 +111,60 @@ function checkNegativeMoney(state: GameState): GameState {
     return state;
   }
 
+  // P3-a 拡張: 非不動産資産の自動清算（破産処理優先順位: ①暗号資産→②VC→③株式）
+  let workingState = state;
+  if (state.features?.altAssets || state.features?.loan) {
+    const player = workingState.players[workingState.currentPlayerIndex];
+    const { updatedPlayer, proceeds } = liquidateNonPropertyAssets(
+      player,
+      workingState.stockMarket,
+    );
+    if (proceeds > 0) {
+      workingState = {
+        ...workingState,
+        players: workingState.players.map((p, i) =>
+          i === workingState.currentPlayerIndex ? updatedPlayer : p,
+        ),
+      };
+      if (updatedPlayer.money >= 0) {
+        return {
+          ...workingState,
+          turnPhase: 'endTurn',
+          message: `${updatedPlayer.name}のアセットを売って借金を返したよ！`,
+        };
+      }
+    }
+  }
+
+  const currentPlayerAfter =
+    workingState.players[workingState.currentPlayerIndex];
+
   // 物件を持っていれば強制売りだし
   // (家がある物件のみの場合もあるので、家を売るか物件を売るか選べるようにする)
-  if (currentPlayer.properties.length > 0) {
+  if (currentPlayerAfter.properties.length > 0) {
     return {
-      ...state,
+      ...workingState,
       turnPhase: 'forceSell',
-      message: `${currentPlayer.name}のおかねがマイナスだよ！物件を売ってお金をつくろう！`,
+      message: `${currentPlayerAfter.name}のおかねがマイナスだよ！物件を売ってお金をつくろう！`,
     };
   }
 
   // 物件もない → 破産
-  const newPlayers = state.players.map((p) =>
-    p.id === currentPlayer.id ? { ...p, isBankrupt: true, money: 0 } : p,
+  const newPlayers = workingState.players.map((p) =>
+    p.id === currentPlayerAfter.id ? { ...p, isBankrupt: true, money: 0 } : p,
   );
 
   const winnerId = checkWinner(newPlayers);
 
   return {
-    ...state,
+    ...workingState,
     players: newPlayers,
-    phase: winnerId ? 'finished' : state.phase,
-    winnerId: winnerId ?? state.winnerId,
+    phase: winnerId ? 'finished' : workingState.phase,
+    winnerId: winnerId ?? workingState.winnerId,
     turnPhase: 'endTurn',
     message: winnerId
       ? `${newPlayers.find((p) => p.id === winnerId)!.name}のかちだよ！🎉`
-      : `${currentPlayer.name}ははさんしたよ…`,
+      : `${currentPlayerAfter.name}ははさんしたよ…`,
   };
 }
 
@@ -556,6 +591,8 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
       const stockMarket = action.features?.stocks
         ? createInitialStockMarket()
         : undefined;
+      // P3-a 拡張: ローン機能 ON のときだけ基準金利を初期化
+      const baseRate = action.features?.loan ? BASE_RATE_INITIAL : undefined;
       return {
         ...state,
         phase: 'playing',
@@ -575,6 +612,7 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
         winnerId: null,
         features: action.features,
         stockMarket,
+        baseRate,
       };
     }
 
@@ -1389,6 +1427,11 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
         stateAfterAlt = applyAltAssetsEndTurn(state, nextTurnCount, diceSum);
       }
 
+      // P3-a 拡張: ローン返済・基準金利変動
+      if (stateAfterAlt.features?.loan) {
+        stateAfterAlt = applyLoanEndTurn(stateAfterAlt, nextTurnCount);
+      }
+
       const nextIndex = nextActivePlayer(
         stateAfterAlt.players,
         stateAfterAlt.currentPlayerIndex,
@@ -1529,6 +1572,11 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
         esgHoldings: newHoldings.length > 0 ? newHoldings : undefined,
       });
     }
+
+    // ── P3-a 拡張: 変動金利ローン ──
+    case 'TAKE_LOAN':
+    case 'REPAY_LOAN':
+      return applyLoanAction(state, action);
 
     default:
       return state;

--- a/src/game/systems/loan.ts
+++ b/src/game/systems/loan.ts
@@ -1,0 +1,274 @@
+// P3-a 拡張: 変動金利ローン・クレジットスコアの純粋関数層
+// economy.ts / altAssets.ts と同様に副作用なしで実装する。
+// reducer.ts は applyLoanAction / applyLoanEndTurn の2つだけを呼ぶ薄いラッパーに徹する。
+
+import { mulberry32 } from '../random';
+import { calculateTotalAssets } from '../rules';
+import { sellCrypto } from './altAssets';
+import type { GameState, LoanState, Player } from '../types';
+import type { ColorGroup, ColorGroupStock } from '../types';
+import type { GameAction } from '../actions';
+
+// ── 定数 ──
+
+export const BASE_RATE_INITIAL = 0.05; // 初期基準金利 5%
+export const BASE_RATE_MIN = 0.01; // 最低 1%
+export const BASE_RATE_MAX = 0.3; // 最高 30%
+export const BASE_RATE_UPDATE_INTERVAL = 5; // 毎5ターンで変動
+export const LOAN_SPREAD = 0.02; // スプレッド 2%
+export const LOAN_PERIODS = 10; // 返済回数（ターン数）
+
+// ── 純粋計算関数 ──
+
+// クレジットスコアファクター: 物件所有率に応じた金利上乗せ係数
+// ownershipRatio < 0.25 → 1.5（低信用）
+// 0.25 ≤ ratio ≤ 0.50 → 1.0（標準）
+// ratio > 0.50 → 0.7（高信用）
+export function calculateCreditScoreFactor(ownershipRatio: number): number {
+  if (ownershipRatio < 0.25) return 1.5;
+  if (ownershipRatio <= 0.5) return 1.0;
+  return 0.7;
+}
+
+// 借入金利 = base_rate + spread × credit_score_factor
+export function calculateLoanInterestRate(
+  baseRate: number,
+  creditScoreFactor: number,
+): number {
+  return baseRate + LOAN_SPREAD * creditScoreFactor;
+}
+
+// 借入上限 = 総資産 × 50%（切り捨て）
+export function calculateMaxLoan(totalAssetValue: number): number {
+  return Math.floor(totalAssetValue * 0.5);
+}
+
+// 元利均等返済額（切り上げ）
+// PMT = P × r(1+r)^n / ((1+r)^n - 1)
+// r=0 のフォールバック: P/n（切り上げ）
+export function calculateMonthlyPayment(
+  principal: number,
+  annualRate: number,
+  periods: number,
+): number {
+  if (principal <= 0) return 0;
+  if (annualRate === 0) return Math.ceil(principal / periods);
+  const r = annualRate;
+  const factor = Math.pow(1 + r, periods);
+  return Math.ceil((principal * r * factor) / (factor - 1));
+}
+
+// 基準金利変動: turnCount が BASE_RATE_UPDATE_INTERVAL の倍数のときのみ更新
+// mulberry32 シードで再現可能な ±1〜3% 変動、[BASE_RATE_MIN, BASE_RATE_MAX] にクランプ
+export function calculateNextBaseRate(
+  currentRate: number,
+  turnCount: number,
+): number {
+  if (turnCount === 0 || turnCount % BASE_RATE_UPDATE_INTERVAL !== 0) {
+    return currentRate;
+  }
+  const seed = (turnCount * 7_919) >>> 0;
+  const rng = mulberry32(seed);
+  const raw1 = rng(); // 変動幅: 1, 2, or 3%
+  const raw2 = rng(); // 方向: 上昇 or 下降
+  const changeSteps = Math.floor(raw1 * 3) + 1; // 1, 2, 3
+  const change = changeSteps * 0.01;
+  const direction = raw2 < 0.5 ? -1 : 1;
+  const newRate = currentRate + direction * change;
+  return Math.max(BASE_RATE_MIN, Math.min(BASE_RATE_MAX, newRate));
+}
+
+// ── 破産時の非不動産資産清算（優先順位: ①暗号資産→②VC→③株式） ──
+// 不動産は既存の forceSell/DECLARE_BANKRUPTCY フローで処理するため対象外
+export function liquidateNonPropertyAssets(
+  player: Player,
+  stockMarket: Partial<Record<ColorGroup, ColorGroupStock>> | undefined,
+): { updatedPlayer: Player; proceeds: number } {
+  let proceeds = 0;
+  let updated = { ...player };
+
+  // ① 暗号資産
+  if (updated.cryptoHolding) {
+    proceeds += sellCrypto(updated.cryptoHolding);
+    updated = { ...updated, cryptoHolding: undefined };
+  }
+
+  // ② スタートアップVC（未精算分は投資額をそのまま回収）
+  if (updated.vcInvestments && updated.vcInvestments.length > 0) {
+    for (const vc of updated.vcInvestments) {
+      proceeds += vc.amount;
+    }
+    updated = { ...updated, vcInvestments: undefined };
+  }
+
+  // ③ 株式（現在の市場価格で換金）
+  if (updated.stocks && stockMarket) {
+    for (const [color, shares] of Object.entries(updated.stocks)) {
+      const market = stockMarket[color as ColorGroup];
+      if (market && shares && shares > 0) {
+        proceeds += market.pricePerShare * shares;
+      }
+    }
+    updated = { ...updated, stocks: undefined };
+  }
+
+  return {
+    updatedPlayer: { ...updated, money: updated.money + proceeds },
+    proceeds,
+  };
+}
+
+// ── 1回分のローン返済を適用する内部ヘルパー ──
+function applyOneRepayment(player: Player): Player {
+  const loan = player.loan;
+  if (!loan) return player;
+
+  // 元利均等返済の利息分と元本分を計算
+  const interestPayment = Math.floor(loan.principal * loan.annualRate);
+  const principalPayment = Math.max(0, loan.monthlyPayment - interestPayment);
+  const newPrincipal = Math.max(0, loan.principal - principalPayment);
+  const newRemainingPayments = loan.remainingPayments - 1;
+
+  if (newRemainingPayments <= 0 || newPrincipal <= 0) {
+    // 完済: 残元本と最後の利息分を一括精算
+    const finalPayment = loan.principal + interestPayment;
+    return { ...player, money: player.money - finalPayment, loan: undefined };
+  }
+
+  return {
+    ...player,
+    money: player.money - loan.monthlyPayment,
+    loan: {
+      ...loan,
+      principal: newPrincipal,
+      remainingPayments: newRemainingPayments,
+    },
+  };
+}
+
+// ── 単一エントリポイント: TAKE_LOAN / REPAY_LOAN アクションの処理 ──
+export function applyLoanAction(
+  state: GameState,
+  action: GameAction,
+): GameState {
+  switch (action.type) {
+    case 'TAKE_LOAN': {
+      if (!state.features?.loan) return state;
+      const player = state.players[state.currentPlayerIndex];
+      if (!player || player.isBankrupt) return state;
+      if (action.amount <= 0) return state;
+      if (player.loan) return state; // 既存ローンがある場合は追加借入不可
+
+      // 借入上限チェック（calculateTotalAssets は rules.ts から）
+      const totalAssets = calculateTotalAssets(
+        player,
+        state.propertyStates,
+        state.board,
+      );
+      const maxLoan = calculateMaxLoan(totalAssets);
+      if (action.amount > maxLoan) return state;
+
+      // クレジットスコア計算（物件所有率）
+      const totalProperties = state.board.filter(
+        (s) =>
+          s.type === 'property' ||
+          s.type === 'railroad' ||
+          s.type === 'utility',
+      ).length;
+      const ownershipRatio =
+        totalProperties > 0 ? player.properties.length / totalProperties : 0;
+      const creditScoreFactor = calculateCreditScoreFactor(ownershipRatio);
+
+      const baseRate = state.baseRate ?? BASE_RATE_INITIAL;
+      const annualRate = calculateLoanInterestRate(baseRate, creditScoreFactor);
+      const monthlyPayment = calculateMonthlyPayment(
+        action.amount,
+        annualRate,
+        LOAN_PERIODS,
+      );
+
+      const loan: LoanState = {
+        principal: action.amount,
+        annualRate,
+        monthlyPayment,
+        remainingPayments: LOAN_PERIODS,
+      };
+
+      const newPlayers = state.players.map((p, i) =>
+        i === state.currentPlayerIndex
+          ? { ...p, money: p.money + action.amount, loan }
+          : p,
+      );
+
+      return { ...state, players: newPlayers };
+    }
+
+    case 'REPAY_LOAN': {
+      if (!state.features?.loan) return state;
+      const player = state.players[state.currentPlayerIndex];
+      if (!player || !player.loan) return state;
+
+      const newPlayers = state.players.map((p, i) =>
+        i === state.currentPlayerIndex ? applyOneRepayment(p) : p,
+      );
+      return { ...state, players: newPlayers };
+    }
+
+    default:
+      return state;
+  }
+}
+
+// ── 単一エントリポイント: END_TURN 時のローン処理 ──
+// 1. 基準金利変動（BASE_RATE_UPDATE_INTERVAL ターンごと）
+// 2. 変動時は全プレイヤーのローン金利・返済額を再計算
+// 3. 現在プレイヤーのローン返済を1回実行
+export function applyLoanEndTurn(
+  state: GameState,
+  nextTurnCount: number,
+): GameState {
+  const currentBaseRate = state.baseRate ?? BASE_RATE_INITIAL;
+  const newBaseRate = calculateNextBaseRate(currentBaseRate, nextTurnCount);
+  const baseRateChanged = newBaseRate !== currentBaseRate;
+
+  const totalProperties = state.board.filter(
+    (s) =>
+      s.type === 'property' || s.type === 'railroad' || s.type === 'utility',
+  ).length;
+
+  const newPlayers = state.players.map((p, i) => {
+    if (p.isBankrupt || !p.loan) return p;
+
+    let loan = p.loan;
+
+    // 基準金利変動時: ローン金利と返済額を再計算
+    if (baseRateChanged) {
+      const ownershipRatio =
+        totalProperties > 0 ? p.properties.length / totalProperties : 0;
+      const creditScoreFactor = calculateCreditScoreFactor(ownershipRatio);
+      const newAnnualRate = calculateLoanInterestRate(
+        newBaseRate,
+        creditScoreFactor,
+      );
+      const newMonthlyPayment = calculateMonthlyPayment(
+        loan.principal,
+        newAnnualRate,
+        loan.remainingPayments,
+      );
+      loan = {
+        ...loan,
+        annualRate: newAnnualRate,
+        monthlyPayment: newMonthlyPayment,
+      };
+    }
+
+    // 現在プレイヤーのみ返済実行（他プレイヤーは金利更新のみ）
+    if (i === state.currentPlayerIndex) {
+      return applyOneRepayment({ ...p, loan });
+    }
+
+    return { ...p, loan };
+  });
+
+  return { ...state, baseRate: newBaseRate, players: newPlayers };
+}

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -61,6 +61,8 @@ export type Player = {
   cryptoHolding?: CryptoHolding;
   vcInvestments?: VCInvestment[];
   esgHoldings?: ESGHolding[];
+  // P3-a 拡張: ローン（features.loan が有効なときのみ意味を持つ）
+  loan?: LoanState;
 };
 
 // ── P1 拡張: 機能フラグ（OFF時は既存挙動完全互換） ──
@@ -68,6 +70,7 @@ export type FeatureFlags = {
   stocks?: boolean; // エリア株売買・配当（応援カード）。
   // 株価は需要供給モデル（売買で動的変動）＋家・ホテル建設で連動上昇。
   altAssets?: boolean; // P3 拡張: 新アセットクラス（暗号資産・VC・ESG）。
+  loan?: boolean; // P3-a 拡張: 変動金利ローン・クレジットスコア。
 };
 
 // ── P1 拡張: エリア株（カラーグループ株） ──
@@ -141,6 +144,14 @@ export type TradeValidationResult =
   | { isValid: true }
   | { isValid: false; reason: TradeInvalidReason };
 
+// ── P3-a 拡張: ローン状態 ──
+export type LoanState = {
+  principal: number; // 残元本
+  annualRate: number; // 現在の年利（小数）
+  monthlyPayment: number; // 毎ターン返済額（元利均等）
+  remainingPayments: number; // 残返済回数
+};
+
 // ── P3 拡張: 新アセットクラス ──
 
 export type CryptoHolding = {
@@ -197,6 +208,8 @@ export type GameState = {
   stockMarket?: Partial<Record<ColorGroup, ColorGroupStock>>;
   // P3 拡張: グローバルターンカウンター（END_TURN ごとに +1）
   turnCount?: number;
+  // P3-a 拡張: 基準金利（features.loan が有効なときのみ意味を持つ）
+  baseRate?: number;
 };
 
 // ── ファクトリ関数 ──


### PR DESCRIPTION
## 概要

Issue #170 に対応し、変動金利ローン・クレジットスコアシステム（Phase 3-a）を実装した。
`features.loan` フラグにより既存ゲームへの影響はゼロ。

## 関連 Issue / 設計ドキュメント

Closes #170

## 変更内容

- `src/game/types.ts`: `LoanState` 型（残元本・年利・月額返済・残回数）、`FeatureFlags.loan`、`Player.loan?`、`GameState.baseRate?` を追加
- `src/game/actions.ts`: `TAKE_LOAN` / `REPAY_LOAN` アクション型を追加
- `src/game/systems/loan.ts`（新規）: 純粋関数層を実装
  - `calculateCreditScoreFactor`: 物件所有率に応じたファクター（0.7 / 1.0 / 1.5）
  - `calculateLoanInterestRate`: 借入金利 = base_rate + spread × factor
  - `calculateMaxLoan`: 借入上限 = 総資産 × 50%
  - `calculateMonthlyPayment`: 元利均等返済額（PMT 公式、切り上げ）
  - `calculateNextBaseRate`: 5ターンごとに ±1〜3% 変動、[1%, 30%] クランプ、mulberry32 シードで再現可能
  - `liquidateNonPropertyAssets`: 破産清算優先順位（①暗号資産→②VC→③株式）
  - `applyLoanAction`: `TAKE_LOAN` / `REPAY_LOAN` の単一エントリポイント
  - `applyLoanEndTurn`: END_TURN 時の基準金利変動 + 現プレイヤーのローン返済
- `src/game/reducer.ts`:
  - `START_GAME` で `loan` 機能有効時に `baseRate` を初期化
  - `END_TURN` に `applyLoanEndTurn` を追加
  - `TAKE_LOAN` / `REPAY_LOAN` を `applyLoanAction` に委譲
  - `checkNegativeMoney` で非不動産資産を自動清算（①暗号資産→②VC→③株式→④不動産の優先順位）
- `src/game/__tests__/loan.test.ts`（新規）: 受け入れ基準4項目すべてを網羅する35テスト

## 動作確認

- [x] ローカルで動作確認した
- [x] テストを追加・更新した（35テスト追加、既存301テスト全パス）

## セルフチェック

- [x] `bun run lint` がパスする
- [x] `bun run typecheck` がパスする
- [x] 破壊的変更がある場合、README または docs を更新した
- [x] DB マイグレーションがある場合、ロールバック手順を確認した
- [x] secret / 個人情報を含むコードや設定が含まれていない

## デプロイ時の注意

なし