### PR TITLE
feat(economy): 🎸 Phase 3-c ポイズンピル防衛策（ACTIVATE_POISON_PILL）を実装

### DIFF
--- a/src/game/__tests__/economy.test.ts
+++ b/src/game/__tests__/economy.test.ts
@@ -4,12 +4,16 @@ import { BOARD_SPACES } from '../board';
 import { createInitialGameState, gameReducer } from '../reducer';
 import {
   DIVIDEND_RATE_PCT,
+  FORCE_BUY_MULTIPLIER_MAX,
+  FORCE_BUY_MULTIPLIER_MIN,
+  FORCE_BUY_POISON_PILL_BONUS,
   HOUSE_PRICE_BOOST,
   PRICE_DELTA_PER_SHARE,
   STOCK_INITIAL_PRICE,
   STOCK_MIN_PRICE,
   STOCK_TOTAL_SHARES,
   calculateDividendPool,
+  calculateForceBuyMultiplier,
   calculateNextPrice,
   createInitialStockMarket,
   distributeDividends,
@@ -370,6 +374,46 @@ describe('reducer P1 拡張', () => {
       const next = gameReducer(state, { type: 'CLOSE_STOCK_DIALOG' });
       expect(next.turnPhase).toBe('endTurn');
     });
+  });
+});
+
+// ── calculateForceBuyMultiplier ──
+
+describe('calculateForceBuyMultiplier', () => {
+  it('家なし(0)で最小乗数を返す', () => {
+    expect(calculateForceBuyMultiplier(0)).toBe(FORCE_BUY_MULTIPLIER_MIN);
+  });
+
+  it('ホテル(5)で最大乗数を返す', () => {
+    expect(calculateForceBuyMultiplier(5)).toBe(FORCE_BUY_MULTIPLIER_MAX);
+  });
+
+  it('家2つで線形補間した乗数を返す', () => {
+    // 3 + (5-3)*2/5 = 3.8
+    expect(calculateForceBuyMultiplier(2)).toBeCloseTo(3.8);
+  });
+
+  it('範囲外の値は端点にクランプされる', () => {
+    expect(calculateForceBuyMultiplier(-1)).toBe(FORCE_BUY_MULTIPLIER_MIN);
+    expect(calculateForceBuyMultiplier(99)).toBe(FORCE_BUY_MULTIPLIER_MAX);
+  });
+
+  it('ポイズンピル有効時は乗数にボーナスが加算される', () => {
+    expect(calculateForceBuyMultiplier(0, true)).toBe(
+      FORCE_BUY_MULTIPLIER_MIN + FORCE_BUY_POISON_PILL_BONUS,
+    );
+  });
+
+  it('ポイズンピル有効時はホテルでも最大+ボーナスを返す', () => {
+    expect(calculateForceBuyMultiplier(5, true)).toBe(
+      FORCE_BUY_MULTIPLIER_MAX + FORCE_BUY_POISON_PILL_BONUS,
+    );
+  });
+
+  it('ポイズンピル無効(false)はデフォルトと同じ動作', () => {
+    expect(calculateForceBuyMultiplier(0, false)).toBe(
+      FORCE_BUY_MULTIPLIER_MIN,
+    );
   });
 });
 

--- a/src/game/__tests__/reducer-actions.test.ts
+++ b/src/game/__tests__/reducer-actions.test.ts
@@ -155,9 +155,9 @@ describe('FINISH_MOVING - handleLanding 各種マス', () => {
     expect(next.turnPhase).toBe('endTurn');
   });
 
-  it('5倍買い可能な額のとき forceBuy フェーズに入る', () => {
+  it('3倍以上買い可能な額のとき forceBuy フェーズに入る', () => {
     let state = startedGame();
-    // baltic (price=60, 5倍=300) を player-1 が所有、player-0 は十分なお金あり
+    // baltic (price=60, 3倍=180) を player-1 が所有、player-0 は十分なお金あり
     state = withPropertyOwner(state, 'baltic', 'player-1');
     state = withCurrentPlayer(state, { position: 0, money: 1000 });
     state = {
@@ -386,7 +386,7 @@ describe('BUILD_HOUSE / SELL_HOUSE', () => {
 // ── FORCE_BUY / DECLINE_FORCE_BUY ──
 
 describe('FORCE_BUY / DECLINE_FORCE_BUY', () => {
-  it('5倍買いで物件を奪える', () => {
+  it('3倍買い（家なし）で物件を奪える', () => {
     let state = startedGame();
     state = withPropertyOwner(state, 'mediterranean', 'player-1');
     state = {
@@ -409,6 +409,31 @@ describe('FORCE_BUY / DECLINE_FORCE_BUY', () => {
     expect(next.turnPhase).toBe('endTurn');
   });
 
+  it('ポイズンピル有効物件の3倍買いはボーナス乗数が適用される', () => {
+    let state = startedGame();
+    state = withPropertyOwner(state, 'mediterranean', 'player-1', {
+      poisonPillActive: true,
+    });
+    state = {
+      ...state,
+      players: state.players.map((p) =>
+        p.id === 'player-1'
+          ? { ...p, properties: ['mediterranean'] }
+          : p.id === 'player-0'
+            ? { ...p, position: 1, money: 2000 }
+            : p,
+      ),
+      turnPhase: 'forceBuy',
+    };
+    const next = gameReducer(state, { type: 'FORCE_BUY' });
+    // ポイズンピル有効: 家なし乗数3倍 + ボーナス1 = 4倍
+    // cost = floor(60 * 4.0) = 240, toOwner = floor(240 * 60%) = 144
+    expect(next.players[0].money).toBe(1760);
+    expect(next.players[1].money).toBe(1644);
+    expect(next.players[0].properties).toContain('mediterranean');
+    expect(next.turnPhase).toBe('endTurn');
+  });
+
   it('DECLINE_FORCE_BUY で endTurn に戻る', () => {
     const state = startedGame();
     const next = gameReducer(
@@ -416,6 +441,45 @@ describe('FORCE_BUY / DECLINE_FORCE_BUY', () => {
       { type: 'DECLINE_FORCE_BUY' },
     );
     expect(next.turnPhase).toBe('endTurn');
+  });
+});
+
+// ── ACTIVATE_POISON_PILL ──
+
+describe('ACTIVATE_POISON_PILL', () => {
+  it('所有物件にポイズンピルを発動できる', () => {
+    let state = startedGame();
+    state = withPropertyOwner(state, 'mediterranean', 'player-0');
+    state = {
+      ...state,
+      players: state.players.map((p) =>
+        p.id === 'player-0' ? { ...p, properties: ['mediterranean'] } : p,
+      ),
+      turnPhase: 'action',
+    };
+    const next = gameReducer(state, {
+      type: 'ACTIVATE_POISON_PILL',
+      propertyId: 'mediterranean',
+    });
+    expect(next.propertyStates['mediterranean'].poisonPillActive).toBe(true);
+    expect(next.turnPhase).toBe('action');
+  });
+
+  it('他プレイヤーの物件にはポイズンピルを発動できない', () => {
+    let state = startedGame();
+    state = withPropertyOwner(state, 'mediterranean', 'player-1');
+    state = {
+      ...state,
+      players: state.players.map((p) =>
+        p.id === 'player-1' ? { ...p, properties: ['mediterranean'] } : p,
+      ),
+      turnPhase: 'action',
+    };
+    const next = gameReducer(state, {
+      type: 'ACTIVATE_POISON_PILL',
+      propertyId: 'mediterranean',
+    });
+    expect(next.propertyStates['mediterranean'].poisonPillActive).toBeFalsy();
   });
 });
 

--- a/src/game/actions.ts
+++ b/src/game/actions.ts
@@ -33,6 +33,7 @@ export type GameAction =
   | { type: 'ROLL_FOR_JAIL' }
   | { type: 'FORCE_BUY' }
   | { type: 'DECLINE_FORCE_BUY' }
+  | { type: 'ACTIVATE_POISON_PILL'; propertyId: string }
   | { type: 'DECLARE_BANKRUPTCY'; creditorId: string | null }
   | { type: 'END_TURN' }
   | { type: 'PAY_TAX' }

--- a/src/game/economy.ts
+++ b/src/game/economy.ts
@@ -180,27 +180,27 @@ export function validateStockSell(
 
 // Phase 1.2 / Phase 3-c 拡張: FORCE_BUY の可変乗数計算（3〜5倍）
 // 物件の開発度（家・ホテルの数）に応じて買収コストが上昇する。
-// 家なし=3倍、ホテル=5倍。ポイズンピル的効果: 増資すると買収が高くなる。
+// 家なし=3倍、ホテル=5倍。ポイズンピル発動時は +FORCE_BUY_POISON_PILL_BONUS の追加ボーナス。
 export const FORCE_BUY_MULTIPLIER_MIN = 3;
 export const FORCE_BUY_MULTIPLIER_MAX = 5;
+export const FORCE_BUY_POISON_PILL_BONUS = 1;
 
 /**
  * FORCE_BUY（強制買収）の可変乗数を計算する。
  *
- * 開発度（家・ホテルの数）に応じて 3〜5 倍へ線形補間する。
- * `houses` は整数 0..5 にクランプされ（0–4 = 家の数、5 = ホテル）、
- * `FORCE_BUY_MULTIPLIER_MIN`（3）から `FORCE_BUY_MULTIPLIER_MAX`（5）の
- * 範囲で値を返す。範囲外の入力は端点に正規化されるため、
- * reducer 側の金額計算でそのまま利用できる。
+ * 開発度（家・ホテルの数）に応じて 3〜5 倍へ線形補間し、
+ * `poisonPillActive` が true の場合は `FORCE_BUY_POISON_PILL_BONUS`（1）を加算する。
  *
- * @param houses 物件の開発度（0..5、整数を想定）。範囲外は 0/5 にクランプされる。
- * @returns 買収倍率（通常 3〜5）。`houses=0` で 3、`houses=5` で 5、その間は線形補間。
+ * @param houses 物件の開発度（0..5）。範囲外は 0/5 にクランプされる。
+ * @param poisonPillActive ポイズンピル防衛が発動中か否か。
  */
-export function calculateForceBuyMultiplier(houses: number): number {
-  // houses: 0-4が家、5がホテル
+export function calculateForceBuyMultiplier(
+  houses: number,
+  poisonPillActive?: boolean,
+): number {
   const normalized = Math.max(0, Math.min(houses, 5));
-  return (
+  const base =
     FORCE_BUY_MULTIPLIER_MIN +
-    ((FORCE_BUY_MULTIPLIER_MAX - FORCE_BUY_MULTIPLIER_MIN) * normalized) / 5
-  );
+    ((FORCE_BUY_MULTIPLIER_MAX - FORCE_BUY_MULTIPLIER_MIN) * normalized) / 5;
+  return base + (poisonPillActive ? FORCE_BUY_POISON_PILL_BONUS : 0);
 }

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -1082,7 +1082,12 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
     case 'ACTIVATE_POISON_PILL': {
       const player = state.players[state.currentPlayerIndex];
       const propState = state.propertyStates[action.propertyId];
-      if (!propState || propState.ownerId !== player.id) return state;
+      if (
+        !propState ||
+        propState.ownerId !== player.id ||
+        propState.poisonPillActive
+      )
+        return state;
       return {
         ...state,
         propertyStates: {

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -314,7 +314,10 @@ function handleLanding(state: GameState): GameState {
       });
 
       // P1.2 拡張: FORCE_BUY 可変乗数（3〜5倍）で買い取り可能かチェック（所持金が足りる場合のみ提示）
-      const forceBuyMultiplier = calculateForceBuyMultiplier(propState.houses);
+      const forceBuyMultiplier = calculateForceBuyMultiplier(
+        propState.houses,
+        propState.poisonPillActive,
+      );
       const forceBuyCost = Math.floor((space.price ?? 0) * forceBuyMultiplier);
       const forceBuyMultiplierDisplay = forceBuyMultiplier.toFixed(1);
       const playerAfterRent = newPlayers.find((p) => p.id === player.id)!;
@@ -1020,8 +1023,11 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
       const propState = state.propertyStates[space.id];
       if (!propState?.ownerId || propState.ownerId === player.id) return state;
 
-      // P1.2 拡張: 開発度（家・ホテル数）に応じた可変乗数（3〜5倍）
-      const multiplier = calculateForceBuyMultiplier(propState.houses);
+      // P1.2 拡張: 開発度（家・ホテル数）に応じた可変乗数（3〜5倍）。ポイズンピル発動時は追加ボーナス
+      const multiplier = calculateForceBuyMultiplier(
+        propState.houses,
+        propState.poisonPillActive,
+      );
       const cost = Math.floor((space.price ?? 0) * multiplier);
       if (player.money < cost) return state;
 
@@ -1070,6 +1076,20 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
 
     case 'DECLINE_FORCE_BUY': {
       return { ...state, turnPhase: 'endTurn' };
+    }
+
+    // ── ACTIVATE_POISON_PILL (ポイズンピル防衛策の発動) ──
+    case 'ACTIVATE_POISON_PILL': {
+      const player = state.players[state.currentPlayerIndex];
+      const propState = state.propertyStates[action.propertyId];
+      if (!propState || propState.ownerId !== player.id) return state;
+      return {
+        ...state,
+        propertyStates: {
+          ...state.propertyStates,
+          [action.propertyId]: { ...propState, poisonPillActive: true },
+        },
+      };
     }
 
     // ── SELL_PROPERTY (オークション形式で売り出し) ──

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -101,6 +101,7 @@ export type PropertyState = {
   ownerId: string | null;
   houses: number; // 0-4, 5=ホテル
   isMortgaged: boolean;
+  poisonPillActive?: boolean;
 };
 
 // ── 競売状態 ──


### PR DESCRIPTION
## 概要

Issue #172 の未実装だった `ACTIVATE_POISON_PILL` アクションを追加し、ポイズンピル防衛策を明示的に発動できるようにしました。

## 関連 Issue / 設計ドキュメント

Closes #172

## 変更内容

- `PropertyState` に `poisonPillActive?: boolean` フラグを追加（`types.ts`）
- `ACTIVATE_POISON_PILL` アクション型を `actions.ts` に追加
- `calculateForceBuyMultiplier(houses, poisonPillActive?)` に第2引数を追加し、発動時に `FORCE_BUY_POISON_PILL_BONUS`（+1）を加算（`economy.ts`）
- reducer に `ACTIVATE_POISON_PILL` ケースを追加（所有者チェック付き）
- `FORCE_BUY` の2箇所の乗数計算で `poisonPillActive` を渡すよう更新（`reducer.ts`）
- テスト名を実仕様に更新（"5倍買い" → "3倍買い（家なし）"）
- `calculateForceBuyMultiplier` の単体テストを `economy.test.ts` に追加（7ケース）
- `ACTIVATE_POISON_PILL` の動作テストを `reducer-actions.test.ts` に追加（2ケース）

## 動作確認

- [x] ローカルで動作確認した
- [x] テストを追加・更新した（107テスト全パス）

## セルフチェック

- [x] `bun run lint` がパスする
- [x] `bun run typecheck` がパスする
- [ ] 破壊的変更がある場合、README または docs を更新した
- [ ] DB マイグレーションがある場合、ロールバック手順を確認した
- [x] secret / 個人情報を含むコードや設定が含まれていない

## デプロイ時の注意

なし

## AIツール・CI/CD連携に関する手動セットアップ（必要な場合のみ）