### PR TITLE
🎨 Palette: オークション入札ボタンのアクセシビリティ改善

### DIFF
--- a/src/components/ActionDialog/AuctionDialog.tsx
+++ b/src/components/ActionDialog/AuctionDialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useId } from 'react';
 import type { AuctionState, Player } from '../../game/types';
 import { BOARD_SPACES } from '../../game/board';
 import { getSpaceById } from '../../game/rules';
@@ -31,6 +31,7 @@ export default function AuctionDialog({
     return dict;
   }, [players]);
 
+  const noMoneyHintId = useId();
   const space = getSpaceById(auction.propertyId, BOARD_SPACES);
   const currentBidder = auction.currentBidderId
     ? playersById[auction.currentBidderId]
@@ -67,7 +68,7 @@ export default function AuctionDialog({
           }
           aria-describedby={
             activePlayer && activePlayer.money < auction.currentBid + 10
-              ? 'auction-no-money-hint'
+              ? noMoneyHintId
               : undefined
           }
         >
@@ -82,7 +83,7 @@ export default function AuctionDialog({
           }
           aria-describedby={
             activePlayer && activePlayer.money < auction.currentBid + 50
-              ? 'auction-no-money-hint'
+              ? noMoneyHintId
               : undefined
           }
         >
@@ -99,7 +100,7 @@ export default function AuctionDialog({
           aria-describedby={
             activePlayer &&
             activePlayer.money < auction.currentBid + MAX_BID_INCREMENT
-              ? 'auction-no-money-hint'
+              ? noMoneyHintId
               : undefined
           }
         >
@@ -111,11 +112,7 @@ export default function AuctionDialog({
       </div>
       {activePlayer &&
         activePlayer.money < auction.currentBid + MAX_BID_INCREMENT && (
-          <div
-            id="auction-no-money-hint"
-            className={styles.noMoneyHint}
-            role="status"
-          >
+          <div id={noMoneyHintId} className={styles.noMoneyHint} role="status">
             {NO_MONEY_HINT_TEXT}
           </div>
         )}

--- a/src/components/ActionDialog/AuctionDialog.tsx
+++ b/src/components/ActionDialog/AuctionDialog.tsx
@@ -61,7 +61,8 @@ export default function AuctionDialog({
         <Button
           size="small"
           onClick={() => onBid(10)}
-          disabled={
+          aria-label="10ドル追加"
+          aria-disabled={
             !activePlayer || activePlayer.money < auction.currentBid + 10
           }
           aria-describedby={
@@ -75,7 +76,8 @@ export default function AuctionDialog({
         <Button
           size="small"
           onClick={() => onBid(50)}
-          disabled={
+          aria-label="50ドル追加"
+          aria-disabled={
             !activePlayer || activePlayer.money < auction.currentBid + 50
           }
           aria-describedby={
@@ -89,7 +91,8 @@ export default function AuctionDialog({
         <Button
           size="small"
           onClick={() => onBid(MAX_BID_INCREMENT)}
-          disabled={
+          aria-label={`${MAX_BID_INCREMENT}ドル追加`}
+          aria-disabled={
             !activePlayer ||
             activePlayer.money < auction.currentBid + MAX_BID_INCREMENT
           }


### PR DESCRIPTION
💡 **What:**
- Replaced native `disabled` attribute with `aria-disabled` on the bid buttons in the `AuctionDialog` component.
- Added explicit `aria-label`s to the bid buttons (`10ドル追加`, `50ドル追加`, `100ドル追加`).
- Created `.jules/palette.md` to journal the accessibility learning regarding `disabled` vs `aria-disabled` in combination with `aria-describedby`.

🎯 **Why:**
- When a button uses the native `disabled` attribute, it is removed from the keyboard focus order. Consequently, screen reader users cannot focus on the button to hear the helpful contextual hint provided by `aria-describedby` (such as "おかねがたりないよ" when funds are insufficient).
- By switching to `aria-disabled="true"`, the buttons remain focusable, allowing the screen reader to announce both the button's purpose and the reason it is currently inactive.
- The `Button` component internally prevents `onClick` from firing when `aria-disabled` is active, ensuring no functional regressions occur (e.g., players cannot bid without enough money).
- Screen readers may struggle to pronounce symbolic text like `+$10` clearly. Adding an explicit `aria-label` ensures a clear and unambiguous announcement (e.g., "10ドル追加").

♿ **Accessibility:**
- Improved keyboard accessibility and screen reader context for disabled actions.
- Clarified button actions for assistive technologies.

---
*PR created automatically by Jules for task [17298935524032359342](https://jules.google.com/task/17298935524032359342) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * オークションダイアログのアクセシビリティを向上しました。通知メッセージとビッドボタン間の関連性が適切に認識されるよう改善し、スクリーンリーダーとの互換性を高めました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->