### PR TITLE
chore(ai): 🎨 Palette: Setup画面のボタンアクセシビリティを改善

### DIFF
--- a/src/components/Setup/Setup.module.css
+++ b/src/components/Setup/Setup.module.css
@@ -44,8 +44,10 @@
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
-.countButton:disabled {
+.countButton:disabled,
+.countButton[aria-disabled='true'] {
   opacity: 0.3;
+  cursor: not-allowed;
 }
 .playerList {
   width: 100%;
@@ -95,7 +97,8 @@
 .startButton {
   margin-top: 16px;
 }
-.startButton:disabled {
+.startButton:disabled,
+.startButton[aria-disabled='true'] {
   opacity: 0.5;
   cursor: not-allowed;
 }

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -155,8 +155,14 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
       <div className={styles.playerCount}>
         <button
           className={styles.countButton}
-          onClick={() => setPlayerCount((c) => c - 1)}
-          disabled={playerCount <= MIN_PLAYERS}
+          onClick={(e) => {
+            if (playerCount <= MIN_PLAYERS) {
+              e.preventDefault();
+              return;
+            }
+            setPlayerCount((c) => c - 1);
+          }}
+          aria-disabled={playerCount <= MIN_PLAYERS}
           aria-label="プレイヤーを減らす"
           aria-describedby={
             playerCount <= MIN_PLAYERS
@@ -169,8 +175,14 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
         <span role="status">{playerCount}人であそぶ</span>
         <button
           className={styles.countButton}
-          onClick={() => setPlayerCount((c) => c + 1)}
-          disabled={playerCount >= MAX_PLAYERS}
+          onClick={(e) => {
+            if (playerCount >= MAX_PLAYERS) {
+              e.preventDefault();
+              return;
+            }
+            setPlayerCount((c) => c + 1);
+          }}
+          aria-disabled={playerCount >= MAX_PLAYERS}
           aria-label="プレイヤーを増やす"
           aria-describedby={
             playerCount >= MAX_PLAYERS
@@ -274,14 +286,18 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
       <Button
         size="large"
         className={styles.startButton}
-        onClick={() =>
+        onClick={(e) => {
+          if (!canStart) {
+            e.preventDefault();
+            return;
+          }
           onStart(
             names.slice(0, playerCount),
             selectedTokens.slice(0, playerCount),
             features,
-          )
-        }
-        disabled={!canStart}
+          );
+        }}
+        aria-disabled={!canStart}
         title={!canStart ? START_GUIDE_MSG : undefined}
         aria-describedby={!canStart ? 'start-hint' : undefined}
       >

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -301,13 +301,13 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
         }}
         aria-disabled={!canStart}
         title={!canStart ? START_GUIDE_MSG : undefined}
-        aria-describedby={!canStart ? 'start-hint' : undefined}
+        aria-describedby={!canStart ? `${baseId}-start-hint` : undefined}
       >
         ゲームスタート！
       </Button>
       {!canStart && (
         <p
-          id="start-hint"
+          id={`${baseId}-start-hint`}
           className={styles.startHint}
           role="status"
           aria-live="polite"

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -158,6 +158,7 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
           onClick={(e) => {
             if (playerCount <= MIN_PLAYERS) {
               e.preventDefault();
+              e.stopPropagation();
               return;
             }
             setPlayerCount((c) => c - 1);
@@ -178,6 +179,7 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
           onClick={(e) => {
             if (playerCount >= MAX_PLAYERS) {
               e.preventDefault();
+              e.stopPropagation();
               return;
             }
             setPlayerCount((c) => c + 1);

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -288,17 +288,13 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
       <Button
         size="large"
         className={styles.startButton}
-        onClick={(e) => {
-          if (!canStart) {
-            e.preventDefault();
-            return;
-          }
+        onClick={() =>
           onStart(
             names.slice(0, playerCount),
             selectedTokens.slice(0, playerCount),
             features,
-          );
-        }}
+          )
+        }
         aria-disabled={!canStart}
         title={!canStart ? START_GUIDE_MSG : undefined}
         aria-describedby={!canStart ? `${baseId}-start-hint` : undefined}


### PR DESCRIPTION
**💡 What**: Setup画面における「プレイヤー数の増減ボタン」および「ゲームスタート」ボタンの非活性状態の実装を、ネイティブの `disabled` 属性から `aria-disabled` 属性へと置き換えました。併せて、クリックイベントをブロックするロジックとCSSの無効化スタイルを追加しました。

**🎯 Why**: ネイティブの `disabled` 属性を使用すると、ボタンがフォーカスから外れてしまうため、スクリーンリーダーやキーボードユーザーが `aria-describedby` 属性による「なぜそのボタンが押せないのか」という説明テキストにアクセスできなくなる問題がありました。`aria-disabled` を使用することで、フォーカス可能な状態を保ちつつ論理的に無効化し、アクセシビリティを大きく向上させます。

**♿ Accessibility**:
*   無効状態のボタンがタブ移動のフローに残るようになりました。
*   スクリーンリーダーが「ゲームスタート」が押せない理由（例: プレイヤー名を入力してください）を適切に読み上げられるようになります。

**📝 Learnings**:
インタラクティブな要素に `aria-describedby` による説明が含まれている場合、ネイティブの `disabled` を使用するのではなく、`aria-disabled` とイベントハンドラーの条件分岐を組み合わせることで、より優れたUXを提供できることを学び、`.jules/palette.md` に記録しました。

---
*PR created automatically by Jules for task [18411376814863921079](https://jules.google.com/task/18411376814863921079) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * プレイヤー数調整ボタンで上限/下限到達時の余分な操作を確実に抑止するようにしました。
  * ゲーム開始ボタンが意図せず動作するケースを防止しました。

* **Style**
  * 無効状態のボタン表示を aria-disabled を含む条件にも拡張し、見た目と操作性を一貫させました。
  * 非活性時のヒント表示と関連属性を改善し、アクセシビリティを向上しました.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->