### PR TITLE
chore(security): 🔒 github/codeql-action/upload-sarif の SHA ピン留めによるサプライチェーン攻撃対策強化

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: 'osv-scanner.sarif'
           category: osv-scanner

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,5 +1,0 @@
-## 2025-02-15 - [Pin Action SHAs to Prevent Supply Chain Attacks]
-
-**Vulnerability:** Third-party GitHub Actions like `github/codeql-action/upload-sarif` were referenced via mutable version tags (e.g., `@v4`) rather than immutable commit SHAs.
-**Learning:** Mutable tags can be moved by malicious actors if they compromise the upstream repository, leading to the execution of untrusted code in our CI/CD pipelines (a supply chain attack).
-**Prevention:** Always pin third-party actions to an exact 40-character commit SHA (e.g., `@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4`) to ensure immutability and reproducibility.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,4 +2,4 @@
 
 **Vulnerability:** Third-party GitHub Actions like `github/codeql-action/upload-sarif` were referenced via mutable version tags (e.g., `@v4`) rather than immutable commit SHAs.
 **Learning:** Mutable tags can be moved by malicious actors if they compromise the upstream repository, leading to the execution of untrusted code in our CI/CD pipelines (a supply chain attack).
-**Prevention:** Always pin third-party actions to an exact 40-character commit SHA (e.g., `@8aad20d5b1a6162244f4afe5362d3140e1422245 # v4`) to ensure immutability and reproducibility.
+**Prevention:** Always pin third-party actions to an exact 40-character commit SHA (e.g., `@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4`) to ensure immutability and reproducibility.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,4 +2,4 @@
 
 **Vulnerability:** Third-party GitHub Actions like `github/codeql-action/upload-sarif` were referenced via mutable version tags (e.g., `@v4`) rather than immutable commit SHAs.
 **Learning:** Mutable tags can be moved by malicious actors if they compromise the upstream repository, leading to the execution of untrusted code in our CI/CD pipelines (a supply chain attack).
-**Prevention:** Always pin third-party actions to an exact 40-character commit SHA (e.g., `@8aad20d... # v4`) to ensure immutability and reproducibility.
+**Prevention:** Always pin third-party actions to an exact 40-character commit SHA (e.g., `@8aad20d5b1a6162244f4afe5362d3140e1422245 # v4`) to ensure immutability and reproducibility.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,5 @@
 ## 2025-02-15 - [Pin Action SHAs to Prevent Supply Chain Attacks]
+
 **Vulnerability:** Third-party GitHub Actions like `github/codeql-action/upload-sarif` were referenced via mutable version tags (e.g., `@v4`) rather than immutable commit SHAs.
 **Learning:** Mutable tags can be moved by malicious actors if they compromise the upstream repository, leading to the execution of untrusted code in our CI/CD pipelines (a supply chain attack).
 **Prevention:** Always pin third-party actions to an exact 40-character commit SHA (e.g., `@8aad20d... # v4`) to ensure immutability and reproducibility.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-15 - [Pin Action SHAs to Prevent Supply Chain Attacks]
+**Vulnerability:** Third-party GitHub Actions like `github/codeql-action/upload-sarif` were referenced via mutable version tags (e.g., `@v4`) rather than immutable commit SHAs.
+**Learning:** Mutable tags can be moved by malicious actors if they compromise the upstream repository, leading to the execution of untrusted code in our CI/CD pipelines (a supply chain attack).
+**Prevention:** Always pin third-party actions to an exact 40-character commit SHA (e.g., `@8aad20d... # v4`) to ensure immutability and reproducibility.


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `.github/workflows/osv-scanner.yml` にてサードパーティのアクション (`github/codeql-action/upload-sarif`) がミュータブルなバージョンタグ (`@v4`) で参照されていました。
🎯 Impact: アップストリームのリポジトリが侵害された場合、タグが移動されて不正なコードがCI上で実行されるおそれがありました（サプライチェーン攻撃リスク）。
🔧 Fix: バージョン指定を `v4` から、対応する不変な40桁のコミット SHA に置き換えました。
✅ Verification: `cat .github/workflows/osv-scanner.yml` を用いて、アクションが正しくSHAで参照されていることを確認し、またすべてのテストにパスすることを確認しました。

---
*PR created automatically by Jules for task [9046261890277729708](https://jules.google.com/task/9046261890277729708) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * SARIF アップロードを行うワークフローで、使用するアクション参照を可変タグから特定のコミットへ更新し、供給網リスクを低減しました。
  * 外部 GitHub Actions は immutable なコミットSHAへ固定するべき、というセキュリティ注意喚起を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->