### PR TITLE
🎨 Palette: 無効化されたボタンのスクリーンリーダー・アクセシビリティの改善

### DIFF
--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -78,6 +78,7 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
     isPurchasable && !state.propertyStates[currentSpace.id]?.ownerId;
 
   const handleRoll = () => {
+    if (isRolling) return;
     // Capture position before dispatch changes state
     positionRef.current = currentPlayer.position;
     play('diceRoll');
@@ -167,6 +168,7 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
   };
 
   const handleRollForJail = () => {
+    if (isRolling) return;
     // 脱出時のアニメーションのため、現在位置をキャプチャ
     positionRef.current = currentPlayer.position;
     play('diceRoll');
@@ -304,7 +306,7 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
               <Button
                 size="large"
                 onClick={handleRoll}
-                disabled={isRolling}
+                aria-disabled={isRolling}
                 aria-describedby={isRolling ? rollingHintId : undefined}
               >
                 🎲 さいころをふる！

--- a/src/components/PlayerPanel/PlayerPanel.module.css
+++ b/src/components/PlayerPanel/PlayerPanel.module.css
@@ -34,3 +34,10 @@
 .jailBadge {
   font-size: 12px;
 }
+.playerChip[aria-disabled='true'] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.playerChip[aria-disabled='true']:active {
+  pointer-events: none;
+}

--- a/src/components/PlayerPanel/PlayerPanel.module.css
+++ b/src/components/PlayerPanel/PlayerPanel.module.css
@@ -38,6 +38,3 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
-.playerChip[aria-disabled='true']:active {
-  pointer-events: none;
-}

--- a/src/components/PlayerPanel/PlayerPanel.tsx
+++ b/src/components/PlayerPanel/PlayerPanel.tsx
@@ -29,8 +29,13 @@ const PlayerPanel = memo(function PlayerPanel({
           aria-current={idx === currentPlayerIndex ? 'true' : 'false'}
           aria-disabled={!onPlayerClick}
           className={`${styles.playerChip} ${idx === currentPlayerIndex ? styles.playerChipActive : ''} ${player.isBankrupt ? styles.playerChipBankrupt : ''}`}
-          disabled={!onPlayerClick}
-          onClick={() => onPlayerClick?.(player.id)}
+          onClick={(e) => {
+            if (!onPlayerClick) {
+              e.preventDefault();
+              return;
+            }
+            onPlayerClick(player.id);
+          }}
           style={{ background: getOwnerBg(player.id) }}
           title={onPlayerClick ? `${player.name}の詳細を見る` : undefined}
         >

--- a/src/components/PlayerPanel/PlayerPanel.tsx
+++ b/src/components/PlayerPanel/PlayerPanel.tsx
@@ -32,6 +32,7 @@ const PlayerPanel = memo(function PlayerPanel({
           onClick={(e) => {
             if (!onPlayerClick) {
               e.preventDefault();
+              e.stopPropagation();
               return;
             }
             onPlayerClick(player.id);


### PR DESCRIPTION
💡 What: disabled属性を使用していたボタン（GameBoardのサイコロボタン、PlayerPanelのプレイヤーボタン）をaria-disabledに変更し、クリックを防ぐロジックとスタイリングを追加しました。
🎯 Why: ネイティブのdisabled属性を使用すると要素がフォーカス対象から外れ、aria-describedbyによる追加説明がスクリーンリーダーで読み上げられなくなるため。
📸 Before/After: 見た目に変更はありません。
♿ Accessibility: サイコロを振っている最中の状態や、クリックできない状態のプレイヤーボタンの詳細説明がスクリーンリーダーから正しく読み上げられるようになりました。

---
*PR created automatically by Jules for task [18329696925342356533](https://jules.google.com/task/18329696925342356533) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * さいころを振る処理の二重実行を防止しました。

* **改善**
  * ボタンや操作要素の無効状態の表示と操作性を改善しました。
  * アクセシビリティ対応を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->