### PR TITLE
fix(setup): 🐛 セットアップ画面を縦スクロール可能にしスタートボタンを名前入力欄の直下へ移動

### DIFF
--- a/src/components/Setup/Setup.module.css
+++ b/src/components/Setup/Setup.module.css
@@ -1,9 +1,12 @@
 .setup {
   height: 100%;
+  /* 内容がビューポートより縦長の場合に縦スクロールを許可する */
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  /* 内容が溢れたときは上端を切らず flex-start に退避する (safe) */
+  justify-content: safe center;
   padding: 24px;
   gap: 24px;
 }

--- a/src/components/Setup/Setup.module.css
+++ b/src/components/Setup/Setup.module.css
@@ -6,6 +6,8 @@
   flex-direction: column;
   align-items: center;
   /* 内容が溢れたときは上端を切らず flex-start に退避する (safe) */
+  /* safe center 非対応ブラウザ向けに通常の center を先に記述してフォールバックする */
+  justify-content: center;
   justify-content: safe center;
   padding: 24px;
   gap: 24px;

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -253,6 +253,34 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
           </div>
         ))}
       </div>
+
+      <Button
+        size="large"
+        className={styles.startButton}
+        onClick={() =>
+          onStart(
+            names.slice(0, playerCount),
+            selectedTokens.slice(0, playerCount),
+            features,
+          )
+        }
+        aria-disabled={!canStart}
+        title={!canStart ? START_GUIDE_MSG : undefined}
+        aria-describedby={!canStart ? `${baseId}-start-hint` : undefined}
+      >
+        ゲームスタート！
+      </Button>
+      {!canStart && (
+        <p
+          id={`${baseId}-start-hint`}
+          className={styles.startHint}
+          role="status"
+          aria-live="polite"
+        >
+          {START_GUIDE_MSG}
+        </p>
+      )}
+
       <div className={styles.subtitle}>
         アイコンをタップしてコマをえらべるよ
       </div>
@@ -284,33 +312,6 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
           );
         })}
       </fieldset>
-
-      <Button
-        size="large"
-        className={styles.startButton}
-        onClick={() =>
-          onStart(
-            names.slice(0, playerCount),
-            selectedTokens.slice(0, playerCount),
-            features,
-          )
-        }
-        aria-disabled={!canStart}
-        title={!canStart ? START_GUIDE_MSG : undefined}
-        aria-describedby={!canStart ? `${baseId}-start-hint` : undefined}
-      >
-        ゲームスタート！
-      </Button>
-      {!canStart && (
-        <p
-          id={`${baseId}-start-hint`}
-          className={styles.startHint}
-          role="status"
-          aria-live="polite"
-        >
-          {START_GUIDE_MSG}
-        </p>
-      )}
     </div>
   );
 }

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -278,7 +278,6 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
           id={`${baseId}-start-hint`}
           className={styles.startHint}
           role="status"
-          aria-live="polite"
         >
           {START_GUIDE_MSG}
         </p>

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -215,6 +215,9 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
           これ以上増やせません
         </span>
       )}
+      <div className={styles.subtitle}>
+        アイコンをタップしてコマをえらべるよ
+      </div>
       <div className={styles.playerList}>
         {Array.from({ length: playerCount }).map((_, i) => (
           <div key={i} className={styles.playerRow}>
@@ -280,10 +283,6 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
           {START_GUIDE_MSG}
         </p>
       )}
-
-      <div className={styles.subtitle}>
-        アイコンをタップしてコマをえらべるよ
-      </div>
 
       {/* P1 拡張: 機能トグル */}
       <fieldset className={styles.featureSection}>


### PR DESCRIPTION
## 概要

最初に表示されるセットアップ画面が縦長の場合に縦スクロールできず、人数変更やゲーム開始ボタンが操作できない問題を修正します。あわせてゲームスタートボタンをプレイヤー名入力欄の直下へ移動します。

## 変更内容

- `.setup` に `overflow-y: auto` を付与し、内容がビューポートより縦長のときに縦スクロールを許可
- `justify-content: center` を `safe center` に変更し、内容が溢れたときも上端を切らず `flex-start` に退避（中央寄せは維持）
- 「ゲームスタート！」ボタン（および未入力時ヒント）をプレイヤー名入力欄の直下へ移動。コマ説明・拡張機能トグルなどの設定はボタンの下に配置

## 技術的な選択理由

`#root` の `overflow: hidden` はゲーム本編のレイアウトに必要なため変更せず、セットアップ画面の `.setup` 自体をスクロールコンテナにすることでグローバルへの影響を避けています。`justify-content: center` 単体では内容がコンテナを超えた際に上端が切れてスクロールでも到達できないため、`safe` キーワードで `flex-start` に退避させています。

## テスト

- [x] `bun run typecheck` がパス
- [ ] ウィンドウ高を縮めた状態でセットアップ画面が縦スクロールでき、人数変更・ゲーム開始ボタンが操作可能
- [ ] ゲームスタートボタンが名前入力欄の直下に表示され、設定がその下に配置される

## 関連Issue

なし