### PR TITLE
🎨 Palette: [UX improvement] 借入・返済ボタンをアクセシブルにし、無効時の理由を明示

### DIFF
--- a/src/components/ActionDialog/LoanDialog.tsx
+++ b/src/components/ActionDialog/LoanDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useId } from 'react';
 import type { GameState, Player } from '../../game/types';
 import type { LoanType } from '../../game/systems/loan';
 import {
@@ -30,6 +30,8 @@ export default function LoanDialog({
   const [loanType, setLoanType] = useState<LoanType>('variable');
   const [borrowAmount, setBorrowAmount] = useState('');
   const [repayAmount, setRepayAmount] = useState('');
+  const borrowHintId = useId();
+  const repayHintId = useId();
 
   const totalAssets = calculateTotalAssets(
     currentPlayer,
@@ -153,13 +155,19 @@ export default function LoanDialog({
                     }
                   }}
                   aria-disabled={!canBorrow}
-                  aria-describedby={!canBorrow ? 'loan-borrow-hint' : undefined}
+                  aria-describedby={
+                    !canBorrow && borrowAmount !== '' ? borrowHintId : undefined
+                  }
                 >
                   かりる
                 </Button>
               </div>
               {!canBorrow && borrowAmount !== '' && (
-                <div id="loan-borrow-hint" className={styles.noMoneyHintTight}>
+                <div
+                  id={borrowHintId}
+                  className={styles.noMoneyHintTight}
+                  role="status"
+                >
                   かりられる上限をこえているか、正しくないよ
                 </div>
               )}
@@ -193,14 +201,18 @@ export default function LoanDialog({
                     }
                   }}
                   aria-disabled={!canRepay}
-                  aria-describedby={!canRepay ? 'loan-repay-hint' : undefined}
+                  aria-describedby={
+                    !canRepay && repayAmount !== '' ? repayHintId : undefined
+                  }
                 >
                   返済する
                 </Button>
               </div>
-              {(!canRepay && repayAmount !== '') && (
+              {!canRepay && repayAmount !== '' && (
                 <div id="loan-repay-hint" className={styles.noMoneyHintTight}>
-                  {parsedRepay > currentPlayer.money ? 'おかねがたりないよ' : '正しく入力してね'}
+                  {parsedRepay > currentPlayer.money
+                    ? 'おかねがたりないよ'
+                    : '正しく入力してね'}
                 </div>
               )}
             </div>

--- a/src/components/ActionDialog/LoanDialog.tsx
+++ b/src/components/ActionDialog/LoanDialog.tsx
@@ -152,11 +152,17 @@ export default function LoanDialog({
                       setBorrowAmount('');
                     }
                   }}
-                  disabled={!canBorrow}
+                  aria-disabled={!canBorrow}
+                  aria-describedby={!canBorrow ? 'loan-borrow-hint' : undefined}
                 >
                   かりる
                 </Button>
               </div>
+              {!canBorrow && borrowAmount !== '' && (
+                <div id="loan-borrow-hint" className={styles.noMoneyHintTight}>
+                  かりられる上限をこえているか、正しくないよ
+                </div>
+              )}
             </div>
           </div>
         )}
@@ -186,14 +192,15 @@ export default function LoanDialog({
                       setRepayAmount('');
                     }
                   }}
-                  disabled={!canRepay}
+                  aria-disabled={!canRepay}
+                  aria-describedby={!canRepay ? 'loan-repay-hint' : undefined}
                 >
                   返済する
                 </Button>
               </div>
-              {parsedRepay > currentPlayer.money && (
-                <div className={styles.noMoneyHintTight}>
-                  おかねがたりないよ
+              {(!canRepay && repayAmount !== '') && (
+                <div id="loan-repay-hint" className={styles.noMoneyHintTight}>
+                  {parsedRepay > currentPlayer.money ? 'おかねがたりないよ' : '正しく入力してね'}
                 </div>
               )}
             </div>

--- a/src/components/ActionDialog/LoanDialog.tsx
+++ b/src/components/ActionDialog/LoanDialog.tsx
@@ -209,7 +209,7 @@ export default function LoanDialog({
                 </Button>
               </div>
               {!canRepay && repayAmount !== '' && (
-                <div id="loan-repay-hint" className={styles.noMoneyHintTight}>
+                <div id={repayHintId} className={styles.noMoneyHintTight}>
                   {parsedRepay > currentPlayer.money
                     ? 'おかねがたりないよ'
                     : '正しく入力してね'}


### PR DESCRIPTION
## 💡 What:
`LoanDialog`（ローン・返済ダイアログ）の「かりる」「返済する」ボタンにおいて、ネイティブの `disabled` 属性を `aria-disabled="true"` に変更し、ボタンが無効化されている理由を説明するインラインヒントを追加しました。ヒントは `aria-describedby` でボタンと紐付けています。

## 🎯 Why:
ネイティブの `disabled` 属性はキーボードフォーカスを完全に外してしまうため、スクリーンリーダーユーザーが「なぜ操作できないのか」を把握できなくなります。
`aria-disabled` を用いてフォーカスを維持しつつ、動的にレンダリングされるヒントテキスト（「かりられる上限をこえているか、正しくないよ」「おかねがたりないよ」など）を `aria-describedby` で関連付けることで、誰もが直感的に状態を理解できるアクセシブルな設計を実現しました。

## 📸 Before/After:
*   **Before:** 無効化されたボタンはフォーカスできず、無効な金額を入力してもフィードバックがありませんでした。
*   **After:** 無効化されたボタンにもフォーカスが可能になり、金額が不正な場合はボタンの直下に赤いヒントテキストが表示され、スクリーンリーダーでも読み上げられます。

## ♿ Accessibility:
*   `disabled` から `aria-disabled="true"` への移行によるキーボード操作の担保。
*   無効な入力に対するリアルタイムのフィードバックメッセージの追加と、`aria-describedby` によるコンテキストの提供。

---
*PR created automatically by Jules for task [7307297882054049923](https://jules.google.com/task/7307297882054049923) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ローンダイアログの「借りる」「返済する」ボタンが無効で、入力がある場合に表示されるヒント文言を更新しました。無効時の案内を「借りられる上限をこえているか、正しくないよ」に変更し、状況が分かりやすくなりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->