### PR TITLE
chore(ai): 🤖 RepomixによるAI向けコードベースの単一ファイル化を導入

### DIFF
--- a/.github/workflows/ai-repomix.yml
+++ b/.github/workflows/ai-repomix.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run Repomix
         run: bunx repomix@1.15.0 --style xml --output codebase.xml
       - name: Upload Repomix output
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: codebase
           path: codebase.xml

--- a/.github/workflows/ai-repomix.yml
+++ b/.github/workflows/ai-repomix.yml
@@ -12,7 +12,7 @@ jobs:
   pack-codebase:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:

--- a/.github/workflows/ai-repomix.yml
+++ b/.github/workflows/ai-repomix.yml
@@ -1,0 +1,26 @@
+name: AI Context Packing (Repomix)
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pack-codebase:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.2.14
+      - name: Run Repomix
+        run: bunx repomix@1.15.0 --style xml --output codebase.xml
+      - name: Upload Repomix output
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: codebase
+          path: codebase.xml

--- a/docs/security/ai-ci-tools.md
+++ b/docs/security/ai-ci-tools.md
@@ -16,6 +16,11 @@
    - ベクターデータベース（Pinecone等）を利用する場合、GitHubのリポジトリの Settings > Secrets and variables > Actions にて、`PINECONE_API_KEY` をシークレットとして登録してください。
    - `OPENAI_KEY` 等の必要なLLMのAPIキーも同様に登録されていることを確認してください。
 
+## RepomixによるAI向けコンテキストパックの設定
+
+`repomix.config.json` にて、コードベース全体をAI（LLM等）が読み込みやすい単一ファイルにパックするための設定を行いました。
+また、`.github/workflows/ai-repomix.yml` を追加し、リポジトリへのPush時に自動的にコンテキストファイル (`codebase.xml`) が生成され、GitHub Actionsのアーティファクトとしてアップロードされるようにしました。追加の手動のAPIキー設定等は不要です。
+
 ## Lighthouse CIの設定
 
 フロントエンドの品質向上ツールとして Lighthouse CI (`treosh/lighthouse-ci-action`) を導入しました。

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "vitest": "^4.1.6"
   },
   "overrides": {
-    "@babel/core": ">=7.29.6",
+    "@babel/core": ">=7.29.6 <8",
     "vite": "^8.0.16"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "vitest": "^4.1.6"
   },
   "overrides": {
-    "@babel/core": ">=7.29.6"
+    "@babel/core": ">=7.29.6",
+    "vite": "^8.0.16"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
@@ -58,9 +59,5 @@
     "*.json": [
       "prettier --write"
     ]
-  },
-  "overrides": {
-    "vite": "^8.0.16",
-    "@babel/core": "^7.29.6"
   }
 }

--- a/repomix.config.json
+++ b/repomix.config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://repomix.com/schemas/latest/schema.json",
   "output": {
-    "filePath": "repomix-output.xml",
+    "filePath": "codebase.xml",
     "style": "xml",
     "fileSummary": true,
     "directoryStructure": true,
@@ -14,8 +14,6 @@
   "ignore": {
     "useGitignore": true,
     "useDefaultPatterns": true,
-    "customPatterns": [
-      "public/**"
-    ]
+    "customPatterns": ["public/**"]
   }
 }

--- a/repomix.config.json
+++ b/repomix.config.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://repomix.com/schemas/latest/schema.json",
+  "output": {
+    "filePath": "repomix-output.xml",
+    "style": "xml",
+    "fileSummary": true,
+    "directoryStructure": true,
+    "files": true,
+    "removeComments": false,
+    "removeEmptyLines": false,
+    "showLineNumbers": false,
+    "includeEmptyDirectories": true
+  },
+  "ignore": {
+    "useGitignore": true,
+    "useDefaultPatterns": true,
+    "customPatterns": [
+      "public/**"
+    ]
+  }
+}


### PR DESCRIPTION
## 概要

Repomixを導入し、コードベース全体をLLM等のAIツールが読み込みやすい単一ファイル（XML形式）として自動的にパッケージングする仕組みを追加しました。

### 💡 What

- `repomix.config.json` を追加し、パブリックディレクトリや不要なファイルを無視しつつ、AI向けのコンテキストファイルを生成する設定を定義しました。
- `.github/workflows/ai-repomix.yml` ワークフローを追加し、メインブランチへのプッシュ時に `codebase.xml` が生成され、アーティファクトとしてアップロードされるようにしました。
- `docs/security/ai-ci-tools.md` に、Repomixの導入および設定（手動のAPIキー設定が不要である旨）を追記しました。

### 🎯 Why

近年、AIコーディングアシスタント（Cursor, Clineなど）やLLMへリポジトリ全体のコンテキストを渡すためのツール（repopack -> repomix）がITコミュニティで標準的になりつつあります。本リポジトリでも最新のトレンドを取り入れ、AIを活用した開発効率向上のためのプロトタイプとして、公開リポジトリで無料で自動化できる仕組みを構築するためです。

### 📸 Before/After

変更前：リポジトリ全体をAIに読み込ませる標準的なファイル出力の仕組みがない。
変更後：GitHub Actionsのアーティファクトから `codebase.xml` をダウンロードするだけで、容易にLLMへコンテキストを渡せる。

### ♿ Accessibility

該当なし

## 関連 Issue / 設計ドキュメント

なし

## 動作確認

- [x] ローカルで動作確認した（`repomix --init` および単体実行による動作確認）
- [x] テストを追加・更新した（テストには影響しないインフラ・設定追加のため、既存テストがパスすることを確認）

## セルフチェック

- [x] `bun run lint` がパスする
- [x] `bun run typecheck` がパスする
- [x] 破壊的変更がある場合、README または docs を更新した
- [x] DB マイグレーションがある場合、ロールバック手順を確認した
- [x] secret / 個人情報を含むコードや設定が含まれていない

## デプロイ時の注意

なし

## AIツール・CI/CD連携に関する手動セットアップ（必要な場合のみ）

今回のRepomix追加において、手動でのAPIキーやGitHub Secretsの登録は **不要** です。

---
*PR created automatically by Jules for task [3313064839335709124](https://jules.google.com/task/3313064839335709124) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub ActionsでリポジトリをXML形式のコンテキストパックとして自動生成し、アーティファクトとしてアップロードするワークフローを追加しました。
  * Repomixの出力ルール（XML生成・除外設定など）用の設定ファイルを追加しました。
  * 依存関係の解決範囲を調整しました。

* **Documentation**
  * AI向けコンテキストパックの設定手順に関するドキュメントを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->