### PR TITLE
🛡️ Sentinel: [MEDIUM] 数値入力の文字数制限によるDoS対策

### DIFF
--- a/src/components/ActionDialog/LoanDialog.tsx
+++ b/src/components/ActionDialog/LoanDialog.tsx
@@ -139,7 +139,10 @@ export default function LoanDialog({
                   min={1}
                   max={maxBorrow}
                   value={borrowAmount}
-                  onChange={(e) => setBorrowAmount(e.target.value)}
+                  onChange={(e) => {
+                    const raw = e.target.value;
+                    if (raw.length <= 6) setBorrowAmount(raw);
+                  }}
                   placeholder={`最大 $${maxBorrow}`}
                   style={{ width: 120 }}
                   aria-label="借入金額"
@@ -172,7 +175,10 @@ export default function LoanDialog({
                   min={1}
                   max={Math.min(loanBalance, currentPlayer.money)}
                   value={repayAmount}
-                  onChange={(e) => setRepayAmount(e.target.value)}
+                  onChange={(e) => {
+                    const raw = e.target.value;
+                    if (raw.length <= 6) setRepayAmount(raw);
+                  }}
                   placeholder={`残高 $${loanBalance}`}
                   style={{ width: 120 }}
                   aria-label="返済金額"

--- a/src/components/ActionDialog/LoanDialog.tsx
+++ b/src/components/ActionDialog/LoanDialog.tsx
@@ -141,7 +141,7 @@ export default function LoanDialog({
                   value={borrowAmount}
                   onChange={(e) => {
                     const raw = e.target.value;
-                    if (raw.length <= 6) setBorrowAmount(raw);
+                    if ([...raw].length <= 6) setBorrowAmount(raw);
                   }}
                   placeholder={`最大 $${maxBorrow}`}
                   style={{ width: 120 }}
@@ -177,7 +177,7 @@ export default function LoanDialog({
                   value={repayAmount}
                   onChange={(e) => {
                     const raw = e.target.value;
-                    if (raw.length <= 6) setRepayAmount(raw);
+                    if ([...raw].length <= 6) setRepayAmount(raw);
                   }}
                   placeholder={`残高 $${loanBalance}`}
                   style={{ width: 120 }}


### PR DESCRIPTION
## 💡 What:
Reactの数値入力（`LoanDialog.tsx` の `borrowAmount` および `repayAmount`）に対して、`e.target.value` の直接更新を防ぐため最大文字数（6文字）のバリデーションを追加し、さらに今回のセキュリティに関する学びを `.jules/sentinel.md` に記録しました。

## 🎯 Why:
`<input type="number">` と `max` 属性を使用していても、ブラウザによっては極端に長い文字列（ペーストなど）がパース前に `e.target.value` として渡される可能性があります。これがそのままReactのステートに保存されて `Number()` 等で評価されると、メモリのスパイクやDoSのリスクとなるため、`e.target.value` の文字数を制限する防御的な実装が必要でした。（参考: `TradeDialog.tsx` の類似実装）

## 📸 Before/After:
*   **Before:** `LoanDialog` の借入・返済金額入力欄で、任意の長さの文字列が状態としてセットされる可能性があった。
*   **After:** 入力欄で `e.target.value` が6文字以下の場合のみ状態が更新されるようになり、極端な長さの入力をブロックできるようになった。

## 🚨 Security Scope:
*   Severity: MEDIUM
*   Vulnerability: 状態に保持される数値入力に対する長さの制限の欠如によるDoSやメモリスパイクのリスク
*   Impact: ローンモーダルにおいて極端に大きな入力を受け付けてしまった場合、UIがフリーズしたり予期せぬ演算エラーを引き起こす可能性がある
*   Fix: `LoanDialog` の各 `onChange` 内で `raw.length <= 6` の条件を付与し、パース前に長さを制限した
*   Verification: `bun test` の通過および入力ロジックの修正を確認済み

---
*PR created automatically by Jules for task [15085267185863416670](https://jules.google.com/task/15085267185863416670) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ローン機能の「借りる／返済する」入力フィールドで、入力の反映条件をより厳密に調整しました。特定の長さを超える入力では状態更新を抑制することで、安定した動作を実現しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->