### PR TITLE
🎨 Palette: [UX improvement] ローンダイアログのアクセシビリティ向上と入力文字数制限の追加

### DIFF
--- a/src/components/ActionDialog/LoanDialog.tsx
+++ b/src/components/ActionDialog/LoanDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useId } from 'react';
 import type { GameState, Player } from '../../game/types';
 import type { LoanType } from '../../game/systems/loan';
 import {
@@ -11,6 +11,8 @@ import { calculateTotalAssets } from '../../game/rules';
 import Dialog from '../common/Dialog';
 import Button from '../common/Button';
 import styles from './ActionDialog.module.css';
+
+const MAX_MONEY_INPUT_LENGTH = 6;
 
 type LoanDialogProps = {
   state: GameState;
@@ -27,6 +29,8 @@ export default function LoanDialog({
   onRepayLoan,
   onClose,
 }: LoanDialogProps) {
+  const borrowHintId = useId();
+  const repayHintId = useId();
   const [loanType, setLoanType] = useState<LoanType>('variable');
   const [borrowAmount, setBorrowAmount] = useState('');
   const [repayAmount, setRepayAmount] = useState('');
@@ -139,7 +143,10 @@ export default function LoanDialog({
                   min={1}
                   max={maxBorrow}
                   value={borrowAmount}
-                  onChange={(e) => setBorrowAmount(e.target.value)}
+                  onChange={(e) => {
+                    if (e.target.value.length > MAX_MONEY_INPUT_LENGTH) return;
+                    setBorrowAmount(e.target.value);
+                  }}
                   placeholder={`最大 $${maxBorrow}`}
                   style={{ width: 120 }}
                   aria-label="借入金額"
@@ -147,16 +154,21 @@ export default function LoanDialog({
                 <Button
                   size="small"
                   onClick={() => {
-                    if (canBorrow) {
-                      onTakeLoan(parsedBorrow, loanType);
-                      setBorrowAmount('');
-                    }
+                    if (!canBorrow) return;
+                    onTakeLoan(parsedBorrow, loanType);
+                    setBorrowAmount('');
                   }}
-                  disabled={!canBorrow}
+                  aria-disabled={!canBorrow}
+                  aria-describedby={!canBorrow ? borrowHintId : undefined}
                 >
                   かりる
                 </Button>
               </div>
+              {!canBorrow && borrowAmount !== '' && (
+                <div id={borrowHintId} className={styles.noMoneyHintTight} role="status">
+                  かりられる金額を正しく入力してね
+                </div>
+              )}
             </div>
           </div>
         )}
@@ -172,7 +184,10 @@ export default function LoanDialog({
                   min={1}
                   max={Math.min(loanBalance, currentPlayer.money)}
                   value={repayAmount}
-                  onChange={(e) => setRepayAmount(e.target.value)}
+                  onChange={(e) => {
+                    if (e.target.value.length > MAX_MONEY_INPUT_LENGTH) return;
+                    setRepayAmount(e.target.value);
+                  }}
                   placeholder={`残高 $${loanBalance}`}
                   style={{ width: 120 }}
                   aria-label="返済金額"
@@ -181,19 +196,19 @@ export default function LoanDialog({
                   size="small"
                   variant="secondary"
                   onClick={() => {
-                    if (canRepay) {
-                      onRepayLoan(parsedRepay);
-                      setRepayAmount('');
-                    }
+                    if (!canRepay) return;
+                    onRepayLoan(parsedRepay);
+                    setRepayAmount('');
                   }}
-                  disabled={!canRepay}
+                  aria-disabled={!canRepay}
+                  aria-describedby={!canRepay ? repayHintId : undefined}
                 >
                   返済する
                 </Button>
               </div>
-              {parsedRepay > currentPlayer.money && (
-                <div className={styles.noMoneyHintTight}>
-                  おかねがたりないよ
+              {!canRepay && repayAmount !== '' && (
+                <div id={repayHintId} className={styles.noMoneyHintTight} role="status">
+                  {parsedRepay > currentPlayer.money ? 'おかねがたりないよ' : '返済する金額を正しく入力してね'}
                 </div>
               )}
             </div>

--- a/src/components/ActionDialog/LoanDialog.tsx
+++ b/src/components/ActionDialog/LoanDialog.tsx
@@ -144,8 +144,14 @@ export default function LoanDialog({
                   max={maxBorrow}
                   value={borrowAmount}
                   onChange={(e) => {
-                    if (e.target.value.length > MAX_MONEY_INPUT_LENGTH) return;
-                    setBorrowAmount(e.target.value);
+                    const val = e.target.value;
+                    if ([...val].length > MAX_MONEY_INPUT_LENGTH) {
+                      setBorrowAmount(
+                        [...val].slice(0, MAX_MONEY_INPUT_LENGTH).join(''),
+                      );
+                      return;
+                    }
+                    setBorrowAmount(val);
                   }}
                   placeholder={`最大 $${maxBorrow}`}
                   style={{ width: 120 }}
@@ -191,8 +197,14 @@ export default function LoanDialog({
                   max={Math.min(loanBalance, currentPlayer.money)}
                   value={repayAmount}
                   onChange={(e) => {
-                    if (e.target.value.length > MAX_MONEY_INPUT_LENGTH) return;
-                    setRepayAmount(e.target.value);
+                    const val = e.target.value;
+                    if ([...val].length > MAX_MONEY_INPUT_LENGTH) {
+                      setRepayAmount(
+                        [...val].slice(0, MAX_MONEY_INPUT_LENGTH).join(''),
+                      );
+                      return;
+                    }
+                    setRepayAmount(val);
                   }}
                   placeholder={`残高 $${loanBalance}`}
                   style={{ width: 120 }}

--- a/src/components/ActionDialog/LoanDialog.tsx
+++ b/src/components/ActionDialog/LoanDialog.tsx
@@ -159,13 +159,19 @@ export default function LoanDialog({
                     setBorrowAmount('');
                   }}
                   aria-disabled={!canBorrow}
-                  aria-describedby={!canBorrow ? borrowHintId : undefined}
+                  aria-describedby={
+                    !canBorrow && borrowAmount !== '' ? borrowHintId : undefined
+                  }
                 >
                   かりる
                 </Button>
               </div>
               {!canBorrow && borrowAmount !== '' && (
-                <div id={borrowHintId} className={styles.noMoneyHintTight} role="status">
+                <div
+                  id={borrowHintId}
+                  className={styles.noMoneyHintTight}
+                  role="status"
+                >
                   かりられる金額を正しく入力してね
                 </div>
               )}
@@ -201,14 +207,22 @@ export default function LoanDialog({
                     setRepayAmount('');
                   }}
                   aria-disabled={!canRepay}
-                  aria-describedby={!canRepay ? repayHintId : undefined}
+                  aria-describedby={
+                    !canRepay && repayAmount !== '' ? repayHintId : undefined
+                  }
                 >
                   返済する
                 </Button>
               </div>
               {!canRepay && repayAmount !== '' && (
-                <div id={repayHintId} className={styles.noMoneyHintTight} role="status">
-                  {parsedRepay > currentPlayer.money ? 'おかねがたりないよ' : '返済する金額を正しく入力してね'}
+                <div
+                  id={repayHintId}
+                  className={styles.noMoneyHintTight}
+                  role="status"
+                >
+                  {parsedRepay > currentPlayer.money
+                    ? 'おかねがたりないよ'
+                    : '返済する金額を正しく入力してね'}
                 </div>
               )}
             </div>


### PR DESCRIPTION
💡 What:
ローンダイアログの「かりる」「返済する」ボタンを、ネイティブの `disabled` 属性から `aria-disabled="true"` に変更しました。
また、各アクションが不可能な場合に、理由を説明するテキストを `aria-describedby` 経由でスクリーンリーダーに読み上げさせるようにし、金額入力の数値が長くなりすぎないように文字数制限（最大6桁）を追加しました。

🎯 Why:
ネイティブの `disabled` 属性ではフォーカスが当たらないため、スクリーンリーダーを利用するユーザーに対して「なぜボタンが押せないのか（借入限度額を超えている、所持金が足りない等）」というコンテキストを伝えることができませんでした。また、金額入力に文字数制限がなかったため、非現実的な長さの数値を入力してパース処理に負荷をかけることが可能でした。

📸 Before/After:
（見た目上の変化はありませんが、スクリーンリーダーによるフォーカス時に以下の情報が伝わるようになります）
- かりるボタンが無効な場合：「かりられる金額を正しく入力してね」
- 返済するボタンが無効な場合：「おかねがたりないよ」または「返済する金額を正しく入力してね」

♿ Accessibility:
ボタンに `aria-disabled="true"` を適用することで、無効状態でもキーボードフォーカスを受け取るようになり、支援技術が `aria-describedby` に関連付けられた理由文を読み上げることが可能になりました。

---
*PR created automatically by Jules for task [16505516100549515452](https://jules.google.com/task/16505516100549515452) started by @genzouw*