### PR TITLE
🎨 Palette: [UX improvement] 資産情報表示ダイアログに所有する「おうえんカード（株）」の情報を追加

### DIFF
--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -885,6 +885,17 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
             'green',
             'blue',
           ];
+          const COLOR_LABEL: Record<string, string> = {
+            brown: '🟤 ちゃいろ',
+            lightblue: '🩵 みずいろ',
+            pink: '🩷 ピンク',
+            orange: '🟠 オレンジ',
+            red: '🔴 あか',
+            yellow: '🟡 きいろ',
+            green: '🟢 みどり',
+            blue: '🔵 あお',
+            railroad: '🚂 てつどう',
+          };
           const ownedProps = detailPlayer.properties
             .map((id) => ({
               space: getSpaceById(id, state.board)!,
@@ -1027,12 +1038,17 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
                     </div>
                   ))}
                 </div>
-                {(state.features?.stocks || (detailPlayer.stocks && Object.keys(detailPlayer.stocks).length > 0)) && (
+                {(state.features?.stocks ||
+                  (detailPlayer.stocks &&
+                    Object.keys(detailPlayer.stocks).length > 0)) && (
                   <div style={{ marginTop: 4 }}>
                     <div style={{ fontWeight: 700, marginBottom: 8 }}>
                       📈 おうえんカード（株）
                     </div>
-                    {(!detailPlayer.stocks || Object.values(detailPlayer.stocks).every((shares) => shares === 0)) ? (
+                    {!detailPlayer.stocks ||
+                    Object.values(detailPlayer.stocks).every(
+                      (shares) => shares === 0,
+                    ) ? (
                       <div
                         style={{
                           color: 'var(--color-text-light)',
@@ -1043,56 +1059,48 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
                       </div>
                     ) : (
                       Object.entries(detailPlayer.stocks)
-                        .filter(([, shares]) => (shares as number) > 0)
+                        .filter(
+                          ([, shares]) =>
+                            typeof shares === 'number' && shares > 0,
+                        )
                         .sort(([colorA], [colorB]) => {
                           const ai = colorOrder.indexOf(colorA);
                           const bi = colorOrder.indexOf(colorB);
-                          return ai - bi;
+                          const realA = ai === -1 ? colorOrder.length : ai;
+                          const realB = bi === -1 ? colorOrder.length : bi;
+                          return realA - realB;
                         })
-                        .map(([color, shares]) => {
-                          const COLOR_LABEL: Record<string, string> = {
-                            brown: '🟤 ちゃいろ',
-                            lightblue: '🩵 みずいろ',
-                            pink: '🩷 ピンク',
-                            orange: '🟠 オレンジ',
-                            red: '🔴 あか',
-                            yellow: '🟡 きいろ',
-                            green: '🟢 みどり',
-                            blue: '🔵 あお',
-                            railroad: '🚂 てつどう',
-                          };
-                          return (
-                            <div
-                              key={color}
-                              style={{
-                                display: 'flex',
-                                justifyContent: 'space-between',
-                                alignItems: 'center',
-                                padding: '4px 0',
-                                fontSize: 14,
-                                borderBottom: '1px solid #f0f0f0',
-                              }}
-                            >
-                              <span>
-                                {color !== 'railroad' && (
-                                  <span
-                                    style={{
-                                      display: 'inline-block',
-                                      width: 10,
-                                      height: 10,
-                                      borderRadius: 2,
-                                      backgroundColor: `var(--color-${color})`,
-                                      marginRight: 6,
-                                      verticalAlign: 'middle',
-                                    }}
-                                  />
-                                )}
-                                {COLOR_LABEL[color] || color}
-                              </span>
-                              <span>{shares}まい</span>
-                            </div>
-                          );
-                        })
+                        .map(([color, shares]) => (
+                          <div
+                            key={color}
+                            style={{
+                              display: 'flex',
+                              justifyContent: 'space-between',
+                              alignItems: 'center',
+                              padding: '4px 0',
+                              fontSize: 14,
+                              borderBottom: '1px solid #f0f0f0',
+                            }}
+                          >
+                            <span>
+                              {color !== 'railroad' && (
+                                <span
+                                  style={{
+                                    display: 'inline-block',
+                                    width: 10,
+                                    height: 10,
+                                    borderRadius: 2,
+                                    backgroundColor: `var(--color-${color})`,
+                                    marginRight: 6,
+                                    verticalAlign: 'middle',
+                                  }}
+                                />
+                              )}
+                              {COLOR_LABEL[color] || color}
+                            </span>
+                            <span>{shares}まい</span>
+                          </div>
+                        ))
                     )}
                   </div>
                 )}

--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -1027,6 +1027,75 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
                     </div>
                   ))}
                 </div>
+                {(state.features?.stocks || (detailPlayer.stocks && Object.keys(detailPlayer.stocks).length > 0)) && (
+                  <div style={{ marginTop: 4 }}>
+                    <div style={{ fontWeight: 700, marginBottom: 8 }}>
+                      📈 おうえんカード（株）
+                    </div>
+                    {(!detailPlayer.stocks || Object.values(detailPlayer.stocks).every((shares) => shares === 0)) ? (
+                      <div
+                        style={{
+                          color: 'var(--color-text-light)',
+                          fontSize: 14,
+                        }}
+                      >
+                        まだもっていないよ
+                      </div>
+                    ) : (
+                      Object.entries(detailPlayer.stocks)
+                        .filter(([, shares]) => (shares as number) > 0)
+                        .sort(([colorA], [colorB]) => {
+                          const ai = colorOrder.indexOf(colorA);
+                          const bi = colorOrder.indexOf(colorB);
+                          return ai - bi;
+                        })
+                        .map(([color, shares]) => {
+                          const COLOR_LABEL: Record<string, string> = {
+                            brown: '🟤 ちゃいろ',
+                            lightblue: '🩵 みずいろ',
+                            pink: '🩷 ピンク',
+                            orange: '🟠 オレンジ',
+                            red: '🔴 あか',
+                            yellow: '🟡 きいろ',
+                            green: '🟢 みどり',
+                            blue: '🔵 あお',
+                            railroad: '🚂 てつどう',
+                          };
+                          return (
+                            <div
+                              key={color}
+                              style={{
+                                display: 'flex',
+                                justifyContent: 'space-between',
+                                alignItems: 'center',
+                                padding: '4px 0',
+                                fontSize: 14,
+                                borderBottom: '1px solid #f0f0f0',
+                              }}
+                            >
+                              <span>
+                                {color !== 'railroad' && (
+                                  <span
+                                    style={{
+                                      display: 'inline-block',
+                                      width: 10,
+                                      height: 10,
+                                      borderRadius: 2,
+                                      backgroundColor: `var(--color-${color})`,
+                                      marginRight: 6,
+                                      verticalAlign: 'middle',
+                                    }}
+                                  />
+                                )}
+                                {COLOR_LABEL[color] || color}
+                              </span>
+                              <span>{shares}まい</span>
+                            </div>
+                          );
+                        })
+                    )}
+                  </div>
+                )}
               </div>
             </Dialog>
           );


### PR DESCRIPTION
🎨 Palette: [UX improvement] 資産情報表示ダイアログに所有する「おうえんカード（株）」の情報を追加 (#275)

💡 What:
プレイヤー名をクリックした際に表示される資産情報ダイアログ（`PlayerDetail`）内に、そのプレイヤーが所有している「おうえんカード（株）」の情報を表示するセクションを追加しました。
所有している株がない場合は「まだもっていないよ」と表示し、所有している場合は色ごとの株数をリスト表示します。また、拡張機能設定（`features.stocks`）が有効であるか、すでに株を所有している場合のみ表示されるようにしました。

🎯 Why:
株を購入した後、現在の自分の保有状況を資産情報ダイアログで確認できない状態でした。ユーザーが自分の資産全体（お金、土地、株など）を一つのダイアログで一元的に把握できるようにするため、この改修が必要でした。

📸 Before/After:
Before:
- 資産情報ダイアログには、「もちがね」「そうしさん」「いまのばしょ」「もっている土地」などの情報しか表示されていませんでした。

After:
- 資産情報ダイアログの「もっている土地」の下に「📈 おうえんカード（株）」セクションが追加され、所有する株（例：「🟤 ちゃいろ 2まい」など）が確認できるようになりました。

♿ Accessibility:
（この変更によるアクセシビリティへの影響はありませんが、既存の UI と一貫性のあるセマンティクスで要素を追加しています。）

---
*PR created automatically by Jules for task [12780473258840183717](https://jules.google.com/task/12780473258840183717) started by @genzouw*