### PR TITLE
fix(economy): 📈 株価を景気連動の実効価格化し不況後の回復を反映

### DIFF
--- a/src/components/ActionDialog/StockDialog.tsx
+++ b/src/components/ActionDialog/StockDialog.tsx
@@ -1,5 +1,11 @@
 import { useId } from 'react';
-import type { ColorGroup, ColorGroupStock, Player } from '../../game/types';
+import type {
+  ColorGroup,
+  ColorGroupStock,
+  EconomyStatus,
+  Player,
+} from '../../game/types';
+import { getEffectiveStockPrice } from '../../game/economy';
 import Dialog from '../common/Dialog';
 import Button from '../common/Button';
 import styles from './ActionDialog.module.css';
@@ -7,6 +13,8 @@ import styles from './ActionDialog.module.css';
 type StockDialogProps = {
   currentPlayer: Player;
   stockMarket: Partial<Record<ColorGroup, ColorGroupStock>>;
+  /** 景気を加味した実効株価を表示するための現在の景気ステータス（macroEconomy 無効時は未指定）。 */
+  economyStatus?: EconomyStatus;
   onBuy: (color: ColorGroup, shares: number) => void;
   onSell: (color: ColorGroup, shares: number) => void;
   onClose: () => void;
@@ -33,6 +41,7 @@ const SHARES_PER_TRADE = 1;
 export default function StockDialog({
   currentPlayer,
   stockMarket,
+  economyStatus,
   onBuy,
   onSell,
   onClose,
@@ -58,7 +67,10 @@ export default function StockDialog({
           const market = stockMarket[color];
           if (!market) return null;
           const owned = currentPlayer.stocks?.[color] ?? 0;
-          const price = market.pricePerShare;
+          const price = getEffectiveStockPrice(
+            market.pricePerShare,
+            economyStatus,
+          );
           const isMoneyShort = currentPlayer.money < price;
           const isBankShort = market.bankShares < SHARES_PER_TRADE;
           const canBuy = !isMoneyShort && !isBankShort;

--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -502,6 +502,9 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
         <StockDialog
           currentPlayer={currentPlayer}
           stockMarket={state.stockMarket}
+          economyStatus={
+            state.features?.macroEconomy ? state.economyStatus : undefined
+          }
           onBuy={(color, shares) =>
             dispatch({ type: 'BUY_STOCK', color, shares })
           }

--- a/src/game/__tests__/economy.test.ts
+++ b/src/game/__tests__/economy.test.ts
@@ -17,6 +17,7 @@ import {
   calculateNextPrice,
   createInitialStockMarket,
   distributeDividends,
+  getEffectiveStockPrice,
   isStocksEnabled,
   validateStockBuy,
   validateStockSell,
@@ -186,6 +187,62 @@ describe('economy.ts 純粋関数', () => {
         ok: false,
         reason: 'INSUFFICIENT_HOLDINGS',
       });
+    });
+  });
+
+  describe('getEffectiveStockPrice', () => {
+    it('景気ステータス未指定なら基準価格をそのまま返す（既存挙動互換）', () => {
+      expect(getEffectiveStockPrice(100)).toBe(100);
+    });
+
+    it('通常時は基準価格と一致する', () => {
+      expect(getEffectiveStockPrice(100, 'normal')).toBe(100);
+    });
+
+    it('好況時は実効株価が上がり、金融危機時は下がる', () => {
+      expect(getEffectiveStockPrice(100, 'boom')).toBe(130);
+      expect(getEffectiveStockPrice(100, 'recession')).toBe(70);
+      expect(getEffectiveStockPrice(100, 'crisis')).toBe(40);
+    });
+
+    it('金融危機で下がった実効株価は景気回復で元の水準へ戻る（片道暴落の解消）', () => {
+      const base = 100;
+      const crashed = getEffectiveStockPrice(base, 'crisis');
+      const recovered = getEffectiveStockPrice(base, 'normal');
+      expect(crashed).toBeLessThan(base);
+      expect(recovered).toBe(base);
+    });
+  });
+
+  describe('景気連動の売買価格（macroEconomy 有効）', () => {
+    function economyState(status: GameState['economyStatus']): GameState {
+      const base = startGame({ stocks: true });
+      return {
+        ...base,
+        features: { ...base.features, stocks: true, macroEconomy: true },
+        economyStatus: status,
+      };
+    }
+
+    it('金融危機時は購入コストが基準価格より安くなる', () => {
+      const result = validateStockBuy(
+        economyState('crisis'),
+        'player-0',
+        'brown',
+        1,
+      );
+      // 基準 100 × crisis 0.4 = 40
+      expect(result).toEqual({ ok: true, cost: 40 });
+    });
+
+    it('景気回復（通常）で購入コストが基準価格へ戻る', () => {
+      const result = validateStockBuy(
+        economyState('normal'),
+        'player-0',
+        'brown',
+        1,
+      );
+      expect(result).toEqual({ ok: true, cost: STOCK_INITIAL_PRICE });
     });
   });
 

--- a/src/game/__tests__/loan.test.ts
+++ b/src/game/__tests__/loan.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { EconomyStatus, GameState } from '../types';
+import type { EconomyStatus, GameState, Player } from '../types';
 import {
   LOAN_INTEREST_RATES,
   FIXED_LOAN_RATE,
@@ -8,6 +8,7 @@ import {
   calculateInterest,
   calculateMaxLoanAmount,
   getLoanInterestRate,
+  liquidateNonPropertyAssets,
   validateTakeLoan,
   validateRepayLoan,
   isLoanEnabled,
@@ -357,6 +358,47 @@ describe('loan', () => {
         ok: false,
         reason: 'INSUFFICIENT_FUNDS',
       });
+    });
+  });
+
+  describe('liquidateNonPropertyAssets（株式の実効株価換金）', () => {
+    const makePlayerWithStocks = (): Player => ({
+      id: 'p1',
+      name: 'Alice',
+      token: '🚗',
+      money: 0,
+      position: 0,
+      properties: [],
+      inJail: false,
+      jailTurns: 0,
+      getOutOfJailCards: 0,
+      isBankrupt: false,
+      stocks: { brown: 10 },
+    });
+    const stockMarket = {
+      brown: {
+        color: 'brown' as const,
+        pricePerShare: 100,
+        totalShares: 100,
+        bankShares: 90,
+      },
+    };
+
+    it('景気未指定なら基準価格で換金する（既存挙動互換）', () => {
+      const { proceeds } = liquidateNonPropertyAssets(
+        makePlayerWithStocks(),
+        stockMarket,
+      );
+      expect(proceeds).toBe(1000); // 100 × 10
+    });
+
+    it('金融危機時は実効株価（0.4倍）で換金額が下がる', () => {
+      const { proceeds } = liquidateNonPropertyAssets(
+        makePlayerWithStocks(),
+        stockMarket,
+        'crisis',
+      );
+      expect(proceeds).toBe(400); // 40 × 10
     });
   });
 });

--- a/src/game/__tests__/macroEconomy.test.ts
+++ b/src/game/__tests__/macroEconomy.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import type { ColorGroupStock } from '../types';
 import {
   ECONOMY_FACTORS,
   ECONOMY_UPDATE_INTERVAL,
   ECONOMY_TRANSITION_MATRIX,
   applyEconomyFactor,
-  applyFinancialCrisisToStocks,
   shouldUpdateEconomy,
   transitionEconomy,
   isMacroEconomyEnabled,
@@ -103,59 +101,6 @@ describe('macroEconomy', () => {
       expect(shouldUpdateEconomy(3)).toBe(false);
       expect(shouldUpdateEconomy(7)).toBe(false);
       expect(shouldUpdateEconomy(11)).toBe(false);
-    });
-  });
-
-  describe('applyFinancialCrisisToStocks', () => {
-    it('全株価を50%減少させる', () => {
-      const market: Record<string, ColorGroupStock> = {
-        brown: {
-          color: 'brown',
-          pricePerShare: 100,
-          totalShares: 100,
-          bankShares: 80,
-        },
-        red: {
-          color: 'red',
-          pricePerShare: 200,
-          totalShares: 100,
-          bankShares: 50,
-        },
-      };
-      const result = applyFinancialCrisisToStocks(market);
-      expect(result?.brown?.pricePerShare).toBe(50);
-      expect(result?.red?.pricePerShare).toBe(100);
-    });
-
-    it('undefinedを渡した場合はundefinedを返す', () => {
-      expect(applyFinancialCrisisToStocks(undefined)).toBeUndefined();
-    });
-
-    it('株価は最低1を下回らない', () => {
-      const market: Record<string, ColorGroupStock> = {
-        brown: {
-          color: 'brown',
-          pricePerShare: 1,
-          totalShares: 100,
-          bankShares: 100,
-        },
-      };
-      const result = applyFinancialCrisisToStocks(market);
-      expect(result?.brown?.pricePerShare).toBe(1);
-    });
-
-    it('stockMarket以外のフィールドは変更しない', () => {
-      const market: Record<string, ColorGroupStock> = {
-        brown: {
-          color: 'brown',
-          pricePerShare: 100,
-          totalShares: 100,
-          bankShares: 80,
-        },
-      };
-      const result = applyFinancialCrisisToStocks(market);
-      expect(result?.brown?.totalShares).toBe(100);
-      expect(result?.brown?.bankShares).toBe(80);
     });
   });
 

--- a/src/game/economy.ts
+++ b/src/game/economy.ts
@@ -2,7 +2,17 @@
 // reducer.ts を肥大化させないため、株式・配当のロジックはここに集約する。
 // 既存ゲーム挙動を破壊しないよう、本ファイルの関数はすべて副作用なしの計算関数として実装する。
 
-import type { ColorGroup, ColorGroupStock, GameState, Player } from './types';
+import type {
+  ColorGroup,
+  ColorGroupStock,
+  EconomyStatus,
+  GameState,
+  Player,
+} from './types';
+import {
+  applyEconomyFactor,
+  isMacroEconomyEnabled,
+} from './systems/macroEconomy';
 
 // TODO: balance review — マジックナンバーは将来のバランス調整で見直す
 export const STOCK_INITIAL_PRICE = 100;
@@ -71,6 +81,29 @@ export function calculateNextPrice(
   priceDelta: number,
 ): number {
   return Math.max(currentPrice + priceDelta, STOCK_MIN_PRICE);
+}
+
+// 景気を加味した実効株価を返す純粋関数。
+//
+// `pricePerShare`（基準価格）は需給・建設のみで変動し景気の影響を受けない素の価格とし、
+// 売買・清算・表示で実際に用いる価格はここで景気乗数を掛けて算出する。
+// これにより不況・金融危機で下がった株価は、景気回復とともに乗数が戻り
+// 自動的に元の水準へ戻る（片道の暴落処理に頼らない対称的な設計）。
+// `status` 未指定（macroEconomy 無効）なら基準価格をそのまま返し、既存挙動と完全互換。
+export function getEffectiveStockPrice(
+  basePrice: number,
+  status?: EconomyStatus,
+): number {
+  if (!status) return basePrice;
+  return applyEconomyFactor(basePrice, status);
+}
+
+// ゲーム状態から株価評価に用いる景気ステータスを導出する。
+// macroEconomy 無効時は `undefined`（景気補正なし）を返す。
+export function getPricingEconomyStatus(
+  state: GameState,
+): EconomyStatus | undefined {
+  return isMacroEconomyEnabled(state) ? state.economyStatus : undefined;
 }
 
 // 家賃支払時の配当総額（家賃の DIVIDEND_RATE_PCT%）
@@ -143,7 +176,11 @@ export function validateStockBuy(
     return { ok: false, reason: 'INSUFFICIENT_BANK_SHARES' };
   const player = state.players.find((p) => p.id === playerId);
   if (!player) return { ok: false, reason: 'COLOR_UNKNOWN' };
-  const cost = market.pricePerShare * shares;
+  const price = getEffectiveStockPrice(
+    market.pricePerShare,
+    getPricingEconomyStatus(state),
+  );
+  const cost = price * shares;
   if (player.money < cost) return { ok: false, reason: 'INSUFFICIENT_FUNDS' };
   return { ok: true, cost };
 }
@@ -174,7 +211,11 @@ export function validateStockSell(
   if (!player) return { ok: false, reason: 'COLOR_UNKNOWN' };
   const owned = player.stocks?.[color] ?? 0;
   if (owned < shares) return { ok: false, reason: 'INSUFFICIENT_HOLDINGS' };
-  const proceeds = market.pricePerShare * shares;
+  const price = getEffectiveStockPrice(
+    market.pricePerShare,
+    getPricingEconomyStatus(state),
+  );
+  const proceeds = price * shares;
   return { ok: true, proceeds };
 }
 

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -30,6 +30,7 @@ import {
   calculateNextPrice,
   createInitialStockMarket,
   distributeDividends,
+  getPricingEconomyStatus,
   isStocksEnabled,
   validateStockBuy,
   validateStockSell,
@@ -55,7 +56,6 @@ import {
 } from './insurance';
 import {
   applyEconomyFactor,
-  applyFinancialCrisisToStocks,
   isMacroEconomyEnabled,
   shouldUpdateEconomy,
   transitionEconomy,
@@ -251,6 +251,7 @@ function checkNegativeMoney(state: GameState): GameState {
     const { updatedPlayer, proceeds } = liquidateNonPropertyAssets(
       player,
       workingState.stockMarket,
+      getPricingEconomyStatus(workingState),
     );
     if (proceeds > 0) {
       workingState = {
@@ -1664,7 +1665,10 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
 
       // P2-a 拡張: 景気サイクル更新
       let newEconomyStatus = state.economyStatus;
-      let newStockMarket = state.stockMarket;
+      // 株価は景気の影響を受けない基準価格として保持し、実効価格は売買・表示時に
+      // getEffectiveStockPrice で景気乗数を掛けて算出する。よって景気遷移で
+      // stockMarket 自体を書き換えることはない（不況→回復で実効株価が自動回復する）。
+      const newStockMarket = state.stockMarket;
       let economyMessage = '';
 
       if (isMacroEconomyEnabled(state) && newEconomyStatus) {
@@ -1674,15 +1678,14 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
             newEconomyStatus,
             getSecureRandom(),
           );
-          // 金融危機に突入した場合: 株式機能 ON のときだけ全株価を 50% 減＋暴落メッセージ。
+          // 金融危機に突入した場合: 株式機能 ON のときだけ株価暴落をアナウンスする。
+          // 暴落自体は景気乗数（crisis=0.4 倍）として実効株価に反映され、
+          // 景気回復とともに自動的に元の水準へ戻る。
           // 株式機能 OFF のときは存在しない株価暴落をアナウンスしないよう、汎用文言にする。
           if (newEconomyStatus === 'crisis' && prevStatus !== 'crisis') {
-            if (isStocksEnabled(state)) {
-              newStockMarket = applyFinancialCrisisToStocks(newStockMarket);
-              economyMessage = ' ⚠️金融危機！株価が暴落したよ！';
-            } else {
-              economyMessage = ' ⚠️金融危機！景気が急変したよ！';
-            }
+            economyMessage = isStocksEnabled(state)
+              ? ' ⚠️金融危機！株価が暴落したよ！'
+              : ' ⚠️金融危機！景気が急変したよ！';
           } else if (newEconomyStatus !== prevStatus) {
             const statusNames: Record<EconomyStatus, string> = {
               boom: '好況',

--- a/src/game/systems/loan.ts
+++ b/src/game/systems/loan.ts
@@ -11,6 +11,7 @@ import type {
   Player,
 } from '../types';
 import { calculateTotalAssets } from '../rules';
+import { getEffectiveStockPrice } from '../economy';
 import {
   CREDIT_SCORE_INITIAL,
   calculateCreditScoreDiscount,
@@ -179,6 +180,7 @@ function _calcAssets(
 export function liquidateNonPropertyAssets(
   player: Player,
   stockMarket: Partial<Record<ColorGroup, ColorGroupStock>> | undefined,
+  economyStatus?: EconomyStatus,
 ): { updatedPlayer: Player; proceeds: number } {
   let proceeds = 0;
   let updated = { ...player };
@@ -197,12 +199,13 @@ export function liquidateNonPropertyAssets(
     updated = { ...updated, vcInvestments: undefined };
   }
 
-  // ③ 株式（現在の市場価格で換金）
+  // ③ 株式（現在の景気を加味した実効株価で換金）
   if (updated.stocks && stockMarket) {
     for (const [color, shares] of Object.entries(updated.stocks)) {
       const market = stockMarket[color as ColorGroup];
       if (market && shares && shares > 0) {
-        proceeds += market.pricePerShare * shares;
+        proceeds +=
+          getEffectiveStockPrice(market.pricePerShare, economyStatus) * shares;
       }
     }
     updated = { ...updated, stocks: undefined };

--- a/src/game/systems/macroEconomy.ts
+++ b/src/game/systems/macroEconomy.ts
@@ -2,12 +2,7 @@
 // reducer.ts を肥大化させないため、景気遷移・乗数計算はここに集約する。
 // 既存ゲーム挙動を破壊しないよう、本ファイルの関数はすべて副作用なしの計算関数として実装する。
 
-import type {
-  ColorGroup,
-  ColorGroupStock,
-  EconomyStatus,
-  GameState,
-} from '../types';
+import type { EconomyStatus, GameState } from '../types';
 
 // 景気乗数（仕様: 好況=1.3、通常=1.0、不況=0.7、金融危機=0.4）
 export const ECONOMY_FACTORS: Record<EconomyStatus, number> = {
@@ -23,9 +18,6 @@ export const ECONOMY_FACTOR_MAX = 2.0;
 
 // 景気更新間隔（ターン数）
 export const ECONOMY_UPDATE_INTERVAL = 5;
-
-// 金融危機時の株価暴落倍率（仕様: 50% 減 = 0.5 倍）
-const CRISIS_STOCK_PRICE_MULTIPLIER = 0.5;
 
 // 景気遷移確率マトリクス: [現在の状態][次の状態] = 確率
 // 各行の合計 = 1.0。好況→金融危機、金融危機→好況への直接遷移は0。
@@ -122,36 +114,4 @@ export function shouldUpdateEconomy(turnCount: number): boolean {
  */
 export function isMacroEconomyEnabled(state: GameState): boolean {
   return state.features?.macroEconomy === true;
-}
-
-/**
- * 金融危機イベント: 全エリア株価を `CRISIS_STOCK_PRICE_MULTIPLIER` 倍（0.5 倍 = 50% 減）にした
- * 新しい株式市場を返す。
- *
- * 各色の `pricePerShare` を `Math.floor(price * CRISIS_STOCK_PRICE_MULTIPLIER)` で切り下げ、
- * 最低価格 1 でクランプする。元の `stockMarket` は変更せず、シャローコピーした新しい
- * オブジェクトを返す（イミュータブル性を保証）。
- * `stockMarket` が `undefined` の場合はそのまま `undefined` を返す。
- *
- * @param stockMarket 現在の株式市場（カラーグループ → 株情報のマップ）。`undefined` 可。
- * @returns 株価を 0.5 倍（最低 1）にした新しい株式市場。入力が `undefined` ならそのまま `undefined`。
- */
-export function applyFinancialCrisisToStocks(
-  stockMarket: Partial<Record<ColorGroup, ColorGroupStock>> | undefined,
-): Partial<Record<ColorGroup, ColorGroupStock>> | undefined {
-  if (!stockMarket) return stockMarket;
-  const newMarket = { ...stockMarket };
-  for (const color of Object.keys(newMarket) as ColorGroup[]) {
-    const stock = newMarket[color];
-    if (stock) {
-      newMarket[color] = {
-        ...stock,
-        pricePerShare: Math.max(
-          Math.floor(stock.pricePerShare * CRISIS_STOCK_PRICE_MULTIPLIER),
-          1,
-        ),
-      };
-    }
-  }
-  return newMarket;
 }


### PR DESCRIPTION
## 概要

株の利用（おうえんカード機能）を有効にしたゲームで、**不況・金融危機で下がった株価が景気回復後も元に戻らない**不具合を修正します。

## 原因

株価 `pricePerShare` を変動させる経路は3つだけで、いずれも景気回復で株価を戻しません。

| 経路 | 方向性 |
|---|---|
| 株の売買（需給, ±5/株） | プレイヤー操作のみ |
| 家・ホテル建設（±15） | 建設操作のみ |
| **金融危機突入（×0.5）** | **下げる一方向のみ** |

決定的なのは `reducer.ts` の金融危機分岐で、`applyFinancialCrisisToStocks` により crisis 突入時に株価を 0.5 倍する**片道の破壊的処理**だけがあり、**回復時に株価を戻す逆処理が存在しません**。景気乗数 `applyEconomyFactor`（好況1.3 / 不況0.7 等）は家賃・配当などの「金額」専用で `pricePerShare` には未適用でした。

結果として、crisis で半減した株価はプレイヤーが買い支えない限り永久に戻らず、複数回の crisis では `0.5ⁿ`（最低1）まで累積的に下落する非対称な挙動になっていました。

## 修正方針（案A: 基準価格 × 景気乗数）

家賃・配当が景気乗数に連動するのに株価だけ片道だった不整合そのものを解消します。

- `pricePerShare` を**景気非依存の基準価格**（需給・建設のみで変動）として保持
- 売買・清算・表示で実際に用いる価格は `getEffectiveStockPrice(base, status)` で景気乗数を掛けて算出
- 景気が回復すれば乗数も戻るため、**下がった実効株価が自動的に元の水準へ戻る**
- 片道の破壊的処理 `applyFinancialCrisisToStocks` を**廃止**

## 変更点

- `economy.ts`: `getEffectiveStockPrice` / `getPricingEconomyStatus` を追加、`validateStockBuy/Sell` を実効株価ベースへ
- `reducer.ts`: 金融危機分岐から破壊的半減を除去（⚠️暴落アナウンスは維持）
- `systems/loan.ts`: 破産時の株式清算を実効株価へ
- `StockDialog.tsx` / `GameBoard.tsx`: 表示・購入判定価格を実効株価へ統一
- `systems/macroEconomy.ts`: 不要になった `applyFinancialCrisisToStocks` と定数を削除

## 互換性

`macroEconomy` 無効時は `status` 未指定 → 基準価格をそのまま使用するため、**既存挙動と完全互換**です（FeatureFlags OFF 時の互換性要件を満たす）。

## テスト

- `getEffectiveStockPrice`: 景気別の実効価格／**金融危機→回復で基準価格へ戻る**検証を追加
- `validateStockBuy`: 危機時のコスト減・回復時の復帰を検証
- `liquidateNonPropertyAssets`: 危機時の清算額が実効株価で下がる検証を追加
- 旧 `applyFinancialCrisisToStocks` テストを削除
- `bun run typecheck` / `bun run lint` / `bun run test`（431 passed）すべて green