### PR TITLE
⚡ Bolt: PlayerPanel内のプレイヤーチップメモ化による再描画最適化

### DIFF
--- a/src/components/PlayerPanel/PlayerPanel.tsx
+++ b/src/components/PlayerPanel/PlayerPanel.tsx
@@ -31,7 +31,13 @@ const MemoizedPlayerChip = memo(function MemoizedPlayerChip({
       }
       aria-current={isActive ? 'true' : 'false'}
       aria-disabled={!onPlayerClick}
-      className={`${styles.playerChip} ${isActive ? styles.playerChipActive : ''} ${player.isBankrupt ? styles.playerChipBankrupt : ''}`}
+      className={[
+        styles.playerChip,
+        isActive && styles.playerChipActive,
+        player.isBankrupt && styles.playerChipBankrupt,
+      ]
+        .filter(Boolean)
+        .join(' ')}
       onClick={(e) => {
         if (!onPlayerClick) {
           e.preventDefault();

--- a/src/components/PlayerPanel/PlayerPanel.tsx
+++ b/src/components/PlayerPanel/PlayerPanel.tsx
@@ -15,6 +15,10 @@ type MemoizedPlayerChipProps = {
   onPlayerClick?: (playerId: string) => void;
 };
 
+/**
+ * プレイヤーチップを描画するメモ化コンポーネント。
+ * `player` の状態と `isActive` に応じて見た目を切り替える。
+ */
 const MemoizedPlayerChip = memo(function MemoizedPlayerChip({
   player,
   isActive,

--- a/src/components/PlayerPanel/PlayerPanel.tsx
+++ b/src/components/PlayerPanel/PlayerPanel.tsx
@@ -9,6 +9,69 @@ type PlayerPanelProps = {
   onPlayerClick?: (playerId: string) => void;
 };
 
+type MemoizedPlayerChipProps = {
+  player: Player;
+  isActive: boolean;
+  onPlayerClick?: (playerId: string) => void;
+};
+
+const MemoizedPlayerChip = memo(function MemoizedPlayerChip({
+  player,
+  isActive,
+  onPlayerClick,
+}: MemoizedPlayerChipProps) {
+  return (
+    <button
+      type="button"
+      aria-label={
+        `${player.token} ${player.name} 所持金 ${player.money.toLocaleString()}ドル` +
+        (player.inJail ? ' 刑務所に入っています' : '') +
+        (player.isBankrupt ? ' 破産しています' : '') +
+        (onPlayerClick ? ' 詳細を見る' : '')
+      }
+      aria-current={isActive ? 'true' : 'false'}
+      aria-disabled={!onPlayerClick}
+      className={`${styles.playerChip} ${isActive ? styles.playerChipActive : ''} ${player.isBankrupt ? styles.playerChipBankrupt : ''}`}
+      onClick={(e) => {
+        if (!onPlayerClick) {
+          e.preventDefault();
+          e.stopPropagation();
+          return;
+        }
+        onPlayerClick(player.id);
+      }}
+      style={{ background: getOwnerBg(player.id) }}
+      title={onPlayerClick ? `${player.name}の詳細を見る` : undefined}
+    >
+      <span aria-hidden="true">{player.token}</span>
+      <span aria-hidden="true">${player.money.toLocaleString()}</span>
+      {player.creditScore !== undefined && (
+        <span
+          className={styles.jailBadge}
+          aria-hidden="true"
+          title={`信用スコア: ${player.creditScore}`}
+        >
+          📊{player.creditScore}
+        </span>
+      )}
+      {(player.loanBalance ?? 0) > 0 && (
+        <span
+          className={styles.jailBadge}
+          aria-hidden="true"
+          title={`ローン残高: $${player.loanBalance}`}
+        >
+          🏦${player.loanBalance}
+        </span>
+      )}
+      {player.inJail && (
+        <span className={styles.jailBadge} aria-hidden="true">
+          🔒
+        </span>
+      )}
+    </button>
+  );
+});
+
 const PlayerPanel = memo(function PlayerPanel({
   allPlayers,
   currentPlayerIndex,
@@ -17,55 +80,12 @@ const PlayerPanel = memo(function PlayerPanel({
   return (
     <div className={styles.allPlayers}>
       {allPlayers.map((player, idx) => (
-        <button
+        <MemoizedPlayerChip
           key={player.id}
-          type="button"
-          aria-label={
-            `${player.token} ${player.name} 所持金 ${player.money.toLocaleString()}ドル` +
-            (player.inJail ? ' 刑務所に入っています' : '') +
-            (player.isBankrupt ? ' 破産しています' : '') +
-            (onPlayerClick ? ' 詳細を見る' : '')
-          }
-          aria-current={idx === currentPlayerIndex ? 'true' : 'false'}
-          aria-disabled={!onPlayerClick}
-          className={`${styles.playerChip} ${idx === currentPlayerIndex ? styles.playerChipActive : ''} ${player.isBankrupt ? styles.playerChipBankrupt : ''}`}
-          onClick={(e) => {
-            if (!onPlayerClick) {
-              e.preventDefault();
-              e.stopPropagation();
-              return;
-            }
-            onPlayerClick(player.id);
-          }}
-          style={{ background: getOwnerBg(player.id) }}
-          title={onPlayerClick ? `${player.name}の詳細を見る` : undefined}
-        >
-          <span aria-hidden="true">{player.token}</span>
-          <span aria-hidden="true">${player.money.toLocaleString()}</span>
-          {player.creditScore !== undefined && (
-            <span
-              className={styles.jailBadge}
-              aria-hidden="true"
-              title={`信用スコア: ${player.creditScore}`}
-            >
-              📊{player.creditScore}
-            </span>
-          )}
-          {(player.loanBalance ?? 0) > 0 && (
-            <span
-              className={styles.jailBadge}
-              aria-hidden="true"
-              title={`ローン残高: $${player.loanBalance}`}
-            >
-              🏦${player.loanBalance}
-            </span>
-          )}
-          {player.inJail && (
-            <span className={styles.jailBadge} aria-hidden="true">
-              🔒
-            </span>
-          )}
-        </button>
+          player={player}
+          isActive={idx === currentPlayerIndex}
+          onPlayerClick={onPlayerClick}
+        />
       ))}
     </div>
   );

--- a/src/components/PlayerPanel/PlayerPanel.tsx
+++ b/src/components/PlayerPanel/PlayerPanel.tsx
@@ -35,6 +35,7 @@ const MemoizedPlayerChip = memo(function MemoizedPlayerChip({
       }
       aria-current={isActive ? 'true' : 'false'}
       aria-disabled={!onPlayerClick}
+      disabled={!onPlayerClick}
       className={[
         styles.playerChip,
         isActive && styles.playerChipActive,
@@ -42,13 +43,8 @@ const MemoizedPlayerChip = memo(function MemoizedPlayerChip({
       ]
         .filter(Boolean)
         .join(' ')}
-      onClick={(e) => {
-        if (!onPlayerClick) {
-          e.preventDefault();
-          e.stopPropagation();
-          return;
-        }
-        onPlayerClick(player.id);
+      onClick={() => {
+        onPlayerClick?.(player.id);
       }}
       style={{ background: getOwnerBg(player.id) }}
       title={onPlayerClick ? `${player.name}の詳細を見る` : undefined}


### PR DESCRIPTION
💡 What: `PlayerPanel`内でリストレンダリングされている各プレイヤーのUI要素を`MemoizedPlayerChip`として抽出し、`React.memo`でメモ化しました。
🎯 Why: `state.players`配列はプレイヤーの移動（アニメーション）や資金変動などによって頻繁に新しい参照となります。全体が再描画されると、変更のないプレイヤーのDOM評価まで無駄に発生していました。要素単位でメモ化することで、状態が変わったプレイヤーのみの再描画に抑えられます。
📊 Impact: プレイヤー移動中のような高頻度な更新時において、無関係なプレイヤーUIの再描画を抑制し、メインスレッドの負荷を軽減します。
🔬 Measurement: React DevToolsのProfilerを使用してサイコロを振った後のアニメーション時のレンダリングを測定し、関係のないプレイヤーのチップが再描画をスキップ（Bailout）することを確認します。

---
*PR created automatically by Jules for task [2313238808778993310](https://jules.google.com/task/2313238808778993310) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * プレイヤーパネルのコンポーネント構造を改善しました。プレイヤーチップの描画ロジックを最適化し、レンダリングのパフォーマンスを向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->