### PR TITLE
🎨 Palette: プレイヤー情報のアクセシビリティ改善（キーボード操作対応）

### DIFF
--- a/src/components/PlayerPanel/PlayerPanel.tsx
+++ b/src/components/PlayerPanel/PlayerPanel.tsx
@@ -44,7 +44,7 @@ const MemoizedPlayerChip = memo(function MemoizedPlayerChip({
         .join(' ')}
       onClick={(e) => {
         if (!onPlayerClick) {
-          e.preventDefault();
+          e.stopPropagation();
           return;
         }
         onPlayerClick(player.id);

--- a/src/components/PlayerPanel/PlayerPanel.tsx
+++ b/src/components/PlayerPanel/PlayerPanel.tsx
@@ -35,7 +35,6 @@ const MemoizedPlayerChip = memo(function MemoizedPlayerChip({
       }
       aria-current={isActive ? 'true' : 'false'}
       aria-disabled={!onPlayerClick}
-      disabled={!onPlayerClick}
       className={[
         styles.playerChip,
         isActive && styles.playerChipActive,
@@ -43,8 +42,12 @@ const MemoizedPlayerChip = memo(function MemoizedPlayerChip({
       ]
         .filter(Boolean)
         .join(' ')}
-      onClick={() => {
-        onPlayerClick?.(player.id);
+      onClick={(e) => {
+        if (!onPlayerClick) {
+          e.preventDefault();
+          return;
+        }
+        onPlayerClick(player.id);
       }}
       style={{ background: getOwnerBg(player.id) }}
       title={onPlayerClick ? `${player.name}の詳細を見る` : undefined}


### PR DESCRIPTION
💡 What: プレイヤーチップ（PlayerPanel）のネイティブ `disabled` 属性を削除し、代わりに `aria-disabled` を使用してクリックハンドラで早期リターンするように修正しました。

🎯 Why: ネイティブの `disabled` 属性を使用すると、要素がタブフォーカス順序から外れてしまい、スクリーンリーダーユーザーがタブ移動した際にプレイヤーの情報（所持金やステータス）を読み上げることができないアクセシビリティ上の問題があったためです。

📸 Before/After:
Before: キーボード操作でプレイヤーチップにフォーカスを当てることができない。
After: キーボード操作でプレイヤーチップにフォーカスが当たり、スクリーンリーダーが `aria-label` の内容を読み上げ可能になる。

♿ Accessibility: ネイティブ `disabled` を排除したことで、無効化された状態でもフォーカスを受け取れるようになり、スクリーンリーダーユーザーに対して状態を正しく伝えることができるようになりました。また、クリック時には処理がブロックされるため、機能上の問題はありません。

---
*PR created automatically by Jules for task [2441172930963850851](https://jules.google.com/task/2441172930963850851) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * プレイヤーパネルのクリック動作を改善しました。クリック不可の状態における処理の精度を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->