### PR TITLE
🎨 Palette: プレイヤーパネルのアクセシビリティ改善

### DIFF
--- a/src/components/PlayerPanel/PlayerPanel.module.css
+++ b/src/components/PlayerPanel/PlayerPanel.module.css
@@ -38,3 +38,18 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+.playerChipContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 52px;
+}
+.helperText {
+  font-size: 11px;
+  color: var(--color-text-secondary, #888);
+  text-align: center;
+  margin-top: 4px;
+  white-space: normal;
+  max-width: 120px;
+  line-height: 1.3;
+}

--- a/src/components/PlayerPanel/PlayerPanel.tsx
+++ b/src/components/PlayerPanel/PlayerPanel.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useId } from 'react';
 import type { Player } from '../../game/types';
 import { getOwnerBg } from '../common/playerColors';
 import styles from './PlayerPanel.module.css';
@@ -24,57 +24,65 @@ const MemoizedPlayerChip = memo(function MemoizedPlayerChip({
   isActive,
   onPlayerClick,
 }: MemoizedPlayerChipProps) {
+  const playerDescriptionId = useId();
   return (
-    <button
-      type="button"
-      aria-label={
-        `${player.token} ${player.name} 所持金 ${player.money.toLocaleString()}ドル` +
-        (player.inJail ? ' 刑務所に入っています' : '') +
-        (player.isBankrupt ? ' 破産しています' : '') +
-        (onPlayerClick ? ' 詳細を見る' : '')
-      }
-      aria-current={isActive ? 'true' : 'false'}
-      aria-disabled={!onPlayerClick}
-      className={[
-        styles.playerChip,
-        isActive && styles.playerChipActive,
-        player.isBankrupt && styles.playerChipBankrupt,
-      ]
-        .filter(Boolean)
-        .join(' ')}
-      onClick={() => {
-        if (!onPlayerClick) return;
-        onPlayerClick(player.id);
-      }}
-      style={{ background: getOwnerBg(player.id) }}
-      title={onPlayerClick ? `${player.name}の詳細を見る` : '他のプレイヤーの操作中や処理中は詳細を見られません'}
-    >
-      <span aria-hidden="true">{player.token}</span>
-      <span aria-hidden="true">${player.money.toLocaleString()}</span>
-      {player.creditScore !== undefined && (
-        <span
-          className={styles.jailBadge}
-          aria-hidden="true"
-          title={`信用スコア: ${player.creditScore}`}
-        >
-          📊{player.creditScore}
+    <div className={styles.playerChipContainer}>
+      <button
+        type="button"
+        aria-label={
+          `${player.token} ${player.name} 所持金 ${player.money.toLocaleString()}ドル` +
+          (player.inJail ? ' 刑務所に入っています' : '') +
+          (player.isBankrupt ? ' 破産しています' : '') +
+          (onPlayerClick ? ' 詳細を見る' : '')
+        }
+        aria-current={isActive ? 'true' : 'false'}
+        aria-disabled={!onPlayerClick}
+        aria-describedby={!onPlayerClick ? playerDescriptionId : undefined}
+        className={[
+          styles.playerChip,
+          isActive && styles.playerChipActive,
+          player.isBankrupt && styles.playerChipBankrupt,
+        ]
+          .filter(Boolean)
+          .join(' ')}
+        onClick={() => {
+          if (!onPlayerClick) return;
+          onPlayerClick(player.id);
+        }}
+        style={{ background: getOwnerBg(player.id) }}
+      >
+        <span aria-hidden="true">{player.token}</span>
+        <span aria-hidden="true">${player.money.toLocaleString()}</span>
+        {player.creditScore !== undefined && (
+          <span
+            className={styles.jailBadge}
+            aria-hidden="true"
+            title={`信用スコア: ${player.creditScore}`}
+          >
+            📊{player.creditScore}
+          </span>
+        )}
+        {(player.loanBalance ?? 0) > 0 && (
+          <span
+            className={styles.jailBadge}
+            aria-hidden="true"
+            title={`ローン残高: $${player.loanBalance}`}
+          >
+            🏦${player.loanBalance}
+          </span>
+        )}
+        {player.inJail && (
+          <span className={styles.jailBadge} aria-hidden="true">
+            🔒
+          </span>
+        )}
+      </button>
+      {!onPlayerClick && (
+        <span id={playerDescriptionId} className={styles.helperText}>
+          他のプレイヤーの操作中や処理中は詳細を見られません
         </span>
       )}
-      {(player.loanBalance ?? 0) > 0 && (
-        <span
-          className={styles.jailBadge}
-          aria-hidden="true"
-          title={`ローン残高: $${player.loanBalance}`}
-        >
-          🏦${player.loanBalance}
-        </span>
-      )}
-      {player.inJail && (
-        <span className={styles.jailBadge} aria-hidden="true">
-          🔒
-        </span>
-      )}
-    </button>
+    </div>
   );
 });
 

--- a/src/components/PlayerPanel/PlayerPanel.tsx
+++ b/src/components/PlayerPanel/PlayerPanel.tsx
@@ -35,7 +35,6 @@ const MemoizedPlayerChip = memo(function MemoizedPlayerChip({
       }
       aria-current={isActive ? 'true' : 'false'}
       aria-disabled={!onPlayerClick}
-      disabled={!onPlayerClick}
       className={[
         styles.playerChip,
         isActive && styles.playerChipActive,
@@ -44,10 +43,11 @@ const MemoizedPlayerChip = memo(function MemoizedPlayerChip({
         .filter(Boolean)
         .join(' ')}
       onClick={() => {
-        onPlayerClick?.(player.id);
+        if (!onPlayerClick) return;
+        onPlayerClick(player.id);
       }}
       style={{ background: getOwnerBg(player.id) }}
-      title={onPlayerClick ? `${player.name}の詳細を見る` : undefined}
+      title={onPlayerClick ? `${player.name}の詳細を見る` : '他のプレイヤーの操作中や処理中は詳細を見られません'}
     >
       <span aria-hidden="true">{player.token}</span>
       <span aria-hidden="true">${player.money.toLocaleString()}</span>


### PR DESCRIPTION
💡 What: プレイヤーパネル（画面上部のプレイヤーステータス）の `disabled` 属性を `aria-disabled="true"` に変更しました。
🎯 Why: 以前はクリック不可のタイミングで `disabled` が付与されていたため、キーボードフォーカスが当たらず、スクリーンリーダーユーザーが自分の所持金などの情報を確認できませんでした。フォーカス可能にすることで、いつでも情報を読み上げられるようにしました。
📸 Before/After: （スクリーンショットはテスト時に撮影）
♿ Accessibility: ネイティブの `disabled` を `aria-disabled` に変更し、フォーカス可能にしました。また、操作できない理由を `title` 属性で明示しました。

---
*PR created automatically by Jules for task [16987179306999960272](https://jules.google.com/task/16987179306999960272) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * プレイヤーカードのクリック挙動を調整し、操作できない場合は詳細表示を行わないようになりました。
  * 詳細リンクの説明文が状況に応じて切り替わり、操作可能時はプレイヤー名付きの案内、操作不可時は固定メッセージを表示します。
  * 見た目とアクセシビリティ属性の扱いを見直し、状態に応じた分かりやすい表示になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->