### PR TITLE
chore(security): 🔒 AIエージェント作業跡およびログのコミット防止強化

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -32,3 +32,8 @@
 .continue/** -diff export-ignore
 .jules/** -diff export-ignore
 .cline/** -diff export-ignore
+.windsurf/** -diff export-ignore
+.trae/** -diff export-ignore
+.roo/** -diff export-ignore
+*.log -diff export-ignore
+*-report.md -diff export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,8 @@ jobs:
             -o -name "*.tfstate" -o -name "*.tfstate.backup" \
             -o -path "*/.cursor/*" -o -path "*/.claude/*" -o -path "*/.aider*/*" \
             -o -path "*/.continue/*" -o -path "*/.jules/*" -o -path "*/.cline/*" \
+            -o -path "*/.windsurf/*" -o -path "*/.trae/*" -o -path "*/.roo/*" \
+            -o -name "*.log" -o -name "*-report.md" \
             \) -not -name ".env.example" -not -path "*/node_modules/*" -not -path "*/.git/*" || true)
 
           if [ -n "$BANNED_FILES" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Logs
 logs
 *.log
+*-report.md
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
@@ -65,6 +66,9 @@ id_dsa
 .aider*
 .continue/
 .cline/
+.windsurf/
+.trae/
+.roo/
 
 # Security tool binaries (downloaded during setup, must not be committed)
 gitleaks*

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -25,7 +25,7 @@ else
 fi
 
 # Block banned files from being committed (Defense in depth against .env/keys/AI workspaces)
-banned_files=$(git diff --cached --name-only | grep -iE '(\.env$|\.env\..*|.*\.pem$|.*\.key$|.*credentials.*\.(json|ya?ml|env)$|.*secret.*\.(json|ya?ml|env)$|\.npmrc$|\.netrc$|.*\.(p12|pfx|keystore|sqlite|sqlite3|db)$|service-?account.*\.(json|ya?ml|env)$|\.tfstate.*|^\.cursor/|^\.claude/|^\.aider.*|^\.continue/|^\.jules/|(^|/)\.cline/)' | grep -vE '\.env\.example$') || true
+banned_files=$(git diff --cached --name-only | grep -iE '(\.env$|\.env\..*|.*\.pem$|.*\.key$|.*credentials.*\.(json|ya?ml|env)$|.*secret.*\.(json|ya?ml|env)$|\.npmrc$|\.netrc$|.*\.(p12|pfx|keystore|sqlite|sqlite3|db)$|service-?account.*\.(json|ya?ml|env)$|\.tfstate.*|^\.cursor/|^\.claude/|^\.aider.*|^\.continue/|^\.jules/|(^|/)\.cline/|^\.windsurf/|^\.trae/|^\.roo/|.*\.log$|.*-report\.md$)' | grep -vE '\.env\.example$') || true
 
 if [ -n "$banned_files" ]; then
   echo "❌ Error: Attempted to commit banned sensitive files or AI workspaces:"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -25,7 +25,7 @@ else
 fi
 
 # Block banned files from being committed (Defense in depth against .env/keys/AI workspaces)
-banned_files=$(git diff --cached --name-only | grep -iE '(\.env$|\.env\..*|.*\.pem$|.*\.key$|.*credentials.*\.(json|ya?ml|env)$|.*secret.*\.(json|ya?ml|env)$|\.npmrc$|\.netrc$|.*\.(p12|pfx|keystore|sqlite|sqlite3|db)$|service-?account.*\.(json|ya?ml|env)$|\.tfstate.*|^\.cursor/|^\.claude/|^\.aider.*|^\.continue/|^\.jules/|(^|/)\.cline/|^\.windsurf/|^\.trae/|^\.roo/|.*\.log$|.*-report\.md$)' | grep -vE '\.env\.example$') || true
+banned_files=$(git diff --cached --name-only | grep -iE '(\.env$|\.env\..*|.*\.pem$|.*\.key$|.*credentials.*\.(json|ya?ml|env)$|.*secret.*\.(json|ya?ml|env)$|\.npmrc$|\.netrc$|.*\.(p12|pfx|keystore|sqlite|sqlite3|db)$|service-?account.*\.(json|ya?ml|env)$|\.tfstate.*|^\.cursor/|^\.claude/|^\.aider.*|^\.continue/|^\.jules/|(^|/)\.cline/|(^|/)\.windsurf/|(^|/)\.trae/|(^|/)\.roo/|.*\.log$|.*-report\.md$)' | grep -vE '\.env\.example$') || true
 
 if [ -n "$banned_files" ]; then
   echo "❌ Error: Attempted to commit banned sensitive files or AI workspaces:"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,7 +28,12 @@
     "**/.aider*/**": true,
     "**/.continue/**": true,
     "**/.jules/**": true,
-    "**/.cline/**": true
+    "**/.cline/**": true,
+    "**/.windsurf/**": true,
+    "**/.trae/**": true,
+    "**/.roo/**": true,
+    "**/*.log": true,
+    "**/*-report.md": true
   },
   "search.exclude": {
     "**/.env": true,
@@ -59,6 +64,11 @@
     "**/.aider*/**": true,
     "**/.continue/**": true,
     "**/.jules/**": true,
-    "**/.cline/**": true
+    "**/.cline/**": true,
+    "**/.windsurf/**": true,
+    "**/.trae/**": true,
+    "**/.roo/**": true,
+    "**/*.log": true,
+    "**/*-report.md": true
   }
 }

--- a/docs/security/leak-prevention.md
+++ b/docs/security/leak-prevention.md
@@ -12,7 +12,7 @@
 - **`.gitignore` と `.gitattributes` による除外・保護**:
   - `.env`, `.env.*` (ただし `.env.example` は除く)
   - `*.pem`, `*.key`, `id_rsa`, `id_ed25519`, `id_ecdsa`, `id_dsa`, `*credentials*.json`, `*secret*.json`, `*.npmrc`, `.netrc`, DBファイル(`*.sqlite` 等) 等
-  - AI エージェントの作業跡（`.cursor/`, `.claude/`, `.aider*`, `.cline/` 等）はローカル環境特有の秘密情報が含まれるリスクがあるため除外しています。
+  - AI エージェントの作業跡（`.cursor/`, `.claude/`, `.aider*`, `.cline/`, `.windsurf/`, `.trae/`, `.roo/` 等）や生成ログ（`*.log`, `*-report.md`）はローカル環境特有の秘密情報が含まれるリスクがあるため除外しています。
   - **さらに、`.gitattributes` により、これらの秘密情報ファイルが誤って `git add` された場合でも、diff の中身がレビュー画面・ログ・PR 上で表示されない（`-diff` によりバイナリ扱いとなり `Binary files differ` 表示）よう、またリポジトリのアーカイブに含まれないよう（`export-ignore`）設定し、二重に保護しています。**
 - **`pre-commit` framework**: `.pre-commit-config.yaml` による標準的なフック（秘密鍵の検知、YAML構文チェックなど）を利用してコミット前の安全性をさらに高めています。
   - **`detect-secrets`**: `gitleaks` を補完し、エントロピーベースで未知の高乱数なシークレットや独自フォーマットのトークンを検知します。


### PR DESCRIPTION
## 背景

事前調査により、本リポジトリには `gitleaks` や `trufflehog` など強力なシークレット検知 CI が導入済みであり、`.gitignore` や `.gitattributes` でも主要なシークレットファイルや一部の AI エージェント（Cursor, Claude, Aider, Cline）の設定ファイル除外が設定されていることを確認しました。しかし、近年普及している他の AI エディタ（Windsurf, Trae, Roo Code）の作業跡や、AI が一時的に生成するログファイル（`*.log`, `*-report.md`）などがカバーされておらず、ローカルコンテキストが漏洩するリスクが残存していました。

## 現状認識（事前調査結果のサマリー）

- 既存防御策: `gitleaks.yml`, `trufflehog.yml`, `trivy.yml`, `ci.yml` (banned-files-check), `.husky/pre-commit`, `.secrets.baseline` 等、多層的な防御策が導入済み。
- 未カバー領域: 新興 AI エディタ（Windsurf, Trae, Roo Code）のワークスペース、および AI ツールがデバッグ・レポート用途で生成する汎用的なログファイル。
- 直近の漏洩リスク兆候: 現在のところ明らかな流出は見られませんが、AI による自律的開発が進む中で一時ファイルが誤コミットされるリスクが高まっています。

## このPRで導入・強化するもの

- 対象: `.gitignore`, `.gitattributes`, `.vscode/settings.json`, `.husky/pre-commit`, `.github/workflows/ci.yml`, `docs/security/leak-prevention.md`
- ツール名とバージョン: 既存のローカルフック（Husky/grep）および CI（banned-files-check）
- 期待される効果: 新たな AI エージェント（Windsurf, Trae, Roo Code）の作業跡や、一時的なログ・レポートファイル（`*.log`, `*-report.md`）がコミットされることをローカルと CI の両面で完全にブロックし、コンテキスト漏洩を未然に防ぎます。

## 検知漏れリスクと補完策

- 検知できないケース: 上記以外の未知の AI エージェント固有ディレクトリや、意図的に拡張子が変更された一時ファイル。
- 補完策: 定期的に `.gitignore` や `banned-files-check` の定義リストを見直し、新規ツールへの追従を行います。また、既存の `gitleaks` と組み合わせることで、未知のファイル内にあるシークレット自体は検知可能です。

## マージ前に必要な手動作業（チェックリスト）

レビュアーは PR をマージする前に必ず以下を実施してください。
本 PR の CI は手動作業完了を前提に通る設計です。

- [x] 特になし（設定ファイルの純粋な追加のみであり、インフラ設定やシークレット操作は伴いません）

## マージ後の確認手順

- [ ] 次の push / PR で導入した workflow が green になることを確認
- [ ] ローカル環境でダミーの `.windsurf/test.txt` や `test.log` を作成し、`git add` しても無視されること（または pre-commit フックで弾かれること）を確認

## ロールバック手順

本 PR のコミットを `git revert` して設定を元に戻してください。既存の CI 動作には影響を与えません。

## 参考情報

- 公式ドキュメント: 各 AI エージェントの公式ドキュメント（Windsurf, Trae, Roo Code）
- 比較検討した他案: 新規 CI ツールの導入を検討しましたが、プロジェクト方針（既存防御策の強化優先）に従い、Husky フックと既存の banned-files-check を拡張するアプローチを採用しました。
- 直近の関連 PR / Issue: なし

---
*PR created automatically by Jules for task [5737960027973646492](https://jules.google.com/task/5737960027973646492) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 特定の作業用フォルダやログ、レポートファイルが、差分表示・アーカイブ・コミット・検索・CI検査で見つかるように更新されました。
  * 開発環境の表示設定でも、これらのファイルが自動的に非表示になるようになりました。

* **Documentation**
  * コミット前の検知ルールに、ログやレポート系ファイルの扱いが追記されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->