### PR TITLE
chore(security): 🛡️ Sentinel: [security improvement] ローンダイアログの過大な入力によるDoSを防止

### DIFF
--- a/src/components/ActionDialog/LoanDialog.tsx
+++ b/src/components/ActionDialog/LoanDialog.tsx
@@ -145,12 +145,7 @@ export default function LoanDialog({
                   value={borrowAmount}
                   onChange={(e) => {
                     const val = e.target.value;
-                    if ([...val].length > MAX_MONEY_INPUT_LENGTH) {
-                      setBorrowAmount(
-                        [...val].slice(0, MAX_MONEY_INPUT_LENGTH).join(''),
-                      );
-                      return;
-                    }
+                    if (val.length > MAX_MONEY_INPUT_LENGTH) return;
                     setBorrowAmount(val);
                   }}
                   placeholder={`最大 $${maxBorrow}`}
@@ -198,12 +193,7 @@ export default function LoanDialog({
                   value={repayAmount}
                   onChange={(e) => {
                     const val = e.target.value;
-                    if ([...val].length > MAX_MONEY_INPUT_LENGTH) {
-                      setRepayAmount(
-                        [...val].slice(0, MAX_MONEY_INPUT_LENGTH).join(''),
-                      );
-                      return;
-                    }
+                    if (val.length > MAX_MONEY_INPUT_LENGTH) return;
                     setRepayAmount(val);
                   }}
                   placeholder={`残高 $${loanBalance}`}


### PR DESCRIPTION
💡 What:
ローンダイアログの `<input type="number">` で、入力文字数を制限する処理を修正しました。スプレッド構文による配列化 (`[...val]`) を廃止し、純粋な文字列長チェックで早期リターンするようにしました。

🎯 Why:
HTML の `max` 属性は巨大な文字列のペーストを防げず、さらに巨大な文字列をスプレッド構文で配列に展開すると、ブラウザのメインスレッドがフリーズしメモリを異常消費する脆弱性 (DoS リスク) があるためです。

📸 Before/After:
Before:
`if ([...val].length > MAX_MONEY_INPUT_LENGTH)` で文字列を配列化し、上限を超えた場合は配列の一部を取り出して `.join('')` で復元し状態更新。

After:
`if (val.length > MAX_MONEY_INPUT_LENGTH) return;` により、文字列のまま軽量に長さを検証し、超えた場合は状態更新自体を行わないように修正。

---
*PR created automatically by Jules for task [3320475342847395988](https://jules.google.com/task/3320475342847395988) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 借入・返済の数値入力で、入力文字数が上限を超えた場合に自動で切り詰められず、入力内容がそのまま無視されるようになりました。
  * これにより、上限超過時の予期しない値の補正や状態更新が発生しなくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->