### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -4,6 +4,7 @@ import {
   MIN_PLAYERS,
   MAX_PLAYERS,
   MAX_NAME_LENGTH,
+  RAW_LENGTH_LIMIT_MULTIPLIER,
 } from '../../game/types';
 import type { FeatureFlags, GameState } from '../../game/types';
 import { loadSetupConfig, saveSetupConfig } from '../../game/storage';
@@ -61,8 +62,6 @@ const DEFAULT_NAMES = [
 ];
 const DEFAULT_TOKENS: string[] = [TOKENS[0], TOKENS[1], TOKENS[2], TOKENS[3]];
 const START_GUIDE_MSG = 'すべてのプレイヤーのなまえを入力してね';
-// サロゲートペアを考慮した余裕係数
-const RAW_LENGTH_LIMIT_MULTIPLIER = 10;
 
 /**
  * ゲーム開始前の初期設定画面コンポーネント。

--- a/src/game/storage.ts
+++ b/src/game/storage.ts
@@ -1,5 +1,11 @@
 import type { FeatureFlags, GameState } from './types';
-import { TOKENS, MIN_PLAYERS, MAX_PLAYERS, MAX_NAME_LENGTH } from './types';
+import {
+  TOKENS,
+  MIN_PLAYERS,
+  MAX_PLAYERS,
+  MAX_NAME_LENGTH,
+  RAW_LENGTH_LIMIT_MULTIPLIER,
+} from './types';
 
 const STORAGE_KEY = 'monopo-save';
 const SETUP_KEY = 'monopo-setup';
@@ -97,7 +103,7 @@ export function loadSetupConfig(): SetupConfig | null {
       !config.names.every(
         (n) =>
           typeof n === 'string' &&
-          n.length <= MAX_NAME_LENGTH * 10 &&
+          n.length <= MAX_NAME_LENGTH * RAW_LENGTH_LIMIT_MULTIPLIER &&
           [...n].length <= MAX_NAME_LENGTH,
       ) ||
       !config.tokens.every(

--- a/src/game/storage.ts
+++ b/src/game/storage.ts
@@ -95,7 +95,10 @@ export function loadSetupConfig(): SetupConfig | null {
       config.names.length !== MAX_PLAYERS ||
       config.tokens.length !== MAX_PLAYERS ||
       !config.names.every(
-        (n) => typeof n === 'string' && [...n].length <= MAX_NAME_LENGTH,
+        (n) =>
+          typeof n === 'string' &&
+          n.length <= MAX_NAME_LENGTH * 10 &&
+          [...n].length <= MAX_NAME_LENGTH,
       ) ||
       !config.tokens.every(
         (t) =>

--- a/src/game/storage.ts
+++ b/src/game/storage.ts
@@ -103,6 +103,7 @@ export function loadSetupConfig(): SetupConfig | null {
       !config.names.every(
         (n) =>
           typeof n === 'string' &&
+          // サロゲートペア分解によるDoSを防ぐための事前チェック（[...n]展開前に上限を絞る）
           n.length <= MAX_NAME_LENGTH * RAW_LENGTH_LIMIT_MULTIPLIER &&
           [...n].length <= MAX_NAME_LENGTH,
       ) ||

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -161,7 +161,8 @@ export type TradeInvalidReason =
   | 'PROPERTY_HAS_HOUSES';
 
 export type TradeValidationResult =
-  { isValid: true } | { isValid: false; reason: TradeInvalidReason };
+  | { isValid: true }
+  | { isValid: false; reason: TradeInvalidReason };
 
 // ── P3-a 拡張: ローン状態 ──
 export type LoanState = {

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -8,6 +8,10 @@ export const MAX_PLAYERS = 4;
 // ── プレイヤー名の最大文字数（コードポイント基準） ──
 export const MAX_NAME_LENGTH = 20;
 
+// ── 名前バリデーション: サロゲートペア分解前のバイト長上限係数 ──
+// サロゲートペアは最大2コードユニット/コードポイントだが、DoS安全マージンとして10倍に設定
+export const RAW_LENGTH_LIMIT_MULTIPLIER = 10;
+
 // ── 物件カラーグループ ──
 export type ColorGroup =
   | 'brown'
@@ -157,8 +161,7 @@ export type TradeInvalidReason =
   | 'PROPERTY_HAS_HOUSES';
 
 export type TradeValidationResult =
-  | { isValid: true }
-  | { isValid: false; reason: TradeInvalidReason };
+  { isValid: true } | { isValid: false; reason: TradeInvalidReason };
 
 // ── P3-a 拡張: ローン状態 ──
 export type LoanState = {


### PR DESCRIPTION
## 実行サマリー
- **Target Repo**: monopo
- **Pre-investigation Summary**: コードベース内で、ユーザー入力の文字列長をチェックする際に、定数時間の `val.length` ではなく `[...val].length` (配列展開) が使用されている箇所を調査しました。
- **Selected Perspective**: セキュリティ (Denial of Service の防止)
- **Selected Tool/Enhancement**: `src/game/storage.ts` において、`localStorage` から読み込んだ未検証の文字列に対して `[...n].length` を実行している箇所を特定し、巨大な文字列の配列展開による OOM/DoS 攻撃を防ぐための事前チェック (`n.length <= MAX_NAME_LENGTH * 10`) を追加しました。
- **Alternatives Considered**: 完全にサロゲートペア対応のバリデーションライブラリを導入することも検討しましたが、依存関係を増やさず、既存の定数倍（`RAW_LENGTH_LIMIT_MULTIPLIER` 相当）を用いた軽量なチェックが最も適切と判断しました。
- **PR Link**: N/A
- **Duplicate Check Result**: 重複する PR はありません。
- **Manual Tasks Count**: 0
- **Remaining Future Tasks**: なし

### セキュリティコンテキスト
- **🚨 Severity**: MEDIUM
- **💡 Vulnerability**: `localStorage` から読み込んだ不正な設定データによって、巨大な文字列が配列展開される際、ブラウザのメインスレッドがハングし、Denial of Service (DoS) を引き起こすリスクが存在していました。
- **🎯 Impact**: 悪意のあるユーザーが巨大な文字列を含むセーブデータをロードさせることで、アプリケーションをクラッシュさせることが可能でした。
- **🔧 Fix**: `[...n].length` を実行する前に、定数時間で完了する `n.length <= MAX_NAME_LENGTH * 10` のチェックを導入しました。
- **✅ Verification**: `bun run test` により既存のテストが正常に通過することを確認しました。

---
*PR created automatically by Jules for task [294916146515781779](https://jules.google.com/task/294916146515781779) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 名前入力の検証を強化し、文字列として不正でないだけでなく、極端に長い入力も制限するようになりました。
  * これにより、想定外に長い名前による表示・処理の不具合や異常な入力を防ぎやすくなりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->