### PR TITLE
🎨 Palette: PlayerPanelのaria-labelに信用スコアとローン残高を追加

### DIFF
--- a/src/components/PlayerPanel/PlayerPanel.tsx
+++ b/src/components/PlayerPanel/PlayerPanel.tsx
@@ -53,6 +53,12 @@ const MemoizedPlayerChip = memo(function MemoizedPlayerChip({
           `${player.token} ${player.name} 所持金 ${player.money.toLocaleString()}ドル` +
           (player.inJail ? ' 刑務所に入っています' : '') +
           (player.isBankrupt ? ' 破産しています' : '') +
+          (player.creditScore !== undefined
+            ? ` 信用スコア ${player.creditScore}`
+            : '') +
+          ((player.loanBalance ?? 0) > 0
+            ? ` ローン残高 ${player.loanBalance}ドル`
+            : '') +
           (onPlayerClick ? ' 詳細を見る' : '')
         }
         aria-current={isActive ? 'true' : 'false'}

--- a/src/components/PlayerPanel/PlayerPanel.tsx
+++ b/src/components/PlayerPanel/PlayerPanel.tsx
@@ -3,6 +3,9 @@ import type { Player } from '../../game/types';
 import { getOwnerBg } from '../common/playerColors';
 import styles from './PlayerPanel.module.css';
 
+const LABEL_LOAN_BALANCE = 'ローン残高';
+const UNIT_CURRENCY = 'ドル';
+
 type PlayerPanelProps = {
   allPlayers: Player[];
   currentPlayerIndex: number;
@@ -57,7 +60,7 @@ const MemoizedPlayerChip = memo(function MemoizedPlayerChip({
             ? ` 信用スコア ${player.creditScore}`
             : '') +
           ((player.loanBalance ?? 0) > 0
-            ? ` ローン残高 ${player.loanBalance}ドル`
+            ? ` ${LABEL_LOAN_BALANCE} ${player.loanBalance?.toLocaleString()}${UNIT_CURRENCY}`
             : '') +
           (onPlayerClick ? ' 詳細を見る' : '')
         }


### PR DESCRIPTION
💡 What: PlayerPanelのチップ要素(`MemoizedPlayerChip`)の`aria-label`に、現在視覚的のみで提供されている「信用スコア」と「ローン残高」の情報を含めました。
🎯 Why: 拡張機能の「ローン」などをONにした際に表示される「信用スコア」や「ローン残高」のバッジは、`aria-hidden="true"`でマークアップされているため、スクリーンリーダーには読み上げられませんでした。これを親要素の`aria-label`に動的に追加することで、視覚情報とアクセシビリティ情報の同期を図ります。
♿ Accessibility: スクリーンリーダーユーザーがフォーカスした際に、自身の（または他人の）信用スコアとローン残高を正しく把握できるようになります。

---
*PR created automatically by Jules for task [13873127413376478085](https://jules.google.com/task/13873127413376478085) started by @genzouw*