### PR TITLE
ci: ♻️ 統一CIワークフローを genzouw/ci-workflows の reusable 呼び出しへ移行

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,5 +1,8 @@
 name: actionlint
 
+# 本ワークフローは genzouw/ci-workflows の reusable workflow を呼び出す薄いスタブ。
+# ロジックの実体・変更は ci-workflows 側で一元管理する (トリガー定義のみここで持つ)。
+# 参照 SHA の更新は Dependabot (github-actions ecosystem) が自動で PR を出す。
 on:
   push:
     branches: [main, master]
@@ -21,82 +24,4 @@ permissions:
 
 jobs:
   actionlint:
-    name: actionlint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Download actionlint
-        id: actionlint
-        run: |
-          set -euo pipefail
-          VERSION=1.7.12
-          TARBALL="actionlint_${VERSION}_linux_amd64.tar.gz"
-          curl -fsSL -o "/tmp/${TARBALL}" "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/${TARBALL}"
-          curl -fsSL -o /tmp/checksums.txt "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_checksums.txt"
-          cd /tmp && grep "${TARBALL}" checksums.txt | sha256sum -c -
-          tar -xzf "/tmp/${TARBALL}" -C /tmp actionlint
-          echo "executable=/tmp/actionlint" >> "$GITHUB_OUTPUT"
-
-      - name: Install dependencies (shellcheck, pyflakes)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y shellcheck pyflakes3
-          if [ ! -e /usr/bin/pyflakes ]; then
-            sudo ln -s /usr/bin/pyflakes3 /usr/bin/pyflakes
-          fi
-
-      - name: Run actionlint
-        env:
-          ACTIONLINT: ${{ steps.actionlint.outputs.executable }}
-        run: |
-          "$ACTIONLINT" -color
-
-      - name: Reject non-SHA action references in `uses:`
-        # 外部 Action をブランチ・タグ参照すると、上流のリポジトリリネームや
-        # タグ付け替えで startup_failure や不意の破壊的変更・供給網攻撃を
-        # 取り込むリスクがある。コミット SHA (40桁) でのピン留めを CI で強制する。
-        #
-        # grep のパターンには 3 つの工夫を入れている:
-        #  1. `u[s]es` で `uses` リテラルを文字クラスに分解 → 本ステップ自身
-        #     が自分の検出パターンに hit するのを防ぐ（self-match 回避）。
-        #  2. 行頭アンカー `^[[:space:]]*-?[[:space:]]*` で YAML キー位置に
-        #     限定し、コメントや文字列内の偶発的な `uses:` を除外。加えて
-        #     `--include='*.yml' --include='*.yaml'` で対象拡張子を絞る。
-        #  3. キー・値を囲むクオート（`"..."` / `'...'`）を任意でマッチさせる
-        #     → `uses: "owner/repo@main"` のようなクオート記法での
-        #     ガードバイパスを防ぐ（YAML 上いずれも有効な記法のため）。
-        run: |
-          set -euo pipefail
-          refs=$(grep -rEn \
-            --include='*.yml' --include='*.yaml' \
-            -e "^[[:space:]]*-?[[:space:]]*[\"']?u[s]es[\"']?[[:space:]]*:[[:space:]]+[\"']?[^@[:space:]\"']+@[^[:space:]\"'#]+" \
-            .github/workflows || true)
-          violations=$(printf '%s\n' "$refs" | grep -Ev "@[0-9a-fA-F]{40}([\"'[:space:]]|#|$)" | grep -v '^$' || true)
-          if [ -n "$violations" ]; then
-            echo "::error::外部 Action 参照がコミット SHA でピン留めされていません:"
-            echo "$violations"
-            echo ""
-            echo "修正方法: \`uses: owner/repo@<40桁SHA> # v1.2.3\` の形式に書き換える。"
-            exit 1
-          fi
-          echo "✅ 全ての外部 Action 参照がコミット SHA でピン留めされています。"
-
-      - name: Reject pull_request_target
-        run: |
-          set -euo pipefail
-          violations=$(grep -rEn \
-            --include='*.yml' --include='*.yaml' \
-            -e "^[[:space:]]*[\"']?pull_request_targ[e]t[\"']?[[:space:]]*:" \
-            -e "^[[:space:]]*[\"']?on[\"']?[[:space:]]*:[[:space:]]*\[[^]]*pull_request_targ[e]t[^]]*\]" \
-            .github/workflows || true)
-          if [ -n "$violations" ]; then
-            echo "::error::フォークPRからのシークレット漏洩リスクがあるため、pull_request_target の使用は禁止されています:"
-            echo "$violations"
-            echo ""
-            echo "修正方法: 通常の \`pull_request\` トリガーを使用してください。"
-            exit 1
-          fi
-          echo "✅ pull_request_target の使用はありません。"
+    uses: genzouw/ci-workflows/.github/workflows/actionlint.yml@28d2b9b6f563eb1126e786f28e308390b2558a47 # v1.0.1

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,5 +1,9 @@
 name: Gitleaks
 
+# 本ワークフローは genzouw/ci-workflows の reusable workflow を呼び出す薄いスタブ。
+# ロジックの実体・変更は ci-workflows 側で一元管理する (トリガー定義のみここで持つ)。
+# 参照 SHA の更新は Dependabot (github-actions ecosystem) が自動で PR を出す。
+# 必須チェック (context: "gitleaks / Scan for leaked secrets") のため paths フィルタ禁止。
 on:
   push:
     branches: [main, master]
@@ -20,42 +24,4 @@ permissions:
 
 jobs:
   gitleaks:
-    name: Scan for leaked secrets
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # 履歴全体をスキャンするためフルクローン
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Install gitleaks
-        run: |
-          set -euo pipefail
-          GITLEAKS_VERSION=8.21.2
-          TARBALL="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
-          curl -fsSLO "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${TARBALL}"
-          curl -fsSLo checksums.txt "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_checksums.txt"
-          grep " ${TARBALL}$" checksums.txt | sha256sum -c -
-          tar -xzf "${TARBALL}" gitleaks
-          sudo mv gitleaks /usr/local/bin/gitleaks
-          gitleaks version
-
-      - name: Run gitleaks
-        run: |
-          gitleaks detect \
-            --source . \
-            --log-opts="--all" \
-            --redact \
-            --verbose \
-            --no-banner \
-            --exit-code 1 \
-            --report-format sarif \
-            --report-path gitleaks.sarif
-
-      - name: Upload SARIF
-        if: always()
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
-        with:
-          sarif_file: gitleaks.sarif
-          category: gitleaks
+    uses: genzouw/ci-workflows/.github/workflows/gitleaks.yml@28d2b9b6f563eb1126e786f28e308390b2558a47 # v1.0.1

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,5 +1,8 @@
 name: hadolint
 
+# 本ワークフローは genzouw/ci-workflows の reusable workflow を呼び出す薄いスタブ。
+# ロジックの実体・変更は ci-workflows 側で一元管理する (トリガー定義のみここで持つ)。
+# 参照 SHA の更新は Dependabot (github-actions ecosystem) が自動で PR を出す。
 on:
   push:
     branches: [main, master]
@@ -25,48 +28,4 @@ permissions:
 
 jobs:
   hadolint:
-    name: Hadolint (Dockerfile lint)
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    # 既存 Dockerfile の DL3008/DL3018 等の指摘を片付けるまでは赤検知にしない。
-    # 整備完了後に continue-on-error を外して赤検知に切り替える。
-    continue-on-error: true
-    env:
-      HADOLINT_VERSION: v2.12.0
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Install hadolint
-        working-directory: ${{ runner.temp }}
-        run: |
-          set -eu
-          # 供給網攻撃対策として公式の .sha256 を併せて取得し整合性検証を行う。
-          # 公式 .sha256 にはオリジナルのファイル名が記載されるため、
-          # ハッシュのみを抜き出してローカル保存名と照合する。
-          curl --fail --silent --show-error --location \
-            --retry 3 --retry-all-errors --retry-delay 2 \
-            --connect-timeout 10 --max-time 120 \
-            -o hadolint \
-            "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-Linux-x86_64"
-          curl --fail --silent --show-error --location \
-            --retry 3 --retry-all-errors --retry-delay 2 \
-            --connect-timeout 10 --max-time 120 \
-            -o hadolint.sha256 \
-            "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-Linux-x86_64.sha256"
-          expected_sha=$(awk '{print $1}' hadolint.sha256)
-          echo "${expected_sha}  hadolint" | sha256sum -c -
-          chmod +x hadolint
-
-      - name: Run hadolint
-        run: |
-          set -eu
-          # リポジトリ内の全 Dockerfile を対象に lint する。
-          mapfile -t dockerfiles < <(git ls-files '*Dockerfile' '*Dockerfile.*')
-          if [ "${#dockerfiles[@]}" -eq 0 ]; then
-            echo "Dockerfile が見つかりませんでした。スキップします。"
-            exit 0
-          fi
-          printf 'lint 対象: %s\n' "${dockerfiles[@]}"
-          "${RUNNER_TEMP}/hadolint" "${dockerfiles[@]}"
+    uses: genzouw/ci-workflows/.github/workflows/hadolint.yml@28d2b9b6f563eb1126e786f28e308390b2558a47 # v1.0.1

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,5 +1,8 @@
 name: markdownlint
 
+# 本ワークフローは genzouw/ci-workflows の reusable workflow を呼び出す薄いスタブ。
+# ロジックの実体・変更は ci-workflows 側で一元管理する (トリガー定義のみここで持つ)。
+# 参照 SHA の更新は Dependabot (github-actions ecosystem) が自動で PR を出す。
 on:
   push:
     branches: [main, master]
@@ -23,20 +26,4 @@ permissions:
 
 jobs:
   markdownlint:
-    name: markdownlint-cli2
-    runs-on: ubuntu-latest
-    # 既存ドキュメントの違反を片付けるまでは赤検知にしない。
-    # 整備完了後に continue-on-error を外して赤検知に切り替える。
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Run markdownlint-cli2
-        # v23.x 以降は Node.js 24 ランタイム要求のため startup_failure する。
-        # GitHub Actions runner が node24 を正式サポートするまで v22.0.0 で固定する。
-        uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101 # v22.0.0
-        with:
-          config: '.markdownlint-cli2.jsonc'
-          globs: '**/*.md'
+    uses: genzouw/ci-workflows/.github/workflows/markdownlint.yml@28d2b9b6f563eb1126e786f28e308390b2558a47 # v1.0.1

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,5 +1,8 @@
 name: shellcheck
 
+# 本ワークフローは genzouw/ci-workflows の reusable workflow を呼び出す薄いスタブ。
+# ロジックの実体・変更は ci-workflows 側で一元管理する (トリガー定義のみここで持つ)。
+# 参照 SHA の更新は Dependabot (github-actions ecosystem) が自動で PR を出す。
 on:
   push:
     branches: [main, master]
@@ -21,25 +24,4 @@ permissions:
 
 jobs:
   shellcheck:
-    name: ShellCheck (shell script lint)
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Run shellcheck
-        run: |
-          set -euo pipefail
-          # ランナー同梱の shellcheck を使用する（バージョンはログで確認できるよう出力）。
-          shellcheck --version
-          # リポジトリ内の全シェルスクリプトを対象に lint する。
-          # サードパーティ由来の vendor / node_modules 配下は対象外。
-          mapfile -t scripts < <(git ls-files '*.sh' | grep -viE '(^|/)(vendor|node_modules)/' || true)
-          if [ "${#scripts[@]}" -eq 0 ]; then
-            echo "シェルスクリプトが見つかりませんでした。スキップします。"
-            exit 0
-          fi
-          printf 'lint 対象: %s\n' "${scripts[@]}"
-          shellcheck --severity=warning "${scripts[@]}"
+    uses: genzouw/ci-workflows/.github/workflows/shellcheck.yml@28d2b9b6f563eb1126e786f28e308390b2558a47 # v1.0.1

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,5 +1,9 @@
 name: Trivy Scan
 
+# 本ワークフローは genzouw/ci-workflows の reusable workflow を呼び出す薄いスタブ。
+# ロジックの実体・変更は ci-workflows 側で一元管理する (トリガー定義のみここで持つ)。
+# 参照 SHA の更新は Dependabot (github-actions ecosystem) が自動で PR を出す。
+# 必須チェック (context: "trivy / Trivy filesystem scan") のため paths フィルタ禁止。
 on:
   push:
     branches: [main, master]
@@ -14,58 +18,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  # チェックアウト・リポジトリ参照用
   contents: read
-  # Trivy スキャン結果を GitHub Security タブへアップロードするために必要
   security-events: write
 
 jobs:
-  fs-scan:
-    name: Trivy filesystem scan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Install Trivy
-        env:
-          TRIVY_VERSION: v0.70.0
-        run: |
-          ARCH=Linux-64bit
-          BASE_URL="https://github.com/aquasecurity/trivy/releases/download/${TRIVY_VERSION}"
-          TARBALL="trivy_${TRIVY_VERSION#v}_${ARCH}.tar.gz"
-          curl -sSfL -o "${TARBALL}" "${BASE_URL}/${TARBALL}"
-          curl -sSfL -o trivy_checksums.txt "${BASE_URL}/trivy_${TRIVY_VERSION#v}_checksums.txt"
-          grep "${TARBALL}" trivy_checksums.txt | sha256sum -c -
-          tar -xzf "${TARBALL}" trivy
-          sudo install -m 0755 trivy /usr/local/bin/trivy
-
-      - name: Run Trivy (vulnerabilities)
-        run: |
-          trivy fs \
-            --format sarif \
-            --output trivy-fs.sarif \
-            --severity CRITICAL,HIGH \
-            --ignore-unfixed \
-            --scanners vuln \
-            --exit-code 0 \
-            .
-
-      - name: Run Trivy (misconfig & secret)
-        # 既存 Dockerfile の misconfig (root 実行・HEALTHCHECK 欠如等) を片付ける
-        # までは赤検知にしない (exit-code 0 = レポートのみ)。整備完了後に
-        # exit-code 1 へ戻して赤検知に切り替える。
-        run: |
-          trivy fs \
-            --severity CRITICAL,HIGH \
-            --scanners misconfig,secret \
-            --exit-code 0 \
-            .
-
-      - name: Upload SARIF to GitHub Security
-        if: always()
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
-        with:
-          sarif_file: 'trivy-fs.sarif'
-          category: trivy-fs
+  trivy:
+    uses: genzouw/ci-workflows/.github/workflows/trivy.yml@28d2b9b6f563eb1126e786f28e308390b2558a47 # v1.0.1

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,5 +1,9 @@
 name: zizmor
 
+# 本ワークフローは genzouw/ci-workflows の reusable workflow を呼び出す薄いスタブ。
+# ロジックの実体・変更は ci-workflows 側で一元管理する (トリガー定義のみここで持つ)。
+# 参照 SHA の更新は Dependabot (github-actions ecosystem) が自動で PR を出す。
+# 必須チェック (context: "zizmor / zizmor") のため paths フィルタ禁止。
 on:
   push:
     branches: ['**']
@@ -7,37 +11,14 @@ on:
     branches: ['**']
 
 concurrency:
-  group: zizmor-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: zizmor-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
+  security-events: write
+  actions: read
 
 jobs:
   zizmor:
-    name: zizmor
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      contents: read
-      actions: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
-
-      - name: Run zizmor 🌈
-        run: uvx zizmor --format sarif . > results.sarif
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
-
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
-        with:
-          sarif_file: results.sarif
-          category: zizmor
+    uses: genzouw/ci-workflows/.github/workflows/zizmor.yml@28d2b9b6f563eb1126e786f28e308390b2558a47 # v1.0.1


### PR DESCRIPTION
## 概要

統一CIベースラインを [genzouw/ci-workflows](https://github.com/genzouw/ci-workflows) の reusable workflow を呼び出す薄いスタブへ置換します（全公開リポジトリ横断施策。パイロット: genzouw/gpg#8 で全チェックグリーン確認済み）。

## 効果

- ロジック修正が ci-workflows への 1 PR で全リポジトリに波及（25リポジトリ一斉PRが不要に）
- 参照SHAの更新は Dependabot (github-actions ecosystem) が自動PR
- 各リポジトリのワークフローはトリガー定義のみに縮小

## 注意

- チェックの context 名が `<スタブjob名> / <本体job名>`（例: `gitleaks / Scan for leaked secrets`）へ変わります。Terraform (genzouw.com#231) の必須チェック名も新形式へ切替済みで、同PRのマージ+apply で整合します
- ci-workflows は v1.0.0 タグ + full SHA でピン留め

https://claude.ai/code/session_01EZDkTJMVWFqUL3Q5DzkZ7d