### PR TITLE
🎨 Palette: 装飾用の絵文字に aria-hidden="true" を追加

### DIFF
--- a/src/components/ActionDialog/BankruptDialog.tsx
+++ b/src/components/ActionDialog/BankruptDialog.tsx
@@ -20,7 +20,7 @@ export default function BankruptDialog({
       }
     >
       <div style={{ textAlign: 'center', padding: '16px 0', fontSize: 16 }}>
-        <div style={{ fontSize: 48, marginBottom: 12 }}>😢</div>
+        <div style={{ fontSize: 48, marginBottom: 12 }} aria-hidden="true">😢</div>
         <div>{playerName}はおかねがなくなってしまったよ。</div>
         <div
           style={{

--- a/src/components/ActionDialog/BankruptDialog.tsx
+++ b/src/components/ActionDialog/BankruptDialog.tsx
@@ -20,7 +20,9 @@ export default function BankruptDialog({
       }
     >
       <div style={{ textAlign: 'center', padding: '16px 0', fontSize: 16 }}>
-        <div style={{ fontSize: 48, marginBottom: 12 }} aria-hidden="true">😢</div>
+        <div style={{ fontSize: 48, marginBottom: 12 }} aria-hidden="true">
+          😢
+        </div>
         <div>{playerName}はおかねがなくなってしまったよ。</div>
         <div
           style={{

--- a/src/components/ActionDialog/CardDialog.tsx
+++ b/src/components/ActionDialog/CardDialog.tsx
@@ -17,7 +17,9 @@ export default function CardDialog({ card, onDismiss }: CardDialogProps) {
       actions={<Button onClick={onDismiss}>わかった！</Button>}
     >
       <div className={styles.cardContent}>
-        <div className={styles.cardEmoji} aria-hidden="true">{emoji}</div>
+        <div className={styles.cardEmoji} aria-hidden="true">
+          {emoji}
+        </div>
         <div>{card.text}</div>
       </div>
     </Dialog>

--- a/src/components/ActionDialog/CardDialog.tsx
+++ b/src/components/ActionDialog/CardDialog.tsx
@@ -17,7 +17,7 @@ export default function CardDialog({ card, onDismiss }: CardDialogProps) {
       actions={<Button onClick={onDismiss}>わかった！</Button>}
     >
       <div className={styles.cardContent}>
-        <div className={styles.cardEmoji}>{emoji}</div>
+        <div className={styles.cardEmoji} aria-hidden="true">{emoji}</div>
         <div>{card.text}</div>
       </div>
     </Dialog>


### PR DESCRIPTION
💡 What: `CardDialog` と `BankruptDialog` にある装飾用の絵文字に `aria-hidden="true"` を追加しました。
🎯 Why: スクリーンリーダーが装飾的な絵文字を不要に読み上げるのを防ぎ、視覚障害を持つユーザーにとってより明瞭な音声フィードバックを提供するためです。
📸 Before/After: (Visual changes are not present, only DOM attribute addition)
♿ Accessibility: 不要な音声読み上げを減らし、主要なメッセージの伝達を妨げないようにしました。

## 実行サマリー
- 対象リポジトリ: monopo
- 事前調査の概要: アクセシビリティの観点からコードを調査した結果、`CardDialog` や `BankruptDialog` で装飾目的の絵文字に `aria-hidden="true"` が設定されておらず、スクリーンリーダーで不要な読み上げが発生する可能性があることを確認しました。
- 選択した観点: アクセシビリティ（a11y）
- 選択したツール/強化: `aria-hidden="true"` 属性の追加
- 検討した代替案: 空の `alt` 属性 (`alt=""`) を持たせることは `div` タグには不適切なため除外。他のコンポーネント（例: `GameBoard` のアイコン）の追加修正も検討したが、今回は影響度と規模から対象を絞りました。
- PRリンク: (なし)
- 重複チェック結果: 既存の課題やPRとの重複はなし。
- 手動タスクの数: 0
- 残る将来のタスク: 新規コンポーネントにおける `aria-hidden` の適用ルールの徹底（`.jules/palette.md` に記載）。

---
*PR created automatically by Jules for task [18393971983729394526](https://jules.google.com/task/18393971983729394526) started by @genzouw*