### PR TITLE
chore(deps): 🔒 typescript のメジャーアップデートを Dependabot ignore に追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,6 +54,12 @@ updates:
           - '@types/*'
     allow:
       - dependency-type: 'all'
+    ignore:
+      # TypeScript 7（Goネイティブ実装）は typescript-eslint が未対応
+      # （peerDependencies: typescript >=4.8.4 <6.1.0）で ESLint がクラッシュするため、
+      # typescript-eslint の TS 7 対応リリースまでメジャーアップデートを停止する。
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
 
   # GitHub Actions
   - package-ecosystem: 'github-actions'


### PR DESCRIPTION
## 概要

Dependabot による typescript のメジャーアップデート提案（7.x）を停止する ignore 設定を追加します。

## 背景

- PR #365（typescript 6.0.3 → 7.0.2）の CI が ESLint で失敗
- 原因: typescript-eslint が TypeScript 7（Goネイティブ実装）に未対応。`@typescript-eslint/typescript-estree` が import 時に `TypeError: Cannot read properties of undefined (reading 'Cjs')` でクラッシュ
- 最新の typescript-eslint 8.63.0 でも peerDependencies は `typescript >=4.8.4 <6.1.0` で、TS 7 対応版は存在しない

## 変更内容

- `.github/dependabot.yml` の npm エコシステムに `typescript` の `version-update:semver-major` を ignore する設定を追加

## 解除条件

typescript-eslint が TypeScript 7 をサポートしたら、この ignore を削除して手動で更新 PR を作成する。

## 関連

- Closes: なし（PR #365 は別途クローズ）

https://claude.ai/code/session_01MAxoDryF6VrhFd7hdX4RRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * TypeScript のメジャーアップデートが自動更新対象から一時的に除外されました。
  * これにより、関連ツールとの互換性問題によるビルドや利用時の不具合を避けやすくなります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->