### PR TITLE
🎨 Palette: [UX improvement] 刑務所ダイアログのアクションと残数表示の明確化

### DIFF
--- a/src/components/ActionDialog/JailDialog.tsx
+++ b/src/components/ActionDialog/JailDialog.tsx
@@ -43,7 +43,7 @@ export default function JailDialog({
           </Button>
           {hasCards && (
             <Button variant="secondary" onClick={onUseCard}>
-              カードをつかう
+              カードをつかう（あと {currentPlayer.getOutOfJailCards} まい）
             </Button>
           )}
           <Button variant="secondary" onClick={onRollForJail}>
@@ -62,7 +62,8 @@ export default function JailDialog({
         )}
         {hasCards && (
           <div className={styles.hasCardHint}>
-            しゃくほうカードをもってるよ！
+            しゃくほうカードを {currentPlayer.getOutOfJailCards}{' '}
+            まいもってるよ！
           </div>
         )}
       </div>

--- a/src/components/ActionDialog/JailDialog.tsx
+++ b/src/components/ActionDialog/JailDialog.tsx
@@ -43,7 +43,7 @@ export default function JailDialog({
           </Button>
           {hasCards && (
             <Button variant="secondary" onClick={onUseCard}>
-              カードをつかう（あと {currentPlayer.getOutOfJailCards} まい）
+              カードをつかう（あと {currentPlayer.getOutOfJailCards}まい）
             </Button>
           )}
           <Button variant="secondary" onClick={onRollForJail}>
@@ -62,8 +62,7 @@ export default function JailDialog({
         )}
         {hasCards && (
           <div className={styles.hasCardHint}>
-            しゃくほうカードを {currentPlayer.getOutOfJailCards}{' '}
-            まいもってるよ！
+            しゃくほうカードを {currentPlayer.getOutOfJailCards}まいもってるよ！
           </div>
         )}
       </div>


### PR DESCRIPTION
💡 What: 刑務所から出るための「カードをつかう」ボタンおよびヒントテキストに、現在所持している釈放カードの残枚数を表示するようにしました。
🎯 Why: プレイヤーがカードを使う際、わざわざ自分のステータス詳細を開かなくても、あと何枚カードを持っているかをダイアログ上で直接確認できるようにするためです。
📸 Before/After: （視覚的な変更なし、テキスト表示のみの改善）
♿ Accessibility: 釈放カードの残り枚数が画面リーダー等でも直接読み上げられるようになり、コンテキストの理解が容易になります。

---
*PR created automatically by Jules for task [1780490825097093607](https://jules.google.com/task/1780490825097093607) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 「釈放カードを使う」ボタンと所持カードのヒントに、現在の所持枚数が表示されるようになりました。
  * 使用可能なカードの残り枚数を、より分かりやすく確認できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->