### PR TITLE
🎨 Palette: アクションダイアログの入力フォームのアクセシビリティ改善

### DIFF
--- a/src/components/ActionDialog/ActionDialog.module.css
+++ b/src/components/ActionDialog/ActionDialog.module.css
@@ -229,19 +229,25 @@
   color: var(--color-danger);
   font-size: 13px;
 }
+/* おかね入力の上限超過エラー用ヒント。入力欄の右横にインラインで表示する。 */
+.tradeMoneyErrorHint {
+  color: var(--color-danger);
+  font-size: 12px;
+  margin-left: 8px;
+}
 .tradeEmptyProperties {
   font-size: 13px;
   color: var(--color-text-light);
   padding: 4px 8px;
 }
 
-.moneyInput[aria-invalid="true"],
-.buildItemActions input[aria-invalid="true"] {
+.moneyInput[aria-invalid='true'],
+.buildItemActions input[aria-invalid='true'] {
   border-color: var(--color-danger, #ff4d4f);
-  background-color: #fff0f0;
+  background-color: var(--color-danger-bg, #fff0f0);
 }
-.moneyInput[aria-invalid="true"]:focus-visible,
-.buildItemActions input[aria-invalid="true"]:focus-visible {
+.moneyInput[aria-invalid='true']:focus-visible,
+.buildItemActions input[aria-invalid='true']:focus-visible {
   outline: 2px solid var(--color-danger, #ff4d4f);
   outline-offset: 1px;
 }

--- a/src/components/ActionDialog/ActionDialog.module.css
+++ b/src/components/ActionDialog/ActionDialog.module.css
@@ -234,3 +234,14 @@
   color: var(--color-text-light);
   padding: 4px 8px;
 }
+
+.moneyInput[aria-invalid="true"],
+.buildItemActions input[aria-invalid="true"] {
+  border-color: var(--color-danger, #ff4d4f);
+  background-color: #fff0f0;
+}
+.moneyInput[aria-invalid="true"]:focus-visible,
+.buildItemActions input[aria-invalid="true"]:focus-visible {
+  outline: 2px solid var(--color-danger, #ff4d4f);
+  outline-offset: 1px;
+}

--- a/src/components/ActionDialog/LoanDialog.tsx
+++ b/src/components/ActionDialog/LoanDialog.tsx
@@ -152,7 +152,9 @@ export default function LoanDialog({
                   style={{ width: 120 }}
                   aria-label="借入金額"
                   aria-invalid={!canBorrow && borrowAmount !== ''}
-                  aria-errormessage={!canBorrow && borrowAmount !== '' ? borrowHintId : undefined}
+                  aria-errormessage={
+                    !canBorrow && borrowAmount !== '' ? borrowHintId : undefined
+                  }
                 />
                 <Button
                   size="small"
@@ -173,7 +175,7 @@ export default function LoanDialog({
                 <div
                   id={borrowHintId}
                   className={styles.noMoneyHintTight}
-                  role="status"
+                  role="alert"
                 >
                   かりられる上限をこえているか、正しくないよ
                 </div>
@@ -202,7 +204,9 @@ export default function LoanDialog({
                   style={{ width: 120 }}
                   aria-label="返済金額"
                   aria-invalid={!canRepay && repayAmount !== ''}
-                  aria-errormessage={!canRepay && repayAmount !== '' ? repayHintId : undefined}
+                  aria-errormessage={
+                    !canRepay && repayAmount !== '' ? repayHintId : undefined
+                  }
                 />
                 <Button
                   size="small"
@@ -224,7 +228,7 @@ export default function LoanDialog({
                 <div
                   id={repayHintId}
                   className={styles.noMoneyHintTight}
-                  role="status"
+                  role="alert"
                 >
                   {parsedRepay > currentPlayer.money
                     ? 'おかねがたりないよ'

--- a/src/components/ActionDialog/LoanDialog.tsx
+++ b/src/components/ActionDialog/LoanDialog.tsx
@@ -148,9 +148,11 @@ export default function LoanDialog({
                     if (val.length > MAX_MONEY_INPUT_LENGTH) return;
                     setBorrowAmount(val);
                   }}
-                  placeholder={`最大 $${maxBorrow}`}
+                  placeholder={`最大 ${maxBorrow}`}
                   style={{ width: 120 }}
                   aria-label="借入金額"
+                  aria-invalid={!canBorrow && borrowAmount !== ''}
+                  aria-errormessage={!canBorrow && borrowAmount !== '' ? borrowHintId : undefined}
                 />
                 <Button
                   size="small"
@@ -196,9 +198,11 @@ export default function LoanDialog({
                     if (val.length > MAX_MONEY_INPUT_LENGTH) return;
                     setRepayAmount(val);
                   }}
-                  placeholder={`残高 $${loanBalance}`}
+                  placeholder={`残高 ${loanBalance}`}
                   style={{ width: 120 }}
                   aria-label="返済金額"
+                  aria-invalid={!canRepay && repayAmount !== ''}
+                  aria-errormessage={!canRepay && repayAmount !== '' ? repayHintId : undefined}
                 />
                 <Button
                   size="small"

--- a/src/components/ActionDialog/LoanDialog.tsx
+++ b/src/components/ActionDialog/LoanDialog.tsx
@@ -155,6 +155,9 @@ export default function LoanDialog({
                   aria-errormessage={
                     !canBorrow && borrowAmount !== '' ? borrowHintId : undefined
                   }
+                  aria-describedby={
+                    !canBorrow && borrowAmount !== '' ? borrowHintId : undefined
+                  }
                 />
                 <Button
                   size="small"
@@ -205,6 +208,9 @@ export default function LoanDialog({
                   aria-label="返済金額"
                   aria-invalid={!canRepay && repayAmount !== ''}
                   aria-errormessage={
+                    !canRepay && repayAmount !== '' ? repayHintId : undefined
+                  }
+                  aria-describedby={
                     !canRepay && repayAmount !== '' ? repayHintId : undefined
                   }
                 />

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -117,8 +117,10 @@ export default function TradeDialog({
     );
   };
 
-  const isOfferMoneyInvalid = offerMoney > currentPlayer.money;
-  const isRequestMoneyInvalid = requestMoney > targetPlayer.money;
+  const isOfferMoneyInvalid =
+    offerMoney < 0 || offerMoney > currentPlayer.money;
+  const isRequestMoneyInvalid =
+    requestMoney < 0 || requestMoney > targetPlayer.money;
   const isTradeEmpty =
     offerProperties.length === 0 &&
     requestProperties.length === 0 &&
@@ -147,7 +149,9 @@ export default function TradeDialog({
           <div className={styles.tradeActionButtons}>
             <Button
               onClick={handlePropose}
-              aria-disabled={isTradeEmpty || isOfferMoneyInvalid || isRequestMoneyInvalid}
+              aria-disabled={
+                isTradeEmpty || isOfferMoneyInvalid || isRequestMoneyInvalid
+              }
               aria-describedby={isTradeEmpty ? tradeEmptyHintId : undefined}
             >
               {LABELS.propose}
@@ -231,10 +235,17 @@ export default function TradeDialog({
               setOfferMoney(val);
             }}
             aria-invalid={isOfferMoneyInvalid}
-            aria-errormessage={isOfferMoneyInvalid ? offerMoneyErrorId : undefined}
+            aria-errormessage={
+              isOfferMoneyInvalid ? offerMoneyErrorId : undefined
+            }
           />
           {isOfferMoneyInvalid && (
-            <div id={offerMoneyErrorId} className={styles.tradeEmptyHint} role="alert" style={{marginLeft: 8, fontSize: 12}}>
+            <div
+              id={offerMoneyErrorId}
+              className={styles.tradeEmptyHint}
+              role="alert"
+              style={{ marginLeft: 8, fontSize: 12 }}
+            >
               所持金を超えています
             </div>
           )}
@@ -333,10 +344,17 @@ export default function TradeDialog({
               setRequestMoney(val);
             }}
             aria-invalid={isRequestMoneyInvalid}
-            aria-errormessage={isRequestMoneyInvalid ? requestMoneyErrorId : undefined}
+            aria-errormessage={
+              isRequestMoneyInvalid ? requestMoneyErrorId : undefined
+            }
           />
           {isRequestMoneyInvalid && (
-            <div id={requestMoneyErrorId} className={styles.tradeEmptyHint} role="alert" style={{marginLeft: 8, fontSize: 12}}>
+            <div
+              id={requestMoneyErrorId}
+              className={styles.tradeEmptyHint}
+              role="alert"
+              style={{ marginLeft: 8, fontSize: 12 }}
+            >
               相手の所持金を超えています
             </div>
           )}

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -78,6 +78,8 @@ export default function TradeDialog({
   const offerMoneyId = useId();
   const requestMoneyId = useId();
   const tradeEmptyHintId = useId();
+  const offerMoneyErrorId = useId();
+  const requestMoneyErrorId = useId();
   const [offerProperties, setOfferProperties] = useState<string[]>([]);
   const [requestProperties, setRequestProperties] = useState<string[]>([]);
   const [offerMoney, setOfferMoney] = useState(0);
@@ -115,6 +117,8 @@ export default function TradeDialog({
     );
   };
 
+  const isOfferMoneyInvalid = offerMoney > currentPlayer.money;
+  const isRequestMoneyInvalid = requestMoney > targetPlayer.money;
   const isTradeEmpty =
     offerProperties.length === 0 &&
     requestProperties.length === 0 &&
@@ -143,7 +147,7 @@ export default function TradeDialog({
           <div className={styles.tradeActionButtons}>
             <Button
               onClick={handlePropose}
-              aria-disabled={isTradeEmpty}
+              aria-disabled={isTradeEmpty || isOfferMoneyInvalid || isRequestMoneyInvalid}
               aria-describedby={isTradeEmpty ? tradeEmptyHintId : undefined}
             >
               {LABELS.propose}
@@ -223,9 +227,17 @@ export default function TradeDialog({
               }
               const val = Number(raw);
               if (isNaN(val)) return;
-              setOfferMoney(clamp(val, currentPlayer.money));
+              // Remove clamp here so user can type and see error if they overtype
+              setOfferMoney(val);
             }}
+            aria-invalid={isOfferMoneyInvalid}
+            aria-errormessage={isOfferMoneyInvalid ? offerMoneyErrorId : undefined}
           />
+          {isOfferMoneyInvalid && (
+            <div id={offerMoneyErrorId} className={styles.tradeEmptyHint} role="alert" style={{marginLeft: 8, fontSize: 12}}>
+              所持金を超えています
+            </div>
+          )}
           <div className={styles.moneyQuickButtons}>
             <button
               type="button"
@@ -317,9 +329,17 @@ export default function TradeDialog({
               }
               const val = Number(raw);
               if (isNaN(val)) return;
-              setRequestMoney(clamp(val, targetPlayer.money));
+              // Remove clamp here so user can type and see error if they overtype
+              setRequestMoney(val);
             }}
+            aria-invalid={isRequestMoneyInvalid}
+            aria-errormessage={isRequestMoneyInvalid ? requestMoneyErrorId : undefined}
           />
+          {isRequestMoneyInvalid && (
+            <div id={requestMoneyErrorId} className={styles.tradeEmptyHint} role="alert" style={{marginLeft: 8, fontSize: 12}}>
+              相手の所持金を超えています
+            </div>
+          )}
           <div className={styles.moneyQuickButtons}>
             <button
               type="button"

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -231,20 +231,22 @@ export default function TradeDialog({
               }
               const val = Number(raw);
               if (isNaN(val)) return;
-              // Remove clamp here so user can type and see error if they overtype
+              // クランプを削除し、上限超過時にエラーとして表示できるようにする
               setOfferMoney(val);
             }}
             aria-invalid={isOfferMoneyInvalid}
             aria-errormessage={
               isOfferMoneyInvalid ? offerMoneyErrorId : undefined
             }
+            aria-describedby={
+              isOfferMoneyInvalid ? offerMoneyErrorId : undefined
+            }
           />
           {isOfferMoneyInvalid && (
             <div
               id={offerMoneyErrorId}
-              className={styles.tradeEmptyHint}
+              className={styles.tradeMoneyErrorHint}
               role="alert"
-              style={{ marginLeft: 8, fontSize: 12 }}
             >
               所持金を超えています
             </div>
@@ -340,20 +342,22 @@ export default function TradeDialog({
               }
               const val = Number(raw);
               if (isNaN(val)) return;
-              // Remove clamp here so user can type and see error if they overtype
+              // クランプを削除し、上限超過時にエラーとして表示できるようにする
               setRequestMoney(val);
             }}
             aria-invalid={isRequestMoneyInvalid}
             aria-errormessage={
               isRequestMoneyInvalid ? requestMoneyErrorId : undefined
             }
+            aria-describedby={
+              isRequestMoneyInvalid ? requestMoneyErrorId : undefined
+            }
           />
           {isRequestMoneyInvalid && (
             <div
               id={requestMoneyErrorId}
-              className={styles.tradeEmptyHint}
+              className={styles.tradeMoneyErrorHint}
               role="alert"
-              style={{ marginLeft: 8, fontSize: 12 }}
             >
               相手の所持金を超えています
             </div>

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -248,7 +248,9 @@ export default function TradeDialog({
               className={styles.tradeMoneyErrorHint}
               role="alert"
             >
-              所持金を超えています
+              {offerMoney < 0
+                ? '0以上の金額を入力してね'
+                : '所持金を超えています'}
             </div>
           )}
           <div className={styles.moneyQuickButtons}>
@@ -359,7 +361,9 @@ export default function TradeDialog({
               className={styles.tradeMoneyErrorHint}
               role="alert"
             >
-              相手の所持金を超えています
+              {requestMoney < 0
+                ? '0以上の金額を入力してね'
+                : '相手の所持金を超えています'}
             </div>
           )}
           <div className={styles.moneyQuickButtons}>


### PR DESCRIPTION
💡 What:
ローンやトレードなどアクションダイアログ内の入力フォームにおいて、入力エラー時に `aria-invalid="true"` 属性と対応する `aria-errormessage` を付与し、視覚的なエラースタイルも適用しました。また、入力時に強制的に値をクランプする挙動を修正し、ユーザーが正しくない値を一時的に入力してもエラーメッセージが表示されるようにしました。

🎯 Why:
上限金額を超えた場合などのエラーがスクリーンリーダーに伝わっておらず、入力エラーなのか判別しづらいアクセシビリティ上の課題がありました。また視覚的にも、エラー時に枠線が赤くなるなどのフィードバックが不足していました。さらに入力時に自動的に値が修正される仕様は、ユーザーにとって「なぜ入力できないのか」が分かりづらい問題がありました。

📸 Before/After:
（視覚的変更：エラー時に入力欄の枠線と背景色が赤みがかり、エラーメッセージが近くに表示されるようになりました）

♿ Accessibility:
エラー状態を `aria-invalid` に直接マッピングし、エラーメッセージを `aria-errormessage` で紐付けることで、視覚的状態と支援技術向けの状態を同期させました。これにより、スクリーンリーダーを利用するユーザーがフォーム入力の失敗理由をより正確に把握できるようになります。

---
*PR created automatically by Jules for task [4280323628489311491](https://jules.google.com/task/4280323628489311491) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 借入・返済入力のプレースホルダーを上限/残高表示に変更し、上限超過時は `aria-invalid` と `aria-errormessage` を紐づけてエラーを明確化しました。
  * 取引の所持金超過時に、入力欄へ危険表示と `role="alert"` のエラー情報を付与し、提案ボタンも無効化します。
  * 無効状態の枠線/背景色を `:focus-visible` 時にも反映し、危険系のエラーハント表示用クラスを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->