### PR TITLE
🎨 Palette: フォームバリデーションのアクセシビリティ改善

### DIFF
--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -254,7 +254,9 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
               }
               aria-describedby={[
                 `${baseId}-char-count-${i}`,
-                names[i].trim().length === 0 ? `${baseId}-name-error-${i}` : null,
+                names[i].trim().length === 0
+                  ? `${baseId}-name-error-${i}`
+                  : null,
               ]
                 .filter(Boolean)
                 .join(' ')}

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -252,7 +252,12 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
                   ? `${baseId}-name-error-${i}`
                   : undefined
               }
-              aria-describedby={`${baseId}-char-count-${i}`}
+              aria-describedby={[
+                `${baseId}-char-count-${i}`,
+                names[i].trim().length === 0 ? `${baseId}-name-error-${i}` : null,
+              ]
+                .filter(Boolean)
+                .join(' ')}
             />
             <span
               id={`${baseId}-char-count-${i}`}


### PR DESCRIPTION
💡 What: プレイヤー名入力フォームのエラー表示において、`aria-errormessage` だけでなく `aria-describedby` にもエラーメッセージIDを含めるように修正しました。

🎯 Why: WAI-ARIAのベストプラクティスに従い、`aria-errormessage` をまだ完全にサポートしていない一部のスクリーンリーダーでも、エラー内容が確実に読み上げられるようにするためです。

📸 Before/After: （視覚的な変更はありません）

♿ Accessibility: `aria-invalid="true"` 時のエラーメッセージを `aria-describedby` に追加し、後方互換性のある堅牢なエラー通知を実現しました。

---
*PR created automatically by Jules for task [3658742467005018173](https://jules.google.com/task/3658742467005018173) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **アクセシビリティ**
  * プレイヤー名入力欄の読み上げ対象を調整し、文字数カウンター情報を常に案内するよう改善しました。
  * 入力が空の場合に限り、名前に関するエラーメッセージもあわせて案内されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->