### PR TITLE
chore(security): 🔒 gitleaks カスタムルールによる DB/キャッシュ接続文字列検知の強化

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -70,3 +70,16 @@ regexes = [
 paths = [
     '''docs/security/'''
 ]
+
+[[rules]]
+id = "monopo-connection-string"
+description = "データベース・キャッシュ等の接続文字列 (postgres, redis, mongodb 等) のハードコード検知"
+regex = '''(?i)(?:postgres(?:ql)?|redis|mongodb(?:\+srv)?|mysql)://(?:[^:]+:[^@]+@)?[^/]+(?:/[^?]*)?(?:\?[^"'\s]*)?'''
+tags = ["database", "connection-string", "credential"]
+secretGroup = 0
+entropy = 0.0
+[rules.allowlist]
+regexes = [
+    '''(?i)postgres(?:ql)?://(user:pass@)?localhost''',
+    '''(?i)redis://localhost'''
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -80,6 +80,5 @@ secretGroup = 0
 entropy = 0.0
 [rules.allowlist]
 regexes = [
-    '''(?i)postgres(?:ql)?://(user:pass@)?localhost''',
-    '''(?i)redis://localhost'''
+    '''(?i)(?:postgres(?:ql)?|redis|mongodb(?:\+srv)?|mysql)://(?:[^:]+:[^@]+@)?(?:localhost|127\.0\.0\.1)(?:[:/?]|$)'''
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -74,7 +74,7 @@ paths = [
 [[rules]]
 id = "monopo-connection-string"
 description = "データベース・キャッシュ等の接続文字列 (postgres, redis, mongodb 等) のハードコード検知"
-regex = '''(?i)(?:postgres(?:ql)?|redis|mongodb(?:\+srv)?|mysql)://(?:[^:]+:[^@]+@)?[^/]+(?:/[^?]*)?(?:\?[^"'\s]*)?'''
+regex = '''(?i)(?:postgres(?:ql)?|redis|mongodb(?:\+srv)?|mysql)://(?:[^:]+:[^@]+@)?[^/"'\s]+(?:/[^?"'\s]*)?(?:\?[^"'\s]*)?'''
 tags = ["database", "connection-string", "credential"]
 secretGroup = 0
 entropy = 0.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,3 +68,7 @@ CI の監査ワークフロー (`.github/workflows/permissions-audit.yml`) に�
 ### PR スキャン対象ブランチの拡張について
 
 TruffleHog および pre-commit（gitleaks/detect-secrets）による CI スキャンは、`main` ブランチだけでなく全てのフィーチャーブランチの PR に対しても実行されるよう設定されています。これにより、開発の初期段階からシークレットの流出やポリシー違反を未然に防ぎます。
+
+### 接続文字列・バックエンドURLのハードコード禁止
+
+データベース（PostgreSQL, MongoDB, MySQL）やキャッシュ（Redis）への完全な接続文字列（`postgres://...` や `redis://...` 等）のソースコードへのハードコードは、`.gitleaks.toml` のカスタムルール (`monopo-connection-string`) によって検知・ブロックされます。パスワードが含まれていない場合でも、環境によって接続先が変わるべき値であるため、必ず環境変数経由で設定してください。


### PR DESCRIPTION
## 背景

事前調査の結果、対象リポジトリには `gitleaks`, `trivy`, `trufflehog` による強固なシークレットスキャン体制が構築済みであり、ローカル（pre-commit）とCIの多層防御が整備されています。しかし、完全なデータベース接続文字列（postgres://, redis:// 等）のハードコードを明確に検知するカスタムルールが `.gitleaks.toml` に不足していることが判明しました。

## 現状認識（事前調査結果のサマリー）

- 既存防御策: `gitleaks`, `trufflehog`, `trivy` が pre-commit と CI で導入済み。`.gitleaks.toml` には PII や Cloud ID のカスタムルールが存在。
- 未カバー領域: 接続文字列（Postgres, Redis, MongoDB 等）のハードコード検知。
- 直近の漏洩リスク兆候: 特段の流出形跡は見られませんでしたが、将来的な DB 接続情報やキャッシュエンドポイントの誤混入を防ぐためのプロアクティブな対策が必要です。

## このPRで導入・強化するもの

- 対象: 既存 `.gitleaks.toml` と `SECURITY.md`
- ツール名とバージョン: gitleaks v8.x (設定追加のみ)
- 期待される効果: 開発者がローカルで `postgres://` や `redis://` を含むコードをコミットしようとした際に、gitleaks が検知してブロックし、接続情報の公開リポジトリへの混入を未然に防ぎます。

## 検知漏れリスクと補完策

- 検知できないケース: 一般的なプロトコルスキームを持たない独自形式の接続情報、または細かく分割して動的に結合される接続文字列。
- 補完策: 既存の CodeQL によるデータフロー解析、および GitHub ネイティブの Secret Scanning/Push Protection と組み合わせてカバーします。

## マージ前に必要な手動作業（チェックリスト）

レビュアーは PR をマージする前に必ず以下を実施してください。
本 PR の CI は手動作業完了を前提に通る設計です。

- [x] 特になし (設定ファイルの追加のみのため)

## マージ後の確認手順

- [ ] 次の push / PR で既存の gitleaks CI ワークフローが green になることを確認
- [ ] ローカルで gitleaks を実行し、既存コードに誤検知（False Positive）が発生しないことを確認

## ロールバック手順

問題が出た場合は、本 PR で `.gitleaks.toml` に追加した `[[rules]]` ブロック（id="monopo-connection-string"）と `SECURITY.md` の該当追記部分を削除してください。

## 参考情報

- 公式ドキュメント: https://github.com/gitleaks/gitleaks
- 比較検討した他案: `detect-secrets` のプラグイン拡張も検討しましたが、プロジェクト内で正規表現による柔軟な検知・ブロックを中心的に担っているのは Gitleaks であり、Gitleaks への設定集約が最も運用がシンプルなため本案を採用しました。

---
*PR created automatically by Jules for task [6422942696429869858](https://jules.google.com/task/6422942696429869858) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **セキュリティ**
  * PostgreSQL、Redis、MongoDB、MySQLなどの接続文字列がソースコードにハードコードされていないか検知するルールを追加しました。
  * ローカル開発用の接続設定は検知対象から除外されます。

* **ドキュメント**
  * 接続文字列やバックエンドURLは環境変数で設定するよう、セキュリティガイドに注意事項を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->