### PR TITLE
chore(security): 🔒 Dependabot による pre-commit 強化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,3 +85,22 @@ updates:
       # node24 を正式サポートするまではメジャーアップデートを停止する。
       - dependency-name: 'DavidAnson/markdownlint-cli2-action'
         update-types: ['version-update:semver-major']
+
+  # pre-commit hooks
+  - package-ecosystem: 'pre-commit'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Asia/Tokyo'
+    open-pull-requests-limit: 5
+    target-branch: 'main'
+    reviewers:
+      - 'genzouw'
+    labels:
+      - 'dependencies'
+      - 'security'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -101,6 +101,9 @@ updates:
     labels:
       - 'dependencies'
       - 'security'
+    # 新規リリースを即座に取り込まず一定期間の検証期間を設けることで、
+    # サプライチェーン攻撃（悪意あるリリースの即時混入）のリスクを低減する。
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: 'chore'
-      include: 'scope'

--- a/docs/security/leak-prevention.md
+++ b/docs/security/leak-prevention.md
@@ -98,3 +98,7 @@ CI の監査ワークフロー (`.github/workflows/permissions-audit.yml`) に�
 
 - **必須**: 開発環境には [TruffleHog](https://github.com/trufflesecurity/trufflehog) をインストールしてください（例: `brew install trufflehog`）。未インストールの場合、コミット時にエラーが発生してブロックされます。
 - **オフライン時の回避策**: TruffleHog はデフォルトでシークレットの有効性を外部プロバイダに問い合わせて検証するため、オフライン環境ではコミットが失敗する場合があります。その場合は `SKIP=trufflehog git commit ...` のようにフックを一時的にスキップしてください。
+
+### Dependabot による pre-commit ツールの自動更新
+
+シークレット検知ツール（gitleaks, trufflehog, detect-secrets）を含む `pre-commit` フックのバージョンを常に最新かつ安全に保つため、`.github/dependabot.yml` にて `pre-commit` エコシステムの自動更新を有効化しています。これにより、新しいシークレットパターンへの対応や脆弱性修正が継続的かつ自動で取り込まれ、漏洩防止の防御力が維持されます。


### PR DESCRIPTION
## 背景

事前調査により、プロジェクトには既に `.pre-commit-config.yaml` を用いて gitleaks や trufflehog といった強力なローカルフックが導入されていることが確認できました。しかし、これらセキュリティツールのバージョンを継続的・自動的に最新に保つ仕組みが `.github/dependabot.yml` に不足しており、ツールの検知ルールが陳腐化する懸念（現状ギャップ）がありました。

## 現状認識（事前調査結果のサマリー）

- 既存防御策: `.pre-commit-config.yaml`, `gitleaks.yml`, `trufflehog.yml`, `trivy.yml` 等が既に導入済み
- 未カバー領域: `pre-commit` で管理している各フックの定期的なバージョン追従（Dependabot に未登録）
- 直近の漏洩リスク兆候: 特になし（`.env` 等のヒストリへの流出痕跡なし）

## このPRで導入・強化するもの

- 対象: 既存の `.github/dependabot.yml` へ `pre-commit` エコシステムを追加
- ツール名とバージョン: Dependabot (pre-commit 対応)
- 期待される効果: 定期的に `pre-commit` のフック（gitleaks, detect-secrets 等）を最新版に自動更新する PR が作成されるようになり、最新の漏洩検知ルールを保つことができます。

## 検知漏れリスクと補完策

- 検知できないケース: 未対応のカスタムフォーマットや Dependabot 自体が対応していないマイナーツールの更新
- 補完策: 定期的な手動監査、および CI 上での TruffleHog / Trivy の自動スキャンにより二重にカバーします。

## マージ前に必要な手動作業（チェックリスト）

レビュアーは PR をマージする前に必ず以下を実施してください。
本 PR の CI は手動作業完了を前提に通る設計です。

- [ ] 既に設定済みの GitHub Code security → Push protection が有効になっていることを再確認する
- [ ] 本 PR をマージ後、Dependabot が `.pre-commit-config.yaml` に対する更新 PR を作成するか監視する

## マージ後の確認手順

- [ ] 次の push / PR で導入した workflow が green になることを確認
- [ ] リポジトリの Insights > Dependency graph に pre-commit ツール群が反映されているか確認

## ロールバック手順

問題が出た場合は、`.github/dependabot.yml` から `package-ecosystem: 'pre-commit'` のブロックを削除してください。

## 参考情報

- 公式ドキュメント: https://docs.github.com/ja/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
- 比較検討した他案: `pre-commit autoupdate` を手動で定期実行する CI の作成（Dependabot ネイティブ対応のほうが通知・管理コストが低いため却下）

---
*PR created automatically by Jules for task [16279777621408372824](https://jules.google.com/task/16279777621408372824) started by @genzouw*