### PR TITLE
⚡ Bolt: [performance improvement] MortgageDialogのプロパティ一覧をメモ化

### DIFF
--- a/src/components/ActionDialog/MortgageDialog.tsx
+++ b/src/components/ActionDialog/MortgageDialog.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react';
+import { useId, useMemo } from 'react';
 import type { BoardSpace, Player, PropertyState } from '../../game/types';
 import { canMortgage, canUnmortgage, getSpaceById } from '../../game/rules';
 import Dialog from '../common/Dialog';
@@ -23,9 +23,14 @@ export default function MortgageDialog({
   onClose,
 }: MortgageDialogProps) {
   const hintIdBase = useId();
-  const ownedProperties = currentPlayer.properties
-    .map((id: string) => getSpaceById(id, board))
-    .filter((s): s is BoardSpace => !!s && !!s.mortgageValue);
+
+  // ⚡ Bolt: useMemo to prevent mapping and filtering the properties array on every render.
+  // This reduces rendering overhead when the mortgage dialog is open and parent state changes.
+  const ownedProperties = useMemo(() => {
+    return currentPlayer.properties
+      .map((id: string) => getSpaceById(id, board))
+      .filter((s): s is BoardSpace => !!s && !!s.mortgageValue);
+  }, [currentPlayer.properties, board]);
 
   return (
     <Dialog

--- a/src/components/ActionDialog/MortgageDialog.tsx
+++ b/src/components/ActionDialog/MortgageDialog.tsx
@@ -24,12 +24,15 @@ export default function MortgageDialog({
 }: MortgageDialogProps) {
   const hintIdBase = useId();
 
-  // ⚡ Bolt: useMemo to prevent mapping and filtering the properties array on every render.
-  // This reduces rendering overhead when the mortgage dialog is open and parent state changes.
+  // ⚡ Bolt: 毎回のレンダリングで物件配列のマッピングとフィルタリングが行われるのを防ぐため、useMemo を使用します。
+  // これにより、抵当ダイアログが開いている状態での親コンポーネントの状態変更に伴うレンダリングのオーバーヘッドを削減します。
   const ownedProperties = useMemo(() => {
     return currentPlayer.properties
-      .map((id: string) => getSpaceById(id, board))
-      .filter((s): s is BoardSpace => !!s && !!s.mortgageValue);
+      .map((id) => getSpaceById(id, board))
+      .filter(
+        (s): s is BoardSpace =>
+          s !== undefined && s.mortgageValue !== undefined,
+      );
   }, [currentPlayer.properties, board]);
 
   return (


### PR DESCRIPTION
### 💡 What
`MortgageDialog` 内の `ownedProperties` 配列の生成処理を `useMemo` でラップし、`currentPlayer.properties` または `board` が変更された時のみ再計算されるようにしました。

### 🎯 Why
現在、親コンポーネントで状態変更があるたびに `MortgageDialog` が再レンダーされ、毎回 `currentPlayer.properties` からのマップ処理（`getSpaceById`）とフィルタリング処理が走っていました。他のアクションダイアログ（BuildDialog, SellDialogなど）ではすでにメモ化されていましたが、MortgageDialogでは対応漏れがあったため、パターンを統一して不要な処理オーバーヘッドを防ぎます。

### 📊 Impact
ダイアログが開いている間の親状態の更新時における、O(N) の配列マッピングとフィルタリングによる不要な処理とガベージコレクションを削減。

### 🔬 Measurement
1. ローカルで `bun run dev` を起動
2. 抵当に入れられる物件を所有した状態で抵当ダイアログを開く
3. 他のプレイヤーのターン進行時などに再計算が走らないことを React DevTools Profiler で確認

---
*PR created automatically by Jules for task [18314052160870035240](https://jules.google.com/task/18314052160870035240) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 住宅ローン画面で表示される物件情報の生成処理を最適化しました。
  * 画面の再レンダリング時における不要な再計算を減らし、表示パフォーマンスを向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->