### PR TITLE
chore(security): 🔒 actionlint による CI設定ファイルのローカル脆弱性検知強化

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,11 @@ repos:
       - id: trufflehog
         stages: [commit]
 
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
   - repo: local
     hooks:
       - id: forbid-sensitive-files

--- a/docs/security/leak-prevention.md
+++ b/docs/security/leak-prevention.md
@@ -41,6 +41,8 @@
   - `security-extended` および `security-and-quality` クエリを使用して、データフロー解析によるシークレットのハードコード検知や品質チェックなど、高度な静的解析を行います。
 - **Zizmor ワークフロー (`.github/workflows/zizmor.yml`)**:
   - `zizmor` を利用して、GitHub Actions ワークフロー自体の脆弱性（インジェクションリスクや不適切な権限設定など）を静的解析し、CI 設定を経由した情報漏洩を未然に防ぎます。
+- **Actionlint フック (pre-commit)**:
+  - CI ワークフローファイル (`.github/workflows/*.yml`) にインジェクション脆弱性や設定ミスが混入することをコミット前に防ぐため、ローカルの pre-commit フックとして `actionlint` を導入しています。
 - **権限 (Permissions) の最小化**:
   - CI の各ワークフロー (`.github/workflows/*.yml`) では `permissions` が明示されており、GitHub Actions が必要以上にリポジトリを書き換える権限を持たないように設計されています。
 

--- a/docs/security/leak-prevention.md
+++ b/docs/security/leak-prevention.md
@@ -42,7 +42,8 @@
 - **Zizmor ワークフロー (`.github/workflows/zizmor.yml`)**:
   - `zizmor` を利用して、GitHub Actions ワークフロー自体の脆弱性（インジェクションリスクや不適切な権限設定など）を静的解析し、CI 設定を経由した情報漏洩を未然に防ぎます。
 - **Actionlint フック (pre-commit)**:
-  - CI ワークフローファイル (`.github/workflows/*.yml`) にインジェクション脆弱性や設定ミスが混入することをコミット前に防ぐため、ローカルの pre-commit フックとして `actionlint` を導入しています。
+  - `.github/workflows/` 配下の YAML ファイル（`.yml` / `.yaml`、サブディレクトリ含む）に対して、actionlint が検知可能なインジェクションリスクや設定ミスをコミット前に検査します。
+  - 動的に取得される外部スクリプトなど actionlint の対象外となるリスクは、zizmor および `permissions-audit.yml` の CI 検査で補完します。
 - **権限 (Permissions) の最小化**:
   - CI の各ワークフロー (`.github/workflows/*.yml`) では `permissions` が明示されており、GitHub Actions が必要以上にリポジトリを書き換える権限を持たないように設計されています。
 


### PR DESCRIPTION
## 背景

対象リポジトリ（monopo）は既に gitleaks や TruffleHog を用いたコミット前および CI でのシークレット検知が強固に設定されています。一方で、CI ワークフローファイル（`.github/workflows/*.yml`）自体にインジェクション脆弱性や不適切な設定（例: `pull_request_target` トリガーの誤用）が混入し、それを経由してシークレットが漏洩するリスクが存在します。CI では zizmor や actionlint が稼働していますが、ローカルでのコミット前検知には含まれていませんでした。

## 現状認識（事前調査結果のサマリー）

- 既存防御策: pre-commit (gitleaks, trufflehog, detect-secrets)、CI (gitleaks.yml, codeql.yml, trivy.yml, zizmor.yml, actionlint.yml) 導入済み
- 未カバー領域: ワークフローファイルの静的解析（actionlint）のコミット前（ローカル）での実行
- 直近の漏洩リスク兆候: 現在のところ直接的な兆候はないものの、CI を経由したインジェクションによる漏洩経路を上流で防ぐ必要があります。

## このPRで導入・強化するもの

- 対象: 既存の `.pre-commit-config.yaml` への新規 hook 追加および `docs/security/leak-prevention.md` の更新
- ツール名とバージョン: actionlint v1.7.12
- 期待される効果: 開発者がローカルでコミットする前に、`.github/workflows/` 配下のファイルに対してインジェクション脆弱性や設定ミスを検知し、脆弱な CI ワークフローがリモートにプッシュされるのをブロックします。

## 検知漏れリスクと補完策

- 検知できないケース: 動的に外部から取得される悪意あるスクリプトの実行など、actionlint の静的解析の範囲外の動作。
- 補完策: 既存の `zizmor` ワークフローおよび `permissions-audit.yml` による CI での二重チェックで補完します。

## マージ前に必要な手動作業（チェックリスト）

レビュアーは PR をマージする前に必ず以下を実施してください。
本 PR の CI は手動作業完了を前提に通る設計です。

- [ ] 開発チーム全体に、ローカルで actionlint を実行するため Docker または静的バイナリの導入が求められる可能性があること（pre-commit 経由での自動インストール）を周知する
- [ ] 既存の `.github/workflows/` ファイルに actionlint でエラーとなる箇所がないか、ローカルで一度 `pre-commit run --all-files actionlint` を実行して確認する

## マージ後の確認手順

- [ ] 次の push / PR で actionlint フックが正常に動作することを確認
- [ ] ローカルで GitHub Actions ワークフローを意図的に壊してコミットしようとした際、フックでブロックされることを確認

## ロールバック手順

問題が出た場合（開発者のローカルで実行エラーが多発するなど）は、本 PR で追加した `.pre-commit-config.yaml` の `actionlint` セクションを削除し、コミット・プッシュしてください。

## 参考情報

- 公式ドキュメント: https://github.com/rhysd/actionlint
- 比較検討した他案: zizmor をローカルフックとして追加する案（actionlint の方が GitHub Actions 全般の構文チェックにも強く、既存 CI で両方動かしているため、軽量な actionlint をコミット前に採用）
- 直近の関連 PR / Issue: なし

---
*PR created automatically by Jules for task [6940166709772590978](https://jules.google.com/task/6940166709772590978) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * コミット前にGitHub Actionsのワークフロー設定を検証するチェックを追加しました。

* **ドキュメント**
  * ワークフロー設定の脆弱性や設定ミスを、コミット前に検知できることを追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->