### PR TITLE
fix(reducer): 🐛 資産イベント通知の上書きを修正

### DIFF
--- a/src/game/__tests__/insurance.test.ts
+++ b/src/game/__tests__/insurance.test.ts
@@ -389,6 +389,35 @@ describe('reducer 保険統合', () => {
       expect(state.players[0].money).toBe(moneyBefore + scrapValue);
     });
 
+    it('火災発生時は火災メッセージがターン告知に上書きされず表示される', () => {
+      vi.spyOn(randomModule, 'getSecureRandomInt').mockReturnValue(1);
+      let state = startGame({ insurance: true });
+      const { state: withProp, propId } = buyPropertyForPlayer(state);
+      const space = withProp.board.find((s) => s.id === propId)!;
+      state = {
+        ...withProp,
+        dice: { values: [1, 2], doubles: 0, rolled: true },
+      };
+      state = gameReducer(state, { type: 'END_TURN' });
+      // 火災で物件が消滅したことがプレイヤーに通知される
+      expect(state.message).toContain('火災');
+      expect(state.message).toContain(space.name);
+      // 次のプレイヤーへのターン告知も併記される
+      expect(state.message).toContain('はなこのばんだよ');
+    });
+
+    it('火災が発生しなければ従来どおりターン告知のみ表示される', () => {
+      vi.spyOn(randomModule, 'getSecureRandomInt').mockReturnValue(99);
+      let state = startGame({ insurance: true });
+      const { state: withProp } = buyPropertyForPlayer(state);
+      state = {
+        ...withProp,
+        dice: { values: [1, 2], doubles: 0, rolled: true },
+      };
+      state = gameReducer(state, { type: 'END_TURN' });
+      expect(state.message).toBe('はなこのばんだよ！サイコロをふろう！');
+    });
+
     it('保険料残高不足時に保険が全解除されマイナス残高にならない', () => {
       vi.spyOn(randomModule, 'getSecureRandomInt').mockReturnValue(99);
       let state = startGame({ insurance: true });

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -1723,6 +1723,22 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
         );
       }
 
+      // 資産イベント（VC満期・ESG配当・保険料徴収・火災）のメッセージは
+      // ターン告知で上書きすると一度も表示されず、物件消滅などが無通知になる。
+      // 告知の前に連結して必ず表示する。
+      const eventMessages: string[] = [];
+      if (stateAfterAlt.message !== state.message) {
+        eventMessages.push(stateAfterAlt.message);
+      }
+      if (stateAfterInsurance.message !== stateAfterAlt.message) {
+        eventMessages.push(stateAfterInsurance.message);
+      }
+      const turnAnnouncement =
+        (nextPlayer.inJail
+          ? `${nextPlayer.name}のばんだよ！刑務所にいるよ`
+          : `${nextPlayer.name}のばんだよ！サイコロをふろう！`) +
+        economyMessage;
+
       return {
         ...stateAfterInsurance,
         currentPlayerIndex: nextIndex,
@@ -1731,11 +1747,7 @@ function gameReducerInner(state: GameState, action: GameAction): GameState {
         dice: { values: [1, 1], doubles: 0, rolled: false },
         economyStatus: newEconomyStatus,
         stockMarket: newStockMarket,
-        message:
-          (nextPlayer.inJail
-            ? `${nextPlayer.name}のばんだよ！刑務所にいるよ`
-            : `${nextPlayer.name}のばんだよ！サイコロをふろう！`) +
-          economyMessage,
+        message: [...eventMessages, turnAnnouncement].join(' '),
       };
     }
 


### PR DESCRIPTION
## 概要

END_TURN 処理でターン告知メッセージが直前の資産イベントメッセージを無条件に上書きし、火災による物件消滅などがプレイヤーに無通知となる問題を修正します。

### 💡 What

- END_TURN 処理でイベント処理前後の `message` の差分からイベントメッセージ（VC満期・ESG配当・保険料徴収・火災）を収集し、ターン告知の前に連結して表示するようにしました。
- 火災発生時に火災メッセージとターン告知が併記されること、火災が発生しない場合は従来どおりターン告知のみとなることを検証するテストを追加しました。

### 🎯 Why

END_TURN 処理でターン告知メッセージを無条件に設定していたため、直前に発生した資産イベントのメッセージが一度も表示されず、火災による物件消滅などの重要な情報がプレイヤーに伝わらない問題がありました。

## 関連 Issue / 設計ドキュメント

なし

## 動作確認

- [x] ローカルで動作確認した
- [x] テストを追加・更新した（または不要な理由を記載）

`bun run test` で 442 テスト（追加分含む）がすべてパスすることを確認済みです。

## セルフチェック

- [x] `bun run lint` がパスする
- [x] `bun run typecheck` がパスする
- [x] 破壊的変更がある場合、README または docs を更新した（破壊的変更なし）
- [x] DB マイグレーションがある場合、ロールバック手順を確認した（該当なし）
- [x] secret / 個人情報を含むコードや設定が含まれていない

## デプロイ時の注意

なし

https://claude.ai/code/session_01TV3oMN7agKx2BmxaTEw9au

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ターン終了時に、火災・保険料徴収・配当などのイベント通知が次のプレイヤーへのターン案内で上書きされず、同時に表示されるようになりました。
  * 火災発生時は、火災通知と物件名がターン案内とともに表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->