### PR TITLE
🎨 Palette: トレード画面の所持金上限を超えた際のUX改善

### DIFF
--- a/src/components/ActionDialog/ActionDialog.module.css
+++ b/src/components/ActionDialog/ActionDialog.module.css
@@ -205,6 +205,11 @@
 .moneyQuickButtonClear:active {
   transform: scale(0.96);
 }
+.moneyQuickButton[aria-disabled='true'],
+.moneyQuickButtonClear[aria-disabled='true'] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 .moneyQuickButton {
   border: 2px solid var(--color-secondary);
   color: var(--color-secondary);

--- a/src/components/ActionDialog/ActionDialog.module.css
+++ b/src/components/ActionDialog/ActionDialog.module.css
@@ -209,6 +209,7 @@
 .moneyQuickButtonClear[aria-disabled='true'] {
   opacity: 0.5;
   cursor: not-allowed;
+  transform: none;
 }
 .moneyQuickButton {
   border: 2px solid var(--color-secondary);

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -258,11 +258,11 @@ export default function TradeDialog({
               type="button"
               className={styles.moneyQuickButton}
               onClick={() => {
-                if (offerMoney >= currentPlayer.money) return;
-                setOfferMoney((prev) => clamp(prev + 10, currentPlayer.money))
+                if (offerMoney + 10 > currentPlayer.money) return;
+                setOfferMoney((prev) => clamp(prev + 10, currentPlayer.money));
               }}
               aria-label={LABELS.add10}
-              aria-disabled={offerMoney >= currentPlayer.money}
+              aria-disabled={offerMoney + 10 > currentPlayer.money}
             >
               +$10
             </button>
@@ -270,11 +270,11 @@ export default function TradeDialog({
               type="button"
               className={styles.moneyQuickButton}
               onClick={() => {
-                if (offerMoney >= currentPlayer.money) return;
-                setOfferMoney((prev) => clamp(prev + 100, currentPlayer.money))
+                if (offerMoney + 100 > currentPlayer.money) return;
+                setOfferMoney((prev) => clamp(prev + 100, currentPlayer.money));
               }}
               aria-label={LABELS.add100}
-              aria-disabled={offerMoney >= currentPlayer.money}
+              aria-disabled={offerMoney + 100 > currentPlayer.money}
             >
               +$100
             </button>
@@ -283,7 +283,7 @@ export default function TradeDialog({
               className={styles.moneyQuickButtonClear}
               onClick={() => {
                 if (offerMoney === 0) return;
-                setOfferMoney(0)
+                setOfferMoney(0);
               }}
               aria-label={LABELS.clearMoney}
               aria-disabled={offerMoney === 0}
@@ -379,11 +379,11 @@ export default function TradeDialog({
               type="button"
               className={styles.moneyQuickButton}
               onClick={() => {
-                if (requestMoney >= targetPlayer.money) return;
-                setRequestMoney((prev) => clamp(prev + 10, targetPlayer.money))
+                if (requestMoney + 10 > targetPlayer.money) return;
+                setRequestMoney((prev) => clamp(prev + 10, targetPlayer.money));
               }}
               aria-label={LABELS.add10}
-              aria-disabled={requestMoney >= targetPlayer.money}
+              aria-disabled={requestMoney + 10 > targetPlayer.money}
             >
               +$10
             </button>
@@ -391,11 +391,13 @@ export default function TradeDialog({
               type="button"
               className={styles.moneyQuickButton}
               onClick={() => {
-                if (requestMoney >= targetPlayer.money) return;
-                setRequestMoney((prev) => clamp(prev + 100, targetPlayer.money))
+                if (requestMoney + 100 > targetPlayer.money) return;
+                setRequestMoney((prev) =>
+                  clamp(prev + 100, targetPlayer.money),
+                );
               }}
               aria-label={LABELS.add100}
-              aria-disabled={requestMoney >= targetPlayer.money}
+              aria-disabled={requestMoney + 100 > targetPlayer.money}
             >
               +$100
             </button>
@@ -404,7 +406,7 @@ export default function TradeDialog({
               className={styles.moneyQuickButtonClear}
               onClick={() => {
                 if (requestMoney === 0) return;
-                setRequestMoney(0)
+                setRequestMoney(0);
               }}
               aria-label={LABELS.clearMoney}
               aria-disabled={requestMoney === 0}

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -257,28 +257,36 @@ export default function TradeDialog({
             <button
               type="button"
               className={styles.moneyQuickButton}
-              onClick={() =>
+              onClick={() => {
+                if (offerMoney >= currentPlayer.money) return;
                 setOfferMoney((prev) => clamp(prev + 10, currentPlayer.money))
-              }
+              }}
               aria-label={LABELS.add10}
+              aria-disabled={offerMoney >= currentPlayer.money}
             >
               +$10
             </button>
             <button
               type="button"
               className={styles.moneyQuickButton}
-              onClick={() =>
+              onClick={() => {
+                if (offerMoney >= currentPlayer.money) return;
                 setOfferMoney((prev) => clamp(prev + 100, currentPlayer.money))
-              }
+              }}
               aria-label={LABELS.add100}
+              aria-disabled={offerMoney >= currentPlayer.money}
             >
               +$100
             </button>
             <button
               type="button"
               className={styles.moneyQuickButtonClear}
-              onClick={() => setOfferMoney(0)}
+              onClick={() => {
+                if (offerMoney === 0) return;
+                setOfferMoney(0)
+              }}
               aria-label={LABELS.clearMoney}
+              aria-disabled={offerMoney === 0}
             >
               クリア
             </button>
@@ -370,28 +378,36 @@ export default function TradeDialog({
             <button
               type="button"
               className={styles.moneyQuickButton}
-              onClick={() =>
+              onClick={() => {
+                if (requestMoney >= targetPlayer.money) return;
                 setRequestMoney((prev) => clamp(prev + 10, targetPlayer.money))
-              }
+              }}
               aria-label={LABELS.add10}
+              aria-disabled={requestMoney >= targetPlayer.money}
             >
               +$10
             </button>
             <button
               type="button"
               className={styles.moneyQuickButton}
-              onClick={() =>
+              onClick={() => {
+                if (requestMoney >= targetPlayer.money) return;
                 setRequestMoney((prev) => clamp(prev + 100, targetPlayer.money))
-              }
+              }}
               aria-label={LABELS.add100}
+              aria-disabled={requestMoney >= targetPlayer.money}
             >
               +$100
             </button>
             <button
               type="button"
               className={styles.moneyQuickButtonClear}
-              onClick={() => setRequestMoney(0)}
+              onClick={() => {
+                if (requestMoney === 0) return;
+                setRequestMoney(0)
+              }}
               aria-label={LABELS.clearMoney}
+              aria-disabled={requestMoney === 0}
             >
               クリア
             </button>


### PR DESCRIPTION
## 概要
トレード画面のおかね入力において、クイック入力ボタン（+$10, +$100, クリア）の `aria-disabled` 状態を追加しました。

### 💡 What
- `ActionDialog.module.css` に `aria-disabled="true"` 時の不透明度低下（`opacity: 0.5`）および `cursor: not-allowed` スタイルを追加しました。
- `TradeDialog.tsx` の各種ボタンに対して、現在の金額に加算すると上限を超える場合や、すでに金額が0である場合に `aria-disabled={true}` となるように設定しました。また、非活性時には `onClick` で値を更新しないようガード条件を追加しました。

### 🎯 Why
現状、金額が所持金の上限を超過していてもボタンがクリック可能な見た目のままであり、クリックしても値が変わらない（Clampされている）ため、ユーザーが混乱する可能性がありました。視覚的に非活性状態（Disabled）を示すことで、ボタンが押せないことを直感的に伝え、UXを向上させます。

### 📸 Before/After
- **Before**: 上限を超えていてもボタンが活性化状態になっており、視覚的フィードバックがありませんでした。
- **After**: 上限を超える加算操作や、既に0の場合のクリア操作ではボタンが非活性化（半透明、カーソル変更）され、無効であることが明確になります。

### ♿ Accessibility
- `aria-disabled` 属性を付与することで、スクリーンリーダー等の支援技術に対しても、フォーカス順序を保ったままボタンが無効化されている状態を正しく伝えることができます。

---
*PR created automatically by Jules for task [15986340825198813930](https://jules.google.com/task/15986340825198813930) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 所持金のクイック操作で上限を超えて入力できないようになりました。
  * 所持金が0のときは、クリア操作を実行できないようになりました。
  * 利用できない操作が視覚的に分かるよう、無効表示（opacity）と無効カーソル（not-allowed）を追加しました。
  * 無効状態での押下時の縮小挙動を抑止しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->