### PR TITLE
🎨 Palette: スクリーンリーダー用エラー読み上げの改善（aria-describedbyフォールバック追加）

### DIFF
--- a/src/components/ActionDialog/LoanDialog.tsx
+++ b/src/components/ActionDialog/LoanDialog.tsx
@@ -155,6 +155,9 @@ export default function LoanDialog({
                   aria-errormessage={
                     !canBorrow && borrowAmount !== '' ? borrowHintId : undefined
                   }
+                  aria-describedby={
+                    !canBorrow && borrowAmount !== '' ? borrowHintId : undefined
+                  }
                 />
                 <Button
                   size="small"
@@ -205,6 +208,9 @@ export default function LoanDialog({
                   aria-label="返済金額"
                   aria-invalid={!canRepay && repayAmount !== ''}
                   aria-errormessage={
+                    !canRepay && repayAmount !== '' ? repayHintId : undefined
+                  }
+                  aria-describedby={
                     !canRepay && repayAmount !== '' ? repayHintId : undefined
                   }
                 />

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -238,6 +238,9 @@ export default function TradeDialog({
             aria-errormessage={
               isOfferMoneyInvalid ? offerMoneyErrorId : undefined
             }
+            aria-describedby={
+              isOfferMoneyInvalid ? offerMoneyErrorId : undefined
+            }
           />
           {isOfferMoneyInvalid && (
             <div
@@ -354,6 +357,9 @@ export default function TradeDialog({
             }}
             aria-invalid={isRequestMoneyInvalid}
             aria-errormessage={
+              isRequestMoneyInvalid ? requestMoneyErrorId : undefined
+            }
+            aria-describedby={
               isRequestMoneyInvalid ? requestMoneyErrorId : undefined
             }
           />


### PR DESCRIPTION
### 💡 What
`LoanDialog`と`TradeDialog`のフォーム入力要素（金額入力）に対して、バリデーションエラー時に`aria-errormessage`とともに`aria-describedby`へエラーメッセージのIDを設定するように修正しました。

### 🎯 Why
スクリーンリーダーの`aria-errormessage`属性への対応が不均一であるため、単独で使用すると一部の環境でエラー内容が正しく読み上げられない問題を防ぐためです。W3C ARIAの推奨に則り、`aria-describedby`をフォールバックとして併用することで、スクリーンリーダーの対応状況に関わらずエラーメッセージが確実にユーザーへ伝わるようにしました。

### 📸 Before/After
見た目の変更はありません。DOM属性のみの変更となります。

### ♿ Accessibility
入力フォームのエラー状態（`aria-invalid="true"`）をスクリーンリーダー利用者がより確実に把握できるようになりました。`aria-errormessage`と`aria-describedby`の併用により、一貫したエラーの読み上げ体験を提供します。

---
*PR created automatically by Jules for task [5633715354275476034](https://jules.google.com/task/5633715354275476034) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **アクセシビリティ改善**
  * 借入・返済金額の入力欄で、入力エラーの説明を適切に参照できるよう改善しました。
  * 取引金額の入力欄でも、無効な値の場合に対応するエラーメッセージが明示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->