### PR TITLE
chore(security): 🔒 gitleaks への AI エコシステム向けトークン検知ルールの追加

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -134,7 +134,7 @@ entropy = 0.0
 [[rules]]
 id = "monopo-ai-ecosystem-token"
 description = "AI エコシステムトークン (Hugging Face, Replicate, LangSmith 等) のハードコード検知"
-regex = '''(?:hf_[a-zA-Z0-9]{34}|r8_[a-zA-Z0-9]{37,40}|lsv2_[pt][a-zA-Z0-9]{38})'''
+regex = '''(?:hf_[a-zA-Z0-9]{34}|r8_[a-zA-Z0-9]{37,40}|lsv2_(?:pt|sk)_[a-zA-Z0-9_]{32,})'''
 tags = ["ai", "api-key", "credential"]
 secretGroup = 0
 entropy = 0.0

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -130,3 +130,19 @@ regex = '''(?i)tvly-[a-zA-Z0-9]{32}'''
 tags = ["ai", "api-key", "credential", "tavily"]
 secretGroup = 0
 entropy = 0.0
+
+[[rules]]
+id = "monopo-ai-ecosystem-token"
+description = "AI エコシステムトークン (Hugging Face, Replicate, LangSmith 等) のハードコード検知"
+regex = '''(?:hf_[a-zA-Z0-9]{34}|r8_[a-zA-Z0-9]{37,40}|lsv2_[pt][a-zA-Z0-9]{38})'''
+tags = ["ai", "api-key", "credential"]
+secretGroup = 0
+entropy = 0.0
+
+[[rules]]
+id = "monopo-pinecone-api-key"
+description = "Pinecone API キー (UUID 形式) のハードコード検知"
+regex = '''(?i)(?:pinecone|pc)_[a-z0-9_]*key[\s]*[:=][\s]*["']?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}["']?'''
+tags = ["ai", "api-key", "credential", "pinecone"]
+secretGroup = 0
+entropy = 0.0

--- a/repomix.config.json
+++ b/repomix.config.json
@@ -24,7 +24,16 @@
       ".clinerules",
       ".roorules",
       ".traerules",
-      ".github/copilot-instructions.md"
+      ".github/copilot-instructions.md",
+      ".cline/**",
+      ".windsurf/**",
+      ".aider/**",
+      ".cursor/**",
+      ".claude/**",
+      ".continue/**",
+      ".jules/**",
+      ".trae/**",
+      ".roo/**"
     ]
   }
 }


### PR DESCRIPTION
## 背景
リポジトリには既に Gitleaks や TruffleHog などの強力なシークレットスキャンが導入されていますが、直近のAIツール利用（Pinecone や各種AI APIなど）の増加に伴い、これらの特定のAPIキーやトークンに対する特化ルールの追加が必要であると判断しました。

## 現状認識（事前調査結果のサマリー）
- 既存防御策: pre-commit (Husky, pre-commit framework), Gitleaks, TruffleHog, Trivy, CodeQL などの重層的な設定が既に導入済み。
- 未カバー領域: Hugging Face, Replicate, Pinecone 等の AI 関連エコシステムのトークンに対する特化ルールの不足、および repomix 時の AI エージェント作業領域の明示的な除外の不足。
- 直近の漏洩リスク兆候: 現在のところ漏洩は確認されていないが、Pinecone などの利用（`ai-ci-tools.md`に記載）が進んでおり、未然に防ぐ必要がある。

## このPRで導入・強化するもの
- 対象: `.gitleaks.toml` への新規カスタムルール追加、および `repomix.config.json` の `customPatterns` の厳格化。
- ツール名とバージョン: gitleaks (既存設定)
- 期待される効果: Pinecone APIキーや Hugging Face トークンなどがコミット前にローカルおよびCI上で検知・拒否される。また、AI作業履歴がコンテキストパックに混入しなくなる。

## 検知漏れリスクと補完策
- 検知できないケース: エントロピーが低い独自のパスワードや、UUID形式のトークンで変数名が `key` や `token` などを伴わない場合。
- 補完策: 既存の `detect-secrets` によるエントロピー検知および GitHub Secret Scanning によるサーバー側の二重チェックで補完する。

## マージ前に必要な手動作業（チェックリスト）
レビュアーは PR をマージする前に必ず以下を実施してください。
本 PR の CI は手動作業完了を前提に通る設計です。

- [ ] GitHub repo settings → Code security → Push protection が有効になっていることを再確認する
- [ ] 開発チーム全体に、新しい AI 関連トークンのコミットがブロックされるようになった旨を周知する

## マージ後の確認手順
- [ ] 次の push / PR で gitleaks workflow が正常にパスすることを確認する
- [ ] ローカルで Gitleaks のフックが新しいルールで動作することを確認する

## ロールバック手順
問題が発生した場合（誤検知によるコミットブロックなど）は、本 PR を revert するか、`.gitleaks.toml` の `[rules.allowlist]` に誤検知のパターンを一時的に追加してください。

## 参考情報
- 公式ドキュメント: https://github.com/gitleaks/gitleaks
- 比較検討した他案: `detect-secrets` でのカスタム正規表現追加も検討したが、既存の `.gitleaks.toml` 管理に寄せる方が運用上統一されるためこちらを採用。
- 直近の関連 PR / Issue: なし

---
*PR created automatically by Jules for task [4092658392574317725](https://jules.google.com/task/4092658392574317725) started by @genzouw*