### PR TITLE
✨ 保険加入UIを追加し火災リスクにそなえられるように

### DIFF
--- a/src/components/ActionDialog/InsuranceDialog.tsx
+++ b/src/components/ActionDialog/InsuranceDialog.tsx
@@ -1,0 +1,185 @@
+import { useId, useMemo } from 'react';
+import type { BoardSpace, ColorGroup, Player } from '../../game/types';
+import { getSpaceById } from '../../game/rules';
+import {
+  calculatePremium,
+  FIRE_SCRAP_RATE,
+  INSURANCE_COLLECT_INTERVAL,
+  isPropertyInsured,
+} from '../../game/insurance';
+import { compareByColorOrder } from './colorSort';
+import Dialog from '../common/Dialog';
+import Button from '../common/Button';
+import styles from './ActionDialog.module.css';
+
+const COLOR_MAP: Record<ColorGroup, string> = {
+  brown: 'var(--color-brown)',
+  lightblue: 'var(--color-lightblue)',
+  pink: 'var(--color-pink)',
+  orange: 'var(--color-orange)',
+  red: 'var(--color-red)',
+  yellow: 'var(--color-yellow)',
+  green: 'var(--color-green)',
+  blue: 'var(--color-blue)',
+  railroad: '#555',
+};
+
+const COLOR_ORDER: ColorGroup[] = [
+  'brown',
+  'lightblue',
+  'pink',
+  'orange',
+  'red',
+  'yellow',
+  'green',
+  'blue',
+];
+
+type InsuranceDialogProps = {
+  currentPlayer: Player;
+  board: BoardSpace[];
+  insuranceState: Record<string, boolean> | undefined;
+  onBuy: (propertyId: string) => void;
+  onCancel: (propertyId: string) => void;
+  onClose: () => void;
+};
+
+/**
+ * 火災リスクにそなえる不動産保険への加入・解約を行うダイアログ。
+ *
+ * 自分が所有する「土地（property）」ごとに保険をかけられる。加入すると
+ * {@link INSURANCE_COLLECT_INTERVAL} ターンごとに保険料が徴収され、火災が
+ * 発生しても評価額の全額が補填される（未加入だとスクラップ分しか戻らない）。
+ *
+ * @param props - コンポーネントの引数
+ * @param props.currentPlayer - 保険を操作する現在のプレイヤー
+ * @param props.board - 盤面のマス一覧（物件情報の参照に使用）
+ * @param props.insuranceState - 物件IDごとの保険加入状態（未定義なら未加入）
+ * @param props.onBuy - 保険に加入するときのコールバック（物件IDを渡す）
+ * @param props.onCancel - 保険を解約するときのコールバック（物件IDを渡す）
+ * @param props.onClose - ダイアログを閉じるときのコールバック
+ * @returns 保険ダイアログの React 要素
+ */
+export default function InsuranceDialog({
+  currentPlayer,
+  board,
+  insuranceState,
+  onBuy,
+  onCancel,
+  onClose,
+}: InsuranceDialogProps) {
+  const hintIdBase = useId();
+  // 火災リスクのある「土地（property）」のみ保険対象。鉄道・公共施設は除外する。
+  // 60FPS アニメーション中の再レンダリングでの再計算を避けるためメモ化する。
+  const ownedProperties = useMemo(() => {
+    return currentPlayer.properties
+      .map((id: string) => getSpaceById(id, board))
+      .filter((s): s is BoardSpace => !!s && s.type === 'property')
+      .sort((a, b) => compareByColorOrder(a.color, b.color, COLOR_ORDER));
+  }, [currentPlayer.properties, board]);
+
+  // 未加入時に火災で失う割合（%）。スクラップ率の裏返しを子供向けに表示する。
+  const lossPercent = Math.round((1 - FIRE_SCRAP_RATE) * 100);
+
+  return (
+    <Dialog
+      title="🔥 ほけん（火災にそなえる）"
+      onClose={onClose}
+      actions={
+        <Button variant="secondary" onClick={onClose}>
+          とじる
+        </Button>
+      }
+    >
+      <div className={styles.propertyInfo}>
+        <div className={styles.propertyPrice}>
+          もってるおかね: ${currentPlayer.money.toLocaleString()}
+        </div>
+        <div className={styles.propertyPrice} style={{ fontSize: 13 }}>
+          ほけんに入ると{INSURANCE_COLLECT_INTERVAL}
+          ターンごとにほけん料がいるけど、火事になったら全部もどってくるよ。
+          入ってないと火事で{lossPercent}%なくなるよ
+        </div>
+      </div>
+
+      <div className={styles.buildList}>
+        {ownedProperties.length === 0 && (
+          <div
+            style={{
+              textAlign: 'center',
+              padding: 16,
+              color: 'var(--color-text-light)',
+            }}
+          >
+            ほけんに入れる土地がないよ
+          </div>
+        )}
+        {ownedProperties.map((space) => {
+          const insured = isPropertyInsured(insuranceState, space.id);
+          const premium = calculatePremium(space.price ?? 0);
+          const canAfford = currentPlayer.money >= premium;
+          return (
+            <div key={space.id} className={styles.buildItem}>
+              {space.color && (
+                <div
+                  style={{
+                    width: 6,
+                    borderRadius: 3,
+                    background: COLOR_MAP[space.color],
+                    flexShrink: 0,
+                  }}
+                />
+              )}
+              <div style={{ flex: 1 }}>
+                <div className={styles.buildItemName}>
+                  {space.name}
+                  {insured && (
+                    <span style={{ color: 'var(--color-success)' }}>
+                      ✅ 加入中
+                    </span>
+                  )}
+                </div>
+                <div className={styles.buildItemInfo}>
+                  ほけん料: ${premium} / {INSURANCE_COLLECT_INTERVAL}ターン
+                </div>
+              </div>
+              <div className={styles.buildItemActionColumn}>
+                {insured ? (
+                  <Button
+                    size="small"
+                    variant="secondary"
+                    onClick={() => onCancel(space.id)}
+                  >
+                    かいやく
+                  </Button>
+                ) : (
+                  <>
+                    <Button
+                      size="small"
+                      onClick={() => onBuy(space.id)}
+                      aria-disabled={!canAfford}
+                      aria-describedby={
+                        !canAfford ? `${hintIdBase}-buy-${space.id}` : undefined
+                      }
+                    >
+                      入る（${premium}）
+                    </Button>
+                    {!canAfford && (
+                      <div
+                        id={`${hintIdBase}-buy-${space.id}`}
+                        className={styles.noMoneyHintTight}
+                        role="status"
+                      >
+                        おかねがたりないよ
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Dialog>
+  );
+}

--- a/src/components/ActionDialog/__tests__/InsuranceDialog.test.tsx
+++ b/src/components/ActionDialog/__tests__/InsuranceDialog.test.tsx
@@ -98,6 +98,8 @@ describe('InsuranceDialog', () => {
     const buyButton = screen.getByRole('button', { name: /入る/ });
     expect(buyButton).toHaveAttribute('aria-disabled', 'true');
     expect(screen.getByText('おかねがたりないよ')).toBeInTheDocument();
+    fireEvent.click(buyButton);
+    expect(onBuy).not.toHaveBeenCalled();
   });
 
   it('鉄道・公共施設は保険対象外で一覧に出ない', () => {

--- a/src/components/ActionDialog/__tests__/InsuranceDialog.test.tsx
+++ b/src/components/ActionDialog/__tests__/InsuranceDialog.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, screen, cleanup } from '@testing-library/react';
+import InsuranceDialog from '../InsuranceDialog';
+import type { BoardSpace, Player } from '../../../game/types';
+import { calculatePremium } from '../../../game/insurance';
+
+afterEach(() => {
+  cleanup();
+});
+
+/** テスト用のプレイヤーを生成するヘルパー。 */
+function makePlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    id: 'p1',
+    name: 'プレイヤー1',
+    token: '🐶',
+    money: 1500,
+    position: 0,
+    properties: [],
+    inJail: false,
+    jailTurns: 0,
+    getOutOfJailCards: 0,
+    isBankrupt: false,
+    ...overrides,
+  };
+}
+
+/** テスト用の土地マスを生成するヘルパー。 */
+function makeProperty(overrides: Partial<BoardSpace> = {}): BoardSpace {
+  return {
+    id: 'prop1',
+    position: 1,
+    type: 'property',
+    name: 'さくら通り',
+    color: 'brown',
+    price: 100,
+    ...overrides,
+  };
+}
+
+describe('InsuranceDialog', () => {
+  it('所有する土地に未加入なら「入る」ボタンで onBuy が呼ばれる', () => {
+    const onBuy = vi.fn();
+    const board = [makeProperty()];
+    const player = makePlayer({ properties: ['prop1'] });
+    render(
+      <InsuranceDialog
+        currentPlayer={player}
+        board={board}
+        insuranceState={undefined}
+        onBuy={onBuy}
+        onCancel={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    const premium = calculatePremium(100);
+    const buyButton = screen.getByRole('button', {
+      name: new RegExp(`入る（\\$${premium}）`),
+    });
+    fireEvent.click(buyButton);
+    expect(onBuy).toHaveBeenCalledWith('prop1');
+  });
+
+  it('加入済みの土地は「加入中」表示と「かいやく」ボタンを持つ', () => {
+    const onCancel = vi.fn();
+    const board = [makeProperty()];
+    const player = makePlayer({ properties: ['prop1'] });
+    render(
+      <InsuranceDialog
+        currentPlayer={player}
+        board={board}
+        insuranceState={{ prop1: true }}
+        onBuy={vi.fn()}
+        onCancel={onCancel}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/加入中/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'かいやく' }));
+    expect(onCancel).toHaveBeenCalledWith('prop1');
+  });
+
+  it('保険料が払えないときは加入ボタンが無効化される', () => {
+    const onBuy = vi.fn();
+    const board = [makeProperty({ price: 100 })];
+    // 保険料（100 × 3% = 3）に満たない所持金
+    const player = makePlayer({ properties: ['prop1'], money: 1 });
+    render(
+      <InsuranceDialog
+        currentPlayer={player}
+        board={board}
+        insuranceState={undefined}
+        onBuy={onBuy}
+        onCancel={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    const buyButton = screen.getByRole('button', { name: /入る/ });
+    expect(buyButton).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByText('おかねがたりないよ')).toBeInTheDocument();
+  });
+
+  it('鉄道・公共施設は保険対象外で一覧に出ない', () => {
+    const board: BoardSpace[] = [
+      makeProperty(),
+      {
+        id: 'rr1',
+        position: 5,
+        type: 'railroad',
+        name: 'なかよし鉄道',
+        price: 200,
+      },
+    ];
+    const player = makePlayer({ properties: ['prop1', 'rr1'] });
+    render(
+      <InsuranceDialog
+        currentPlayer={player}
+        board={board}
+        insuranceState={undefined}
+        onBuy={vi.fn()}
+        onCancel={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('さくら通り')).toBeInTheDocument();
+    expect(screen.queryByText('なかよし鉄道')).not.toBeInTheDocument();
+  });
+
+  it('保険対象の土地を持たないときは空状態を表示する', () => {
+    const player = makePlayer({ properties: [] });
+    render(
+      <InsuranceDialog
+        currentPlayer={player}
+        board={[makeProperty()]}
+        insuranceState={undefined}
+        onBuy={vi.fn()}
+        onCancel={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('ほけんに入れる土地がないよ')).toBeInTheDocument();
+  });
+});

--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -33,6 +33,7 @@ import BankruptDialog from '../ActionDialog/BankruptDialog';
 import ForceBuyDialog from '../ActionDialog/ForceBuyDialog';
 import StockDialog from '../ActionDialog/StockDialog';
 import LoanDialog from '../ActionDialog/LoanDialog';
+import InsuranceDialog from '../ActionDialog/InsuranceDialog';
 import { useSound } from '../../sound/useSound';
 import styles from './GameBoard.module.css';
 
@@ -281,6 +282,9 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
   // ローン拡張
   const loanEnabled = state.features?.loan === true;
   const [showLoanDialog, setShowLoanDialog] = useState(false);
+  // 保険拡張（火災リスクにそなえる）
+  const insuranceEnabled = state.features?.insurance === true;
+  const [showInsuranceDialog, setShowInsuranceDialog] = useState(false);
   const canSubAction =
     state.turnPhase === 'endTurn' || state.turnPhase === 'roll';
 
@@ -514,6 +518,16 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
                   🏦 ローン
                 </Button>
               )}
+              {insuranceEnabled && (
+                <Button
+                  size="small"
+                  variant="secondary"
+                  className={styles.subActionButton}
+                  onClick={() => setShowInsuranceDialog(true)}
+                >
+                  🔥 ほけん
+                </Button>
+              )}
             </>
           )}
         </div>
@@ -609,6 +623,22 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
             setShowLoanDialog(false);
           }}
           onClose={() => setShowLoanDialog(false)}
+        />
+      )}
+
+      {showInsuranceDialog && insuranceEnabled && (
+        <InsuranceDialog
+          currentPlayer={currentPlayer}
+          board={state.board}
+          insuranceState={state.insuranceState}
+          onBuy={(propertyId) => {
+            play('purchase');
+            dispatch({ type: 'BUY_INSURANCE', propertyId });
+          }}
+          onCancel={(propertyId) => {
+            dispatch({ type: 'CANCEL_INSURANCE', propertyId });
+          }}
+          onClose={() => setShowInsuranceDialog(false)}
         />
       )}
 

--- a/src/components/GameBoard/__tests__/GameBoard.insurance.test.tsx
+++ b/src/components/GameBoard/__tests__/GameBoard.insurance.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, screen, cleanup } from '@testing-library/react';
+import GameBoard from '../GameBoard';
+import { createInitialGameState, gameReducer } from '../../../game/reducer';
+import type { GameState } from '../../../game/types';
+
+afterEach(() => {
+  cleanup();
+});
+
+/**
+ * 保険機能の導線検証用に、現在のプレイヤーへ土地を1つ所有させた
+ * ゲーム状態を組み立てるヘルパー。
+ * @param options.enabled 保険機能フラグ（既定: true）
+ * @param options.insured 対象の土地を加入済みにするか（既定: false）
+ */
+function makeInsuranceState(options?: {
+  enabled?: boolean;
+  insured?: boolean;
+}): { state: GameState; propertyId: string; playerId: string } {
+  const enabled = options?.enabled ?? true;
+  const base = gameReducer(createInitialGameState(), {
+    type: 'START_GAME',
+    playerNames: ['たろう', 'はなこ'],
+    playerTokens: ['🚗', '🎩'],
+    features: { insurance: enabled },
+  });
+  const prop = base.board.find((s) => s.type === 'property');
+  if (!prop) throw new Error('テスト用の土地マスが見つかりません');
+  const current = base.players[base.currentPlayerIndex];
+  const state: GameState = {
+    ...base,
+    // サブアクションを開ける手番フェーズに固定する
+    turnPhase: 'endTurn',
+    players: base.players.map((p, i) =>
+      i === base.currentPlayerIndex
+        ? { ...p, money: 1500, properties: [...p.properties, prop.id] }
+        : p,
+    ),
+    propertyStates: {
+      ...base.propertyStates,
+      [prop.id]: { ownerId: current.id, houses: 0, isMortgaged: false },
+    },
+    insuranceState: options?.insured ? { [prop.id]: true } : {},
+  };
+  return { state, propertyId: prop.id, playerId: current.id };
+}
+
+describe('GameBoard 保険導線の統合', () => {
+  it('保険機能が有効なとき「🔥 ほけん」ボタンを表示する', () => {
+    const { state } = makeInsuranceState({ enabled: true });
+    render(<GameBoard state={state} dispatch={vi.fn()} />);
+    expect(
+      screen.getByRole('button', { name: '🔥 ほけん' }),
+    ).toBeInTheDocument();
+  });
+
+  it('保険機能が無効なとき「🔥 ほけん」ボタンを表示しない', () => {
+    const { state } = makeInsuranceState({ enabled: false });
+    render(<GameBoard state={state} dispatch={vi.fn()} />);
+    expect(
+      screen.queryByRole('button', { name: '🔥 ほけん' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('ボタン押下でダイアログが開き「入る」で BUY_INSURANCE を dispatch する', () => {
+    const dispatch = vi.fn();
+    const { state, propertyId } = makeInsuranceState();
+    render(<GameBoard state={state} dispatch={dispatch} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '🔥 ほけん' }));
+    // ダイアログが開いたことをタイトルで確認する
+    expect(screen.getByText('🔥 ほけん（火災にそなえる）')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /入る/ }));
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'BUY_INSURANCE',
+      propertyId,
+    });
+  });
+
+  it('加入済みの土地は「かいやく」で CANCEL_INSURANCE を dispatch する', () => {
+    const dispatch = vi.fn();
+    const { state, propertyId } = makeInsuranceState({ insured: true });
+    render(<GameBoard state={state} dispatch={dispatch} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '🔥 ほけん' }));
+    fireEvent.click(screen.getByRole('button', { name: 'かいやく' }));
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'CANCEL_INSURANCE',
+      propertyId,
+    });
+  });
+});


### PR DESCRIPTION
## 概要

保険機能（火災リスク）を有効化しても、ゲーム中に物件へ保険をかける**操作導線が存在せず加入できなかった**問題を解消します。所有する土地ごとに加入・解約できる保険ダイアログを追加しました。

### 💡 What

- **`InsuranceDialog` コンポーネントを新規追加**（`src/components/ActionDialog/InsuranceDialog.tsx`）
  - 自分が所有する土地ごとに、保険料・加入状態を一覧表示
  - 「入る（$保険料）」ボタンで `BUY_INSURANCE`、「かいやく」ボタンで `CANCEL_INSURANCE` をディスパッチ
  - 火災リスクのある**土地（`property`）のみ対象**。鉄道・公共施設は一覧から除外
  - 保険料が払えない場合は加入ボタンを無効化し「おかねがたりないよ」を表示
  - 対象の土地がない場合は空状態（「ほけんに入れる土地がないよ」）を明示
- **`GameBoard` にサブアクション「🔥 ほけん」ボタンを追加**（`src/components/GameBoard/GameBoard.tsx`）
  - 保険機能が有効なときのみ表示（既存の「🏦 ローン」「📈 おうえんカード」と同じパターン）
  - 手番中（`endTurn` / `roll` フェーズ）に開ける

### 🎯 Why

`BUY_INSURANCE` / `CANCEL_INSURANCE` アクションと reducer 側の加入・保険料徴収・火災補填ロジックは実装済みでしたが、UI にディスパッチする導線がなく、設定で保険を有効化しても実際には加入できませんでした。加入操作を提供することで、火災リスクにそなえる本来のゲーム体験を成立させます。

なお「保険機能を有効化した時だけ火災が発生する」挙動は、`END_TURN` 時の `isInsuranceEnabled` ガード（`applyInsuranceOnEndTurn` の呼び出し条件）により既に担保されており、本PRでもその挙動を維持しています。

### 📸 Before/After

- **Before**: 設定で「🔥 ほけん」を有効化しても、ゲーム画面に加入手段がなかった
- **After**: 手番中のサブアクションに「🔥 ほけん」ボタンが出現し、所有物件ごとに加入・解約できる

### ♿ Accessibility

- 加入不可（残高不足）時は `aria-disabled` と `aria-describedby` でヒントを関連付け
- 空状態を明示的にテキスト表示（動的リストの空状態の明示）

## 関連 Issue / 設計ドキュメント

Refs `docs/superpowers/specs/advanced-money-game-features-proposal.md`（保険機能）

## 動作確認

- [x] ローカルで動作確認した（`bun run test` / `typecheck` / `lint` / `format:check` すべてパス）
- [x] テストを追加・更新した（`InsuranceDialog` の加入・解約・残高不足・対象外物件・空状態を検証）

## セルフチェック

- [x] `bun run lint` がパスする
- [x] `bun run typecheck` がパスする
- [x] 破壊的変更なし（保険機能 OFF 時は従来どおりボタン非表示）
- [x] DB マイグレーションなし
- [x] secret / 個人情報を含むコードや設定が含まれていない

## デプロイ時の注意

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199vw5w76UcHKpWzvvVWjyH

---
_Generated by [Claude Code](https://claude.ai/code/session_0199vw5w76UcHKpWzvvVWjyH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ゲームボードから、所有している土地の火災保険に加入・解約できるようになりました。
  * 保険料、加入状況、加入条件、補償内容を確認できます。
  * 保険対象外の鉄道・公共施設は一覧に表示されません。
  * 加入できる土地がない場合や、所持金不足時には案内が表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->