### PR TITLE
chore(security): 🔒 zizmor pre-commit hook による CI 脆弱性のコミット前検知強化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,10 @@ updates:
       # typescript-eslint の TS 7 対応リリースまでメジャーアップデートを停止する。
       - dependency-name: 'typescript'
         update-types: ['version-update:semver-major']
+    # 新規リリースを即座に取り込まず一定期間の検証期間を設けることで、
+    # サプライチェーン攻撃（悪意あるリリースの即時混入）のリスクを低減する。
+    cooldown:
+      default-days: 7
 
   # GitHub Actions
   - package-ecosystem: 'github-actions'
@@ -85,6 +89,10 @@ updates:
       # node24 を正式サポートするまではメジャーアップデートを停止する。
       - dependency-name: 'DavidAnson/markdownlint-cli2-action'
         update-types: ['version-update:semver-major']
+    # 新規リリースを即座に取り込まず一定期間の検証期間を設けることで、
+    # サプライチェーン攻撃（悪意あるリリースの即時混入）のリスクを低減する。
+    cooldown:
+      default-days: 7
 
   # pre-commit hooks
   - package-ecosystem: 'pre-commit'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,8 +60,12 @@ updates:
       # typescript-eslint の TS 7 対応リリースまでメジャーアップデートを停止する。
       - dependency-name: 'typescript'
         update-types: ['version-update:semver-major']
+    # zizmor の dependabot-cooldown 監査が 7 日以上を要求するため 7 を指定している
+    # （zizmor 未指定時は insufficient implicit default-days (less than 7) を検知）。
     # 新規リリースを即座に取り込まず一定期間の検証期間を設けることで、
     # サプライチェーン攻撃（悪意あるリリースの即時混入）のリスクを低減する。
+    # なお cooldown は version updates にのみ効き security updates には適用されないため、
+    # 脆弱性修正の取り込みが遅延することはない。
     cooldown:
       default-days: 7
 
@@ -89,8 +93,12 @@ updates:
       # node24 を正式サポートするまではメジャーアップデートを停止する。
       - dependency-name: 'DavidAnson/markdownlint-cli2-action'
         update-types: ['version-update:semver-major']
+    # zizmor の dependabot-cooldown 監査が 7 日以上を要求するため 7 を指定している
+    # （zizmor 未指定時は insufficient implicit default-days (less than 7) を検知）。
     # 新規リリースを即座に取り込まず一定期間の検証期間を設けることで、
     # サプライチェーン攻撃（悪意あるリリースの即時混入）のリスクを低減する。
+    # なお cooldown は version updates にのみ効き security updates には適用されないため、
+    # 脆弱性修正の取り込みが遅延することはない。
     cooldown:
       default-days: 7
 
@@ -109,8 +117,12 @@ updates:
     labels:
       - 'dependencies'
       - 'security'
+    # zizmor の dependabot-cooldown 監査が 7 日以上を要求するため 7 を指定している
+    # （zizmor 未指定時は insufficient implicit default-days (less than 7) を検知）。
     # 新規リリースを即座に取り込まず一定期間の検証期間を設けることで、
     # サプライチェーン攻撃（悪意あるリリースの即時混入）のリスクを低減する。
+    # なお cooldown は version updates にのみ効き security updates には適用されないため、
+    # 脆弱性修正の取り込みが遅延することはない。
     cooldown:
       default-days: 7
     commit-message:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,11 @@ repos:
     hooks:
       - id: actionlint
 
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v1.28.0
+    hooks:
+      - id: zizmor
+
   - repo: local
     hooks:
       - id: forbid-sensitive-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,17 @@ repos:
   - repo: https://github.com/woodruffw/zizmor-pre-commit
     rev: v1.28.0
     hooks:
+      # --offline を明示し、実行モードを環境非依存に固定する。
+      # zizmor は GH_TOKEN / GITHUB_TOKEN / ZIZMOR_GITHUB_TOKEN のいずれかが
+      # 環境変数にあると自動でオンラインモードへ切り替わり、ref-version-mismatch 等の
+      # 追加検知で非 0 終了する。結果として「トークンを export している開発者だけ
+      # コミットできない」状態になり、回避のための --no-verify が gitleaks 等
+      # すべてのフックを無効化してしまうため、ローカルはオフラインに固定する。
+      # オンライン検査は GH_TOKEN 付きで動く .github/workflows/zizmor.yml が担当する。
+      # なお args を指定するとフック定義側のデフォルト（--no-progress）が
+      # 置き換わるため、両方を明示する必要がある。
       - id: zizmor
+        args: ['--no-progress', '--offline']
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,10 @@ repos:
     hooks:
       - id: actionlint
 
-  - repo: https://github.com/woodruffw/zizmor-pre-commit
+  # 旧名 woodruffw/zizmor-pre-commit は zizmorcore/zizmor-pre-commit にリネーム済み。
+  # 旧名は 301 リダイレクトで解決するが、旧名で誰かが新規リポジトリを作成した時点で
+  # リダイレクトは失われるため、正規名で参照する。
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.28.0
     hooks:
       # --offline を明示し、実行モードを環境非依存に固定する。

--- a/docs/security/leak-prevention.md
+++ b/docs/security/leak-prevention.md
@@ -24,6 +24,11 @@
     - **検出の限界**: 低エントロピーの短いパスワードや独自フォーマットの秘密情報は検知困難な場合があります。`gitleaks` との多層防御で補完しています。
     - **トラブルシューティング**: 誤検知が出た場合は `# pragma: allowlist secret` コメントをその行末に追加するか、`detect-secrets scan --baseline .secrets.baseline` でベースラインを更新して既知の誤検知として登録してください。また、ローカル環境に `detect-secrets` をインストール（例: `pip install detect-secrets`）後、`detect-secrets audit .secrets.baseline` を実行してインタラクティブに誤検知を確認・登録することもできます。
   - **自動依存解決**: `pre-commit` framework が実行する gitleaks フックには、システム依存の `gitleaks-system` ではなく、pre-commit が自動で依存関係を解決して実行する `gitleaks` を使用することで、CI 環境や新規開発者の環境での実行エラーを防ぎ、安定性を向上させています（なお、9〜12行目の `.husky/pre-commit` 経由の gitleaks 実行には、引き続きローカルへの gitleaks インストールが必要です）。
+- **`actionlint` および `zizmor` フック (pre-commit)**: `.github/workflows/` 配下の YAML ファイルに対して、コミット前に `actionlint` と `zizmor` を実行します。
+  - **`zizmor` の検査範囲**: `zizmor` はワークフローファイルに加えて `.github/dependabot.yml` および `action.yml` / `action.yaml`（コンポジットアクション）も検査対象に含みます。
+  - **実行モードの固定**: `args: ['--no-progress', '--offline']` により**オフラインモードに固定**しています。`zizmor` は `GH_TOKEN` / `GITHUB_TOKEN` / `ZIZMOR_GITHUB_TOKEN` のいずれかが環境変数にあると自動でオンラインモードへ切り替わり、追加検知によってコミットがブロックされます。固定しない場合「トークンを export している開発者だけコミットできない」状態となり、その回避に使われる `git commit --no-verify` が gitleaks を含む**すべての**フックを無効化してしまうため、ローカルはオフラインに固定しています。オンライン検査は CI (`.github/workflows/zizmor.yml`) が担当します。
+  - これにより、インジェクションリスクや不適切な権限指定といった CI 固有の脆弱性を**ローカルで早期に検知します**。ただし `git commit --no-verify` やフック未インストールの場合は素通りするため、これは「未然の防止」ではなく早期検知の層です。すり抜けた場合は CI の `zizmor.yml` で検知します。
+  - **検知漏れの補完**: 動的に取得される外部スクリプトなど `actionlint` の対象外となるリスクは、`zizmor` および `permissions-audit.yml` の CI 検査で補完します。
 
 ## 2. CI 検知（リポジトリ防御）
 
@@ -40,11 +45,7 @@
 - **CodeQL ワークフロー (`.github/workflows/codeql.yml`)**:
   - `security-extended` および `security-and-quality` クエリを使用して、データフロー解析によるシークレットのハードコード検知や品質チェックなど、高度な静的解析を行います。
 - **Zizmor ワークフロー (`.github/workflows/zizmor.yml`)**:
-  - `zizmor` を利用して、GitHub Actions ワークフロー自体の脆弱性（インジェクションリスクや不適切な権限設定など）を静的解析し、CI 設定を経由した情報漏洩を未然に防ぎます。
-- **Actionlint および Zizmor フック (pre-commit)**:
-  - `.github/workflows/` 配下の YAML ファイルに対して、コミット前に `actionlint` と `zizmor` を実行します。
-  - **`zizmor` の検査範囲**: `zizmor` はワークフローファイルに加えて `.github/dependabot.yml` および `action.yml` / `action.yaml`（コンポジットアクション）も検査対象に含みます。
-  - これにより、インジェクションリスクや不適切な権限指定といったCI固有の脆弱性をローカル環境で検査・ブロックし、サーバーへのプッシュを未然に防ぎます。
+  - `zizmor` を利用して、GitHub Actions ワークフロー自体の脆弱性（インジェクションリスクや不適切な権限設定など）を静的解析し、**検知結果を SARIF として Code scanning に報告します**。本ワークフローが呼び出す reusable workflow (`genzouw/ci-workflows`) は `continue-on-error: true` で実行されるため、検知が発生しても CI はブロックされません。検知内容は Code scanning のアラートとして確認してください。
 - **権限 (Permissions) の最小化**:
   - CI の各ワークフロー (`.github/workflows/*.yml`) では `permissions` が明示されており、GitHub Actions が必要以上にリポジトリを書き換える権限を持たないように設計されています。
 

--- a/docs/security/leak-prevention.md
+++ b/docs/security/leak-prevention.md
@@ -43,6 +43,7 @@
   - `zizmor` を利用して、GitHub Actions ワークフロー自体の脆弱性（インジェクションリスクや不適切な権限設定など）を静的解析し、CI 設定を経由した情報漏洩を未然に防ぎます。
 - **Actionlint および Zizmor フック (pre-commit)**:
   - `.github/workflows/` 配下の YAML ファイルに対して、コミット前に `actionlint` と `zizmor` を実行します。
+  - **`zizmor` の検査範囲**: `zizmor` はワークフローファイルに加えて `.github/dependabot.yml` および `action.yml` / `action.yaml`（コンポジットアクション）も検査対象に含みます。
   - これにより、インジェクションリスクや不適切な権限指定といったCI固有の脆弱性をローカル環境で検査・ブロックし、サーバーへのプッシュを未然に防ぎます。
 - **権限 (Permissions) の最小化**:
   - CI の各ワークフロー (`.github/workflows/*.yml`) では `permissions` が明示されており、GitHub Actions が必要以上にリポジトリを書き換える権限を持たないように設計されています。

--- a/docs/security/leak-prevention.md
+++ b/docs/security/leak-prevention.md
@@ -41,9 +41,9 @@
   - `security-extended` および `security-and-quality` クエリを使用して、データフロー解析によるシークレットのハードコード検知や品質チェックなど、高度な静的解析を行います。
 - **Zizmor ワークフロー (`.github/workflows/zizmor.yml`)**:
   - `zizmor` を利用して、GitHub Actions ワークフロー自体の脆弱性（インジェクションリスクや不適切な権限設定など）を静的解析し、CI 設定を経由した情報漏洩を未然に防ぎます。
-- **Actionlint フック (pre-commit)**:
-  - `.github/workflows/` 配下の YAML ファイル（`.yml` / `.yaml`、サブディレクトリ含む）に対して、actionlint が検知可能なインジェクションリスクや設定ミスをコミット前に検査します。
-  - 動的に取得される外部スクリプトなど actionlint の対象外となるリスクは、zizmor および `permissions-audit.yml` の CI 検査で補完します。
+- **Actionlint および Zizmor フック (pre-commit)**:
+  - `.github/workflows/` 配下の YAML ファイルに対して、コミット前に `actionlint` と `zizmor` を実行します。
+  - これにより、インジェクションリスクや不適切な権限指定といったCI固有の脆弱性をローカル環境で検査・ブロックし、サーバーへのプッシュを未然に防ぎます。
 - **権限 (Permissions) の最小化**:
   - CI の各ワークフロー (`.github/workflows/*.yml`) では `permissions` が明示されており、GitHub Actions が必要以上にリポジトリを書き換える権限を持たないように設計されています。
 


### PR DESCRIPTION
## 背景

対象リポジトリは Node.js (Bun), React ベースで構成されており、既に `gitleaks`、`trufflehog`、`actionlint` など多層的な防御層を持っています。しかし、GitHub Actions ワークフローの高度な静的解析ツールである `zizmor` は CI（`.github/workflows/zizmor.yml`）のみで実行されており、開発者が危険な CI 設定を誤ってコミットしてしまうリスクがローカル環境に残されていました。

## 現状認識（事前調査結果のサマリー）

- 既存防御策: `gitleaks.yml`, `trufflehog.yml`, `actionlint`, `zizmor.yml`, `.pre-commit-config.yaml` 導入済み。
- 未カバー領域: `zizmor` のローカルでのコミット前検知（pre-commit hook）。
- 直近の漏洩リスク兆候: `.env` 等の混入は防がれているが、CI 設定ファイルのインジェクションリスクをローカルでブロックする仕組みが弱い。

## このPRで導入・強化するもの

- 対象: 既存 `.pre-commit-config.yaml`、`.github/dependabot.yml` および `docs/security/leak-prevention.md`
- ツール名とバージョン: zizmor pre-commit hook (v1.28.0)
- 期待される効果: 開発者が `.github/workflows/` 配下のファイルを変更してコミットする際、ローカル環境で `zizmor` が実行され、インジェクションリスクや過剰な権限設定がある場合はコミットをブロックします。
- **実行モードの固定**: フックは `args: ['--no-progress', '--offline']` でオフラインに固定しています。`zizmor` は `GH_TOKEN` / `GITHUB_TOKEN` / `ZIZMOR_GITHUB_TOKEN` があると自動でオンラインモードに切り替わり、`ref-version-mismatch` 等の追加検知で非 0 終了するため、固定しないと「トークンを export している開発者だけコミットできない」状態になります。オンライン検査は CI (`.github/workflows/zizmor.yml`) が担当します。
- **`.github/dependabot.yml` の `cooldown` について**: この変更は zizmor 導入の必然的な帰結です。zizmor v1.28.0 の `dependabot-cooldown` 監査が npm / github-actions の 2 箇所で `insufficient implicit default-days (less than 7)` を検知するため、`default-days: 7` を追加しています。7 は任意の値ではなく zizmor の閾値そのものです。なお `cooldown` は version updates にのみ効き security updates には適用されないため、脆弱性修正の取り込みが遅延することはありません。

## 検知漏れリスクと補完策

- 検知できないケース: 動的に生成されるスクリプトの実行時の振る舞い。
- 補完策: 既存の GitHub Secret Scanning と組み合わせ、また CI 側でも引き続き `zizmor` を実行することで二重化。

## マージ前に必要な手動作業（チェックリスト）

レビュアーは PR をマージする前に必ず以下を実施してください。
本 PR の CI は手動作業完了を前提に通る設計です。

- [ ] developer 各自のローカルで `pre-commit install` または `bun run prepare` を再実行する周知

## マージ後の確認手順

- [ ] 次の push / PR で導入した workflow (pre-commit 含む) が green になることを確認
- [ ] ローカルで `.github/workflows/` 以下のファイルを編集し、`git commit` 時に zizmor がフックとして動作することを確認

## ロールバック手順

問題が出た場合は、以下をまとめて元に戻してコミットしてください。

1. `.pre-commit-config.yaml` から `zizmor` の記述を削除
2. `.github/dependabot.yml` の `cooldown: default-days: 7`（npm / github-actions / pre-commit の 3 箇所）を削除 — これは zizmor の `dependabot-cooldown` 監査に対応するための変更のため、zizmor を外すなら併せて棚卸ししてください（削除せず残す判断も可、その場合は根拠コメントが zizmor 由来である旨に注意）
3. `docs/security/leak-prevention.md` の zizmor 関連記述を削除

## 参考情報

- 公式ドキュメント: https://docs.zizmor.sh/
- zizmor - dependabot-cooldown: https://docs.zizmor.sh/audits/#dependabot-cooldown
- zizmor - Operating modes: https://docs.zizmor.sh/usage/#operating-modes
- 比較検討した他案: 新規の検知ツール（detect-secrets等）は既に導入済みであったため、現状の CI 防御をローカルへシフトレフトする案を採用。
- 直近の関連 PR / Issue: なし

---
*PR created automatically by Jules for task [9476589348078108835](https://jules.google.com/task/9476589348078108835) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **セキュリティ**
  * コミット前に CI 設定のインジェクションリスクや不適切な権限設定を検査できるようになりました。
  * 問題のある設定をサーバーへプッシュする前に検出・ブロックします。

* **ドキュメント**
  * CI 設定の安全性チェックに関する説明を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
