### PR TITLE
chore(security): 🔒 ローカルエディタ設定 (.vscode/settings.json) のシークレット隠蔽厳格化

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,7 +38,11 @@
     "**/.windsurf/**": true,
     "**/.trae/**": true,
     "**/.roo/**": true,
-    "**/*-report.md": true
+    "**/*-report.md": true,
+    "**/ai-report-*.md": true,
+    "**/*.log": true,
+    "**/*.patch": true,
+    "**/*.diff": true
   },
   "search.exclude": {
     "**/.env": true,
@@ -81,6 +85,7 @@
     "**/.roo/**": true,
     "**/*.log": true,
     "**/*-report.md": true,
+    "**/ai-report-*.md": true,
     "**/*.patch": true,
     "**/*.diff": true
   }

--- a/docs/security/leak-prevention.md
+++ b/docs/security/leak-prevention.md
@@ -15,7 +15,7 @@
   - `*.pem`, `*.key`, `id_rsa`, `id_ed25519`, `id_ecdsa`, `id_dsa`, `*credentials*.json`, `*secret*.json`, `*.npmrc`, `.netrc`, DBファイル(`*.sqlite` 等) 等
   - AI エージェントの作業跡（`.copilot/`, `.cursor/`, `.claude/`, `.aider*`, `.cline/`, `.windsurf/`, `.trae/`, `.roo/` 等）やエディタのローカル履歴（`.history/`）、デバッグ等で出力されるログファイル・レポートファイル（`*.log`, `*-report.md`）、ソースコードの差分ファイル（`*.patch`, `*.diff`）はローカル環境特有の秘密情報や未公開コードが含まれるリスクがあるため除外しています。
   - **さらに、`.gitattributes` により、これらの秘密情報ファイルが誤って `git add` された場合でも、diff の中身がレビュー画面・ログ・PR 上で表示されない（`-diff` によりバイナリ扱いとなり `Binary files differ` 表示）よう、またリポジトリのアーカイブに含まれないよう（`export-ignore`）設定し、二重に保護しています。**
-- **VS Code / Cursor 用安全側プリセット (`.vscode/settings.json`)**: リポジトリに事前に設定されたプリセットにより、ローカルエディタのエクスプローラーや検索からシークレットファイル (`.env`, `*.pem`, `id_rsa`等) やAIエージェントの作業跡 (`.copilot/`, `.cursor/`, `.claude/`等)、エディタ履歴 (`.history/`) を除外 (`files.exclude`) し、誤露出・誤操作のリスクを低減します。コミット防止は `.gitignore` およびフックで担保します。
+- **VS Code / Cursor 用安全側プリセット (`.vscode/settings.json`)**: リポジトリに事前に設定されたプリセットにより、ローカルエディタのエクスプローラーや検索からシークレットファイル (`.env`, `*.pem`, `id_rsa`等) やAIエージェントの作業跡 (`.copilot/`, `.cursor/`, `.claude/` 等に加え `ai-report-*.md` などの一時ファイル)、エディタ履歴 (`.history/`)、ソースコードの差分ファイル（`*.patch`, `*.diff`）などを除外 (`files.exclude`, `search.exclude`) し、誤露出・誤操作のリスクを低減します。コミット防止は `.gitignore` および各種フック（`gitleaks`、`forbid-sensitive-files`）で担保します。
 - **`pre-commit` framework**: `.pre-commit-config.yaml` による標準的なフック（秘密鍵の検知、YAML構文チェックなど）を利用してコミット前の安全性をさらに高めています。
   - **`detect-secrets`**: `gitleaks` を補完し、エントロピーベースで未知の高乱数なシークレットや独自フォーマットのトークンを検知します。
     - **セットアップ**: `pre-commit install` 実行時に自動的にインストールされます。追加の手動インストールは不要です。

--- a/docs/security/leak-prevention.md
+++ b/docs/security/leak-prevention.md
@@ -16,6 +16,7 @@
   - AI エージェントの作業跡（`.copilot/`, `.cursor/`, `.claude/`, `.aider*`, `.cline/`, `.windsurf/`, `.trae/`, `.roo/` 等）やエディタのローカル履歴（`.history/`）、デバッグ等で出力されるログファイル・レポートファイル（`*.log`, `*-report.md`）、ソースコードの差分ファイル（`*.patch`, `*.diff`）はローカル環境特有の秘密情報や未公開コードが含まれるリスクがあるため除外しています。
   - **さらに、`.gitattributes` により、これらの秘密情報ファイルが誤って `git add` された場合でも、diff の中身がレビュー画面・ログ・PR 上で表示されない（`-diff` によりバイナリ扱いとなり `Binary files differ` 表示）よう、またリポジトリのアーカイブに含まれないよう（`export-ignore`）設定し、二重に保護しています。**
 - **VS Code / Cursor 用安全側プリセット (`.vscode/settings.json`)**: リポジトリに事前に設定されたプリセットにより、ローカルエディタのエクスプローラーや検索からシークレットファイル (`.env`, `*.pem`, `id_rsa`等) やAIエージェントの作業跡 (`.copilot/`, `.cursor/`, `.claude/` 等に加え `ai-report-*.md` などの一時ファイル)、エディタ履歴 (`.history/`)、ソースコードの差分ファイル（`*.patch`, `*.diff`）などを除外 (`files.exclude`, `search.exclude`) し、誤露出・誤操作のリスクを低減します。コミット防止は `.gitignore` および各種フック（`gitleaks`、`forbid-sensitive-files`）で担保します。
+  - これは VS Code/Cursor のワークスペース設定を利用した補助的な防御であり、他のエディタや設定を無効化・上書きされた環境には適用されません。設定反映後はエディタを再起動し、`test.patch` 等が Explorer と検索結果から除外されること、GitHub の Push Protection が有効であることを確認してください。
 - **`pre-commit` framework**: `.pre-commit-config.yaml` による標準的なフック（秘密鍵の検知、YAML構文チェックなど）を利用してコミット前の安全性をさらに高めています。
   - **`detect-secrets`**: `gitleaks` を補完し、エントロピーベースで未知の高乱数なシークレットや独自フォーマットのトークンを検知します。
     - **セットアップ**: `pre-commit install` 実行時に自動的にインストールされます。追加の手動インストールは不要です。


### PR DESCRIPTION
## 背景

対象リポジトリはNode.js/Bunベースで、gitleaks、trufflehog、trivyなどのCIチェックやpre-commitフックが多層的に導入され、強固な防御体制が敷かれています。しかし、`.gitignore`、`.gitattributes`、`.pre-commit-config.yaml`（`forbid-sensitive-files`）で設定されているAIエージェントの作業跡や一時ファイル（`*.patch`, `*.diff`, `*.log`, `ai-report-*.md`）に対するローカル環境特有の除外ルールが、VS Code / Cursor用設定である `.vscode/settings.json` の `files.exclude` および `search.exclude` に一部同期されていません。これにより、エディタのエクスプローラーや検索結果にこれらのシークレットリスクを伴う一時ファイルが表示され、誤操作によって漏洩するリスクが残存しています。

## 現状認識（事前調査結果のサマリー）

- 既存防御策: `gitleaks`, `trufflehog`, `trivy`, `actionlint`、`.pre-commit-config.yaml`（`forbid-sensitive-files`）などが導入済み
- 未カバー領域: `.vscode/settings.json` の `files.exclude` および `search.exclude` と、`.gitignore` などの他の除外設定ファイルとの同期漏れ（`*.patch`, `*.diff`, `*.log`, `ai-report-*.md` など）
- 直近の漏洩リスク兆候: Git historyへの直接的な漏洩は確認されていないものの、AIエージェントの一時ファイルがエディタ上で誤って表示・操作される可能性が存在

## このPRで導入・強化するもの

- 対象: `.vscode/settings.json` および `docs/security/leak-prevention.md`
- ツール名とバージョン: VS Code / Cursor Workspace Settings
- 期待される効果: `*.patch`, `*.diff`, `*.log`, `ai-report-*.md` などのAIワークスペース関連・一時ファイルをエクスプローラーや検索対象から除外し、誤操作による漏洩やコンテキストの流出をローカルエディタレベルで防ぐ。また、設定の厳格化を運用ルール（セキュリティドキュメント）に追記し周知を図る。

## 検知漏れリスクと補完策

- 検知できないケース: VS CodeやCursor以外のエディタを使用している場合、またはワークスペース設定を無効化している場合
- 補完策: 既に導入されている `.gitignore`, `.gitattributes`, `.pre-commit-config.yaml` の `forbid-sensitive-files` フックによる多層防御でコミット・プッシュをブロック

## マージ前に必要な手動作業（チェックリスト）

レビュアーは PR をマージする前に必ず以下を実施してください。
本 PR の CI は手動作業完了を前提に通る設計です。

- [ ] ローカルの開発者がVS Code / Cursorの再起動を行い、設定を反映させるよう周知する
- [ ] GitHub repo settings → Code security → Push protection が有効になっていることを念のため確認する

## マージ後の確認手順

- [ ] ローカルで対象ファイル（例: `test.patch`）を作成し、VS Codeエクスプローラーから隠蔽され、検索にヒットしないことを確認する

## ロールバック手順

`.vscode/settings.json` と `docs/security/leak-prevention.md` に追加・変更した設定行を削除し、コミットしてプッシュする。

## 参考情報

- 公式ドキュメント: https://code.visualstudio.com/docs/getstarted/settings
- 比較検討した他案: 新規のローカルフックスクリプトの導入（既にpre-commit等が存在するため、設定の同期を優先し不採用）

---
*PR created automatically by Jules for task [18422719318876756655](https://jules.google.com/task/18422719318876756655) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * VS Code / Cursorで、AIレポートやログ、パッチ、差分などの一時ファイルをファイル一覧と検索結果から除外できるようになりました。
  * セキュリティガイドを更新し、ローカルの除外設定とコミット防止の仕組みについて説明を補足しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->