### PR TITLE
🎨 Palette: できない理由を説明するツールチップの追加

### DIFF
--- a/src/components/ActionDialog/PurchaseDialog.tsx
+++ b/src/components/ActionDialog/PurchaseDialog.tsx
@@ -4,6 +4,8 @@ import Dialog from '../common/Dialog';
 import Button from '../common/Button';
 import styles from './ActionDialog.module.css';
 
+const NO_MONEY_HINT_TEXT = 'おかねがたりないよ';
+
 type PurchaseDialogProps = {
   space: BoardSpace;
   currentPlayer: Player;
@@ -36,7 +38,7 @@ export default function PurchaseDialog({
             onClick={onBuy}
             aria-disabled={!canAfford}
             aria-describedby={!canAfford ? noMoneyHintId : undefined}
-            title={!canAfford ? 'おかねがたりないよ' : undefined}
+            title={!canAfford ? NO_MONEY_HINT_TEXT : undefined}
           >
             ${space.price}で買う！
           </Button>
@@ -54,7 +56,7 @@ export default function PurchaseDialog({
         </div>
         {!canAfford && (
           <div id={noMoneyHintId} className={styles.noMoneyHintTight}>
-            おかねがたりないよ
+            {NO_MONEY_HINT_TEXT}
           </div>
         )}
       </div>

--- a/src/components/ActionDialog/PurchaseDialog.tsx
+++ b/src/components/ActionDialog/PurchaseDialog.tsx
@@ -29,6 +29,7 @@ export default function PurchaseDialog({
             onClick={onBuy}
             aria-disabled={!canAfford}
             aria-describedby={!canAfford ? noMoneyHintId : undefined}
+            title={!canAfford ? 'おかねがたりないよ' : undefined}
           >
             ${space.price}で買う！
           </Button>

--- a/src/components/ActionDialog/PurchaseDialog.tsx
+++ b/src/components/ActionDialog/PurchaseDialog.tsx
@@ -11,6 +11,13 @@ type PurchaseDialogProps = {
   onDecline: () => void;
 };
 
+/**
+ * 物件購入確認ダイアログ。
+ * マス目の物件を購入するかどうかをプレイヤーに確認し、
+ * 所持金が不足している場合は購入ボタンを無効化したうえで、
+ * `title` 属性によるツールチップと `aria-describedby` で結び付けた
+ * 補助メッセージの両方から「おかねがたりないよ」という理由を伝える。
+ */
 export default function PurchaseDialog({
   space,
   currentPlayer,


### PR DESCRIPTION
### 💡 What
ボタンが `aria-disabled` で無効化されている際に、視覚的なフィードバックとしてネイティブのツールチップ（`title`属性）を追加しました。

### 🎯 Why
`disabled`属性の代わりに`aria-disabled`を使用すると、スクリーンリーダーには無効状態が伝わりますが、視覚を利用するユーザーには「なぜクリックできないのか」が伝わりにくくなります。`title`属性を追加することで、マウスホバー時に「おかねがたりないよ」という理由が表示され、UXが向上します。

### 📸 Before/After
- Before: お金が足りなくて購入ボタンが押せない時、ホバーしても何も表示されない。
- After: お金が足りなくて購入ボタンが押せない時、ホバーすると「おかねがたりないよ」とツールチップが表示される。

### ♿ Accessibility
視覚ユーザーへのフィードバックを復元することで、`aria-disabled` によるセマンティックなアクセシビリティ対応とUXを両立しました。

---
*PR created automatically by Jules for task [7748320664783509869](https://jules.google.com/task/7748320664783509869) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 購入できない場合、購入ボタンに「おかねがたりないよ」を表示するようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->