### PR TITLE
🎨 Palette: Add dynamic titles to aria-disabled buttons in Trade Dialog

### DIFF
--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -153,6 +153,13 @@ export default function TradeDialog({
                 isTradeEmpty || isOfferMoneyInvalid || isRequestMoneyInvalid
               }
               aria-describedby={isTradeEmpty ? tradeEmptyHintId : undefined}
+              title={
+                isTradeEmpty
+                  ? LABELS.emptyHint
+                  : isOfferMoneyInvalid || isRequestMoneyInvalid
+                    ? '入力された金額が正しくありません'
+                    : undefined
+              }
             >
               {LABELS.propose}
             </Button>
@@ -263,6 +270,7 @@ export default function TradeDialog({
               }}
               aria-label={LABELS.add10}
               aria-disabled={offerMoney + 10 > currentPlayer.money}
+              title={offerMoney + 10 > currentPlayer.money ? '所持金を超えています' : undefined}
             >
               +$10
             </button>
@@ -275,6 +283,7 @@ export default function TradeDialog({
               }}
               aria-label={LABELS.add100}
               aria-disabled={offerMoney + 100 > currentPlayer.money}
+              title={offerMoney + 100 > currentPlayer.money ? '所持金を超えています' : undefined}
             >
               +$100
             </button>
@@ -287,6 +296,7 @@ export default function TradeDialog({
               }}
               aria-label={LABELS.clearMoney}
               aria-disabled={offerMoney === 0}
+              title={offerMoney === 0 ? 'すでに0です' : undefined}
             >
               クリア
             </button>
@@ -384,6 +394,7 @@ export default function TradeDialog({
               }}
               aria-label={LABELS.add10}
               aria-disabled={requestMoney + 10 > targetPlayer.money}
+              title={requestMoney + 10 > targetPlayer.money ? '相手の所持金を超えています' : undefined}
             >
               +$10
             </button>
@@ -398,6 +409,7 @@ export default function TradeDialog({
               }}
               aria-label={LABELS.add100}
               aria-disabled={requestMoney + 100 > targetPlayer.money}
+              title={requestMoney + 100 > targetPlayer.money ? '相手の所持金を超えています' : undefined}
             >
               +$100
             </button>
@@ -410,6 +422,7 @@ export default function TradeDialog({
               }}
               aria-label={LABELS.clearMoney}
               aria-disabled={requestMoney === 0}
+              title={requestMoney === 0 ? 'すでに0です' : undefined}
             >
               クリア
             </button>

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -127,6 +127,15 @@ export default function TradeDialog({
     offerMoney === 0 &&
     requestMoney === 0;
 
+  // クイック操作ボタンの無効化条件をここで一元管理し、
+  // onClickガード・aria-disabled・titleの3箇所で使い回すことで不整合を防ぐ
+  const isOfferAdd10Disabled = offerMoney + 10 > currentPlayer.money;
+  const isOfferAdd100Disabled = offerMoney + 100 > currentPlayer.money;
+  const isOfferClearDisabled = offerMoney === 0;
+  const isRequestAdd10Disabled = requestMoney + 10 > targetPlayer.money;
+  const isRequestAdd100Disabled = requestMoney + 100 > targetPlayer.money;
+  const isRequestClearDisabled = requestMoney === 0;
+
   const handlePropose = () => {
     onPropose({
       fromPlayerId: currentPlayer.id,
@@ -273,16 +282,12 @@ export default function TradeDialog({
               type="button"
               className={styles.moneyQuickButton}
               onClick={() => {
-                if (offerMoney + 10 > currentPlayer.money) return;
+                if (isOfferAdd10Disabled) return;
                 setOfferMoney((prev) => clamp(prev + 10, currentPlayer.money));
               }}
               aria-label={LABELS.add10}
-              aria-disabled={offerMoney + 10 > currentPlayer.money}
-              title={
-                offerMoney + 10 > currentPlayer.money
-                  ? '所持金を超えています'
-                  : undefined
-              }
+              aria-disabled={isOfferAdd10Disabled}
+              title={isOfferAdd10Disabled ? '所持金を超えています' : undefined}
             >
               +$10
             </button>
@@ -290,16 +295,12 @@ export default function TradeDialog({
               type="button"
               className={styles.moneyQuickButton}
               onClick={() => {
-                if (offerMoney + 100 > currentPlayer.money) return;
+                if (isOfferAdd100Disabled) return;
                 setOfferMoney((prev) => clamp(prev + 100, currentPlayer.money));
               }}
               aria-label={LABELS.add100}
-              aria-disabled={offerMoney + 100 > currentPlayer.money}
-              title={
-                offerMoney + 100 > currentPlayer.money
-                  ? '所持金を超えています'
-                  : undefined
-              }
+              aria-disabled={isOfferAdd100Disabled}
+              title={isOfferAdd100Disabled ? '所持金を超えています' : undefined}
             >
               +$100
             </button>
@@ -307,12 +308,12 @@ export default function TradeDialog({
               type="button"
               className={styles.moneyQuickButtonClear}
               onClick={() => {
-                if (offerMoney === 0) return;
+                if (isOfferClearDisabled) return;
                 setOfferMoney(0);
               }}
               aria-label={LABELS.clearMoney}
-              aria-disabled={offerMoney === 0}
-              title={offerMoney === 0 ? 'すでに0です' : undefined}
+              aria-disabled={isOfferClearDisabled}
+              title={isOfferClearDisabled ? 'すでに0です' : undefined}
             >
               クリア
             </button>
@@ -405,13 +406,13 @@ export default function TradeDialog({
               type="button"
               className={styles.moneyQuickButton}
               onClick={() => {
-                if (requestMoney + 10 > targetPlayer.money) return;
+                if (isRequestAdd10Disabled) return;
                 setRequestMoney((prev) => clamp(prev + 10, targetPlayer.money));
               }}
               aria-label={LABELS.add10}
-              aria-disabled={requestMoney + 10 > targetPlayer.money}
+              aria-disabled={isRequestAdd10Disabled}
               title={
-                requestMoney + 10 > targetPlayer.money
+                isRequestAdd10Disabled
                   ? '相手の所持金を超えています'
                   : undefined
               }
@@ -422,15 +423,15 @@ export default function TradeDialog({
               type="button"
               className={styles.moneyQuickButton}
               onClick={() => {
-                if (requestMoney + 100 > targetPlayer.money) return;
+                if (isRequestAdd100Disabled) return;
                 setRequestMoney((prev) =>
                   clamp(prev + 100, targetPlayer.money),
                 );
               }}
               aria-label={LABELS.add100}
-              aria-disabled={requestMoney + 100 > targetPlayer.money}
+              aria-disabled={isRequestAdd100Disabled}
               title={
-                requestMoney + 100 > targetPlayer.money
+                isRequestAdd100Disabled
                   ? '相手の所持金を超えています'
                   : undefined
               }
@@ -441,12 +442,12 @@ export default function TradeDialog({
               type="button"
               className={styles.moneyQuickButtonClear}
               onClick={() => {
-                if (requestMoney === 0) return;
+                if (isRequestClearDisabled) return;
                 setRequestMoney(0);
               }}
               aria-label={LABELS.clearMoney}
-              aria-disabled={requestMoney === 0}
-              title={requestMoney === 0 ? 'すでに0です' : undefined}
+              aria-disabled={isRequestClearDisabled}
+              title={isRequestClearDisabled ? 'すでに0です' : undefined}
             >
               クリア
             </button>

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -136,6 +136,18 @@ export default function TradeDialog({
   const isRequestAdd100Disabled = requestMoney + 100 > targetPlayer.money;
   const isRequestClearDisabled = requestMoney === 0;
 
+  // 提案ボタンの説明先IDを一元管理する。
+  // 提示・要求の金額エラーが同時に発生した場合も両方のIDを空白区切りで参照させ、
+  // スクリーンリーダーが片方の理由しか読み上げない状態を防ぐ
+  const proposeDescribedBy =
+    [
+      isTradeEmpty ? tradeEmptyHintId : undefined,
+      isOfferMoneyInvalid ? offerMoneyErrorId : undefined,
+      isRequestMoneyInvalid ? requestMoneyErrorId : undefined,
+    ]
+      .filter((id): id is string => id !== undefined)
+      .join(' ') || undefined;
+
   const handlePropose = () => {
     onPropose({
       fromPlayerId: currentPlayer.id,
@@ -161,15 +173,7 @@ export default function TradeDialog({
               aria-disabled={
                 isTradeEmpty || isOfferMoneyInvalid || isRequestMoneyInvalid
               }
-              aria-describedby={
-                isTradeEmpty
-                  ? tradeEmptyHintId
-                  : isOfferMoneyInvalid
-                    ? offerMoneyErrorId
-                    : isRequestMoneyInvalid
-                      ? requestMoneyErrorId
-                      : undefined
-              }
+              aria-describedby={proposeDescribedBy}
               title={
                 isTradeEmpty
                   ? LABELS.emptyHint

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -152,7 +152,15 @@ export default function TradeDialog({
               aria-disabled={
                 isTradeEmpty || isOfferMoneyInvalid || isRequestMoneyInvalid
               }
-              aria-describedby={isTradeEmpty ? tradeEmptyHintId : undefined}
+              aria-describedby={
+                isTradeEmpty
+                  ? tradeEmptyHintId
+                  : isOfferMoneyInvalid
+                    ? offerMoneyErrorId
+                    : isRequestMoneyInvalid
+                      ? requestMoneyErrorId
+                      : undefined
+              }
               title={
                 isTradeEmpty
                   ? LABELS.emptyHint
@@ -270,7 +278,11 @@ export default function TradeDialog({
               }}
               aria-label={LABELS.add10}
               aria-disabled={offerMoney + 10 > currentPlayer.money}
-              title={offerMoney + 10 > currentPlayer.money ? '所持金を超えています' : undefined}
+              title={
+                offerMoney + 10 > currentPlayer.money
+                  ? '所持金を超えています'
+                  : undefined
+              }
             >
               +$10
             </button>
@@ -283,7 +295,11 @@ export default function TradeDialog({
               }}
               aria-label={LABELS.add100}
               aria-disabled={offerMoney + 100 > currentPlayer.money}
-              title={offerMoney + 100 > currentPlayer.money ? '所持金を超えています' : undefined}
+              title={
+                offerMoney + 100 > currentPlayer.money
+                  ? '所持金を超えています'
+                  : undefined
+              }
             >
               +$100
             </button>
@@ -394,7 +410,11 @@ export default function TradeDialog({
               }}
               aria-label={LABELS.add10}
               aria-disabled={requestMoney + 10 > targetPlayer.money}
-              title={requestMoney + 10 > targetPlayer.money ? '相手の所持金を超えています' : undefined}
+              title={
+                requestMoney + 10 > targetPlayer.money
+                  ? '相手の所持金を超えています'
+                  : undefined
+              }
             >
               +$10
             </button>
@@ -409,7 +429,11 @@ export default function TradeDialog({
               }}
               aria-label={LABELS.add100}
               aria-disabled={requestMoney + 100 > targetPlayer.money}
-              title={requestMoney + 100 > targetPlayer.money ? '相手の所持金を超えています' : undefined}
+              title={
+                requestMoney + 100 > targetPlayer.money
+                  ? '相手の所持金を超えています'
+                  : undefined
+              }
             >
               +$100
             </button>


### PR DESCRIPTION
### 💡 What
Added dynamic `title` attributes to all buttons within the Trade Dialog (`Propose` and the `+$10`, `+$100`, `クリア` buttons for both offer and request amounts) that conditionally use `aria-disabled="true"`. Also logged this finding in `.jules/palette.md`.

### 🎯 Why
When `aria-disabled="true"` is used instead of the native `disabled` attribute (which is good for accessibility and allowing focus), standard visual browsers do not natively provide a tooltip explaining why the button is unclickable. Adding dynamic `title` attributes (e.g., '所持金を超えています' or 'こうかんするものをえらんでね') restores this crucial UX feedback for visual users.

### 📸 Before/After
- **Before:** Buttons that were unclickable via `aria-disabled` provided no visual tooltip to explain why they were disabled.
- **After:** Hovering over an `aria-disabled` button now displays a helpful native tooltip explaining the specific reason (e.g., '所持金を超えています', 'すでに0です', or '入力された金額が正しくありません').

### ♿ Accessibility
This change bridges the gap between semantic accessibility (using `aria-disabled` to maintain focusability and screen reader context) and visual UX, ensuring all users receive clear feedback on disabled states.

---
*PR created automatically by Jules for task [14588941131007578037](https://jules.google.com/task/14588941131007578037) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 取引提案ボタンに、取引内容に応じた日本語ツールチップを追加しました。
  * 金額クイック操作ボタンに、金額超過や残高が0ドルの場合の状態説明を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->