### PR TITLE
🎨 Palette: プレイヤー人数の増減ボタンにツールチップを追加

### DIFF
--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -167,6 +167,7 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
             setPlayerCount((c) => c - 1);
           }}
           aria-disabled={playerCount <= MIN_PLAYERS}
+          title={playerCount <= MIN_PLAYERS ? 'これ以上減らせません' : undefined}
           aria-label="プレイヤーを減らす"
           aria-describedby={
             playerCount <= MIN_PLAYERS
@@ -188,6 +189,7 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
             setPlayerCount((c) => c + 1);
           }}
           aria-disabled={playerCount >= MAX_PLAYERS}
+          title={playerCount >= MAX_PLAYERS ? 'これ以上増やせません' : undefined}
           aria-label="プレイヤーを増やす"
           aria-describedby={
             playerCount >= MAX_PLAYERS

--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -62,6 +62,11 @@ const DEFAULT_NAMES = [
 ];
 const DEFAULT_TOKENS: string[] = [TOKENS[0], TOKENS[1], TOKENS[2], TOKENS[3]];
 const START_GUIDE_MSG = 'すべてのプレイヤーのなまえを入力してね';
+// プレイヤー人数の増減ボタンが無効化されたときの理由文言。
+// title 属性と aria-describedby が参照する説明用 span の両方から参照し、
+// 文言の二重管理を避ける。
+const MIN_PLAYERS_DISABLED_MSG = 'これ以上減らせません';
+const MAX_PLAYERS_DISABLED_MSG = 'これ以上増やせません';
 
 /**
  * ゲーム開始前の初期設定画面コンポーネント。
@@ -167,7 +172,9 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
             setPlayerCount((c) => c - 1);
           }}
           aria-disabled={playerCount <= MIN_PLAYERS}
-          title={playerCount <= MIN_PLAYERS ? 'これ以上減らせません' : undefined}
+          title={
+            playerCount <= MIN_PLAYERS ? MIN_PLAYERS_DISABLED_MSG : undefined
+          }
           aria-label="プレイヤーを減らす"
           aria-describedby={
             playerCount <= MIN_PLAYERS
@@ -189,7 +196,9 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
             setPlayerCount((c) => c + 1);
           }}
           aria-disabled={playerCount >= MAX_PLAYERS}
-          title={playerCount >= MAX_PLAYERS ? 'これ以上増やせません' : undefined}
+          title={
+            playerCount >= MAX_PLAYERS ? MAX_PLAYERS_DISABLED_MSG : undefined
+          }
           aria-label="プレイヤーを増やす"
           aria-describedby={
             playerCount >= MAX_PLAYERS
@@ -207,7 +216,7 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
           role="status"
           aria-live="polite"
         >
-          これ以上減らせません
+          {MIN_PLAYERS_DISABLED_MSG}
         </span>
       )}
       {playerCount >= MAX_PLAYERS && (
@@ -217,7 +226,7 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
           role="status"
           aria-live="polite"
         >
-          これ以上増やせません
+          {MAX_PLAYERS_DISABLED_MSG}
         </span>
       )}
       <div className={styles.subtitle}>


### PR DESCRIPTION
### 💡 What
ゲーム設定（Setup）画面におけるプレイヤー人数増減ボタン（`+`, `-`）が上限・下限に達して `aria-disabled="true"` となった際に、ネイティブのツールチップが表示されるよう `title` 属性を追加しました。

### 🎯 Why
現状、ボタンが無効化されると視覚的にはクリックできないことがわかりますが、独自実装の `aria-disabled` のみを使用しているため、なぜ押せないのかという理由（「これ以上減らせません」「これ以上増やせません」）がマウスオーバー時に提示されていませんでした。
`title` 属性を追加することで、ネイティブの `disabled` 属性のようなツールチップ体験を提供し、利用者が戸惑うのを防ぐことができます。

### 📸 Before/After
- **Before:** 上限/下限到達時にボタンにホバーしてもツールチップが表示されない
- **After:** 上限/下限到達時にボタンにホバーすると、それぞれ「これ以上増やせません」「これ以上減らせません」というネイティブツールチップが表示されるようになる

### ♿ Accessibility
`aria-disabled` に頼ったカスタムコントロールに対して、マウスユーザー向けの補助説明を `title` 属性で提供し、アクセシビリティ対応と視覚的なUXの体験格差を是正しました。スクリーンリーダー向けには既存の `aria-describedby` と `aria-live` による読み上げが担保されています。

---
*PR created automatically by Jules for task [9282236015414230177](https://jules.google.com/task/9282236015414230177) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * プレイヤー人数の増減ボタンに、最小・最大人数に達した際の状態を示すツールチップを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->