### PR TITLE
chore(security): 🔒 Gitleaks カスタムルールによる SaaS トークン・GCP サービスアカウント検知強化

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -167,7 +167,7 @@ entropy = 0.0
 [[rules]]
 id = "monopo-gcp-service-account"
 description = "GCP サービスアカウントメールアドレスのハードコード検知"
-regex = '''(?i)[a-z0-9-]+@[a-z0-9-]+\.iam\.gserviceaccount\.com'''
+regex = '''(?i)[a-z0-9-]+@(?:[a-z0-9-]+\.iam\.gserviceaccount\.com|cloudservices\.gserviceaccount\.com|appspot\.gserviceaccount\.com|developer\.gserviceaccount\.com)'''
 tags = ["cloud", "gcp", "service-account", "identifier"]
 secretGroup = 0
 entropy = 0.0

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -146,3 +146,31 @@ regex = '''(?i)(?:pinecone|pc)_[a-z0-9_]*key[\s]*[:=][\s]*["']?[0-9a-f]{8}-[0-9a
 tags = ["ai", "api-key", "credential", "pinecone"]
 secretGroup = 0
 entropy = 0.0
+
+[[rules]]
+id = "monopo-observability-token"
+description = "Observability トークン (Sentry, Datadog 等) のハードコード検知"
+regex = '''(?i)(?:sentry[_-]?auth[_-]?token[\s]*[:=][\s]*["']?[a-zA-Z0-9]{64}["']?|datadog[_-]?api[_-]?key[\s]*[:=][\s]*["']?[a-zA-Z0-9]{32}["']?)'''
+tags = ["observability", "api-key", "credential"]
+secretGroup = 0
+entropy = 0.0
+
+[[rules]]
+id = "monopo-payment-token"
+description = "Payment トークン (Stripe 等) のハードコード検知"
+regex = '''(?i)(?:sk_live|rk_live)_[a-zA-Z0-9]{24,99}'''
+tags = ["payment", "api-key", "credential"]
+secretGroup = 0
+entropy = 0.0
+
+[[rules]]
+id = "monopo-gcp-service-account"
+description = "GCP サービスアカウントメールアドレスのハードコード検知"
+regex = '''(?i)[a-z0-9-]+@[a-z0-9-]+\.iam\.gserviceaccount\.com'''
+tags = ["cloud", "gcp", "service-account", "identifier"]
+secretGroup = 0
+entropy = 0.0
+[rules.allowlist]
+regexes = [
+    '''(?i)example@dummy\.iam\.gserviceaccount\.com'''
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -25,7 +25,8 @@ regexes = [
     '''(?i)@example\.(com|org|net)$''',
     '''(?i)@test\.(com|org|net)$''',
     '''(?i)@dummy\.(com|org|net)$''',
-    '''(?i)@.*\.invalid$'''
+    '''(?i)@.*\.invalid$''',
+    '''(?i)@dummy\.iam\.gserviceaccount\.com$'''
 ]
 
 [[rules]]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -173,5 +173,5 @@ secretGroup = 0
 entropy = 0.0
 [rules.allowlist]
 regexes = [
-    '''(?i)example@dummy\.iam\.gserviceaccount\.com'''
+    '''(?i)^example@dummy\.iam\.gserviceaccount\.com$'''
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -159,7 +159,7 @@ entropy = 0.0
 [[rules]]
 id = "monopo-payment-token"
 description = "Payment トークン (Stripe 等) のハードコード検知"
-regex = '''(?i)(?:sk_live|rk_live)_[a-zA-Z0-9]{24,99}'''
+regex = '''\b(?:sk_live|rk_live)_[a-zA-Z0-9]{24,99}\b'''
 tags = ["payment", "api-key", "credential"]
 secretGroup = 0
 entropy = 0.0

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -158,8 +158,8 @@ entropy = 0.0
 
 [[rules]]
 id = "monopo-payment-token"
-description = "Payment トークン (Stripe 等) のハードコード検知"
-regex = '''\b(?:sk_live|rk_live)_[a-zA-Z0-9]{24,99}\b'''
+description = "Payment トークン (Stripe Secret/Restricted キー, live/test 両方) のハードコード検知"
+regex = '''\b(?:sk|rk)_(?:live|test)_[a-zA-Z0-9]{24,99}\b'''
 tags = ["payment", "api-key", "credential"]
 secretGroup = 0
 entropy = 0.0

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -149,8 +149,8 @@ entropy = 0.0
 
 [[rules]]
 id = "monopo-observability-token"
-description = "Observability トークン (Sentry, Datadog 等) のハードコード検知"
-regex = '''(?i)(?:sentry[_-]?auth[_-]?token[\s]*[:=][\s]*["']?[a-zA-Z0-9]{64}["']?|datadog[_-]?api[_-]?key[\s]*[:=][\s]*["']?[a-zA-Z0-9]{32}["']?)'''
+description = "Observability トークン (Sentry 構造化トークン, Datadog API/APPキー等) のハードコード検知"
+regex = '''(?:sntrys_[A-Za-z0-9+/=_-]{20,}|(?i)(?:datadog|dd)[_-]?(?:api|app)[_-]?key[\s]*[:=][\s]*["']?[a-zA-Z0-9]{32}["']?)'''
 tags = ["observability", "api-key", "credential"]
 secretGroup = 0
 entropy = 0.0

--- a/docs/security/leak-prevention.md
+++ b/docs/security/leak-prevention.md
@@ -42,7 +42,7 @@
   - 全てのブランチへの push および全ての PR、さらに週次のスケジュールで `secretlint` のジョブを実行し、Node.js エコシステムに特化したシークレット漏洩スキャンを行います。これにより、ローカルのフックをすり抜けた場合でも追加の検知層として機能します（ただし、未知のパターンや `.secretlintignore` で除外した対象までは検知できません）。
 - **Gitleaks ワークフロー (`.github/workflows/gitleaks.yml`)**:
   - 全ての PR とすべてのブランチへのプッシュ時に、対象となるソースコードをスキャンし、シークレットの漏洩があれば CI がエラー（赤検知）となります。正規表現とエントロピーによるパターンベースの検知を行います。
-  - **カスタムルールの適用**: リポジトリ直下の `.gitleaks.toml` を使用し、デフォルトの Gitleaks ルールに加えて、個別の汎用ルール（例: メールアドレスや国内電話番号・マイナンバー等の個人情報 [PII] のハードコード、クラウド識別子 [AWS Account ID / GCP Project ID / GCP Service Account]、内部IPアドレス、各種 SaaS・AI トークン (Groq, OpenRouter, DeepSeek 含む)、Observability トークン (Sentry, Datadog)、Payment トークン (Stripe)）も追加で検知するように強化されています。
+  - **カスタムルールの適用**: リポジトリ直下の `.gitleaks.toml` を使用し、デフォルトの Gitleaks ルールに加えて、個別の汎用ルール（例: メールアドレスや国内電話番号・マイナンバー等の個人情報 [PII] のハードコード、クラウド識別子 [AWS Account ID / GCP Project ID / GCP サービスアカウント]、内部IPアドレス、各種 SaaS・AI トークン (Groq, OpenRouter, DeepSeek 含む)、Observability トークン (Sentry, Datadog)、Payment トークン (Stripe)）も追加で検知するように強化されています。
 - **TruffleHog ワークフロー (`.github/workflows/trufflehog.yml`)**:
   - `gitleaks` を補完する形で、実際に外部プロバイダ API に対して有効性を検証できたシークレット（有効性検証済み）のみを検知します（`--only-verified`）。誤検知を減らしつつ、漏洩したキーが現在も利用可能かどうかの重大なリスクを即座にブロックします。
 - **Trivy ワークフロー (`.github/workflows/trivy.yml`)**:

--- a/docs/security/leak-prevention.md
+++ b/docs/security/leak-prevention.md
@@ -42,7 +42,7 @@
   - 全てのブランチへの push および全ての PR、さらに週次のスケジュールで `secretlint` のジョブを実行し、Node.js エコシステムに特化したシークレット漏洩スキャンを行います。これにより、ローカルのフックをすり抜けた場合でも追加の検知層として機能します（ただし、未知のパターンや `.secretlintignore` で除外した対象までは検知できません）。
 - **Gitleaks ワークフロー (`.github/workflows/gitleaks.yml`)**:
   - 全ての PR とすべてのブランチへのプッシュ時に、対象となるソースコードをスキャンし、シークレットの漏洩があれば CI がエラー（赤検知）となります。正規表現とエントロピーによるパターンベースの検知を行います。
-  - **カスタムルールの適用**: リポジトリ直下の `.gitleaks.toml` を使用し、デフォルトの Gitleaks ルールに加えて、個別の汎用ルール（例: メールアドレスや国内電話番号・マイナンバー等の個人情報 [PII] のハードコード、クラウド識別子 [AWS Account ID / GCP Project ID]、内部IPアドレス、各種 SaaS・AI トークン (Groq, OpenRouter, DeepSeek 含む)）も追加で検知するように強化されています。
+  - **カスタムルールの適用**: リポジトリ直下の `.gitleaks.toml` を使用し、デフォルトの Gitleaks ルールに加えて、個別の汎用ルール（例: メールアドレスや国内電話番号・マイナンバー等の個人情報 [PII] のハードコード、クラウド識別子 [AWS Account ID / GCP Project ID / GCP Service Account]、内部IPアドレス、各種 SaaS・AI トークン (Groq, OpenRouter, DeepSeek 含む)、Observability トークン (Sentry, Datadog)、Payment トークン (Stripe)）も追加で検知するように強化されています。
 - **TruffleHog ワークフロー (`.github/workflows/trufflehog.yml`)**:
   - `gitleaks` を補完する形で、実際に外部プロバイダ API に対して有効性を検証できたシークレット（有効性検証済み）のみを検知します（`--only-verified`）。誤検知を減らしつつ、漏洩したキーが現在も利用可能かどうかの重大なリスクを即座にブロックします。
 - **Trivy ワークフロー (`.github/workflows/trivy.yml`)**:


### PR DESCRIPTION
## 背景

事前調査の結果、本リポジトリには既に `gitleaks` (カスタムルール運用含む), `trufflehog`, `trivy`, `secretlint`, `actionlint`、各種 `pre-commit` フックなど、多層的かつ強固なシークレット漏洩防止策が導入済みであることが確認できました。一方で、ドキュメントで例示されている特定の SaaS API キー（Stripe, Sentry, Datadog）や GCP のサービスアカウントメールアドレスなどについて、より明示的で高精度なカスタムルール（タグ付けやゼロフォールスポジティブを狙ったアロリスト運用）の余地がありました。

## 現状認識（事前調査結果のサマリー）

- 既存防御策: `gitleaks.yml`, `trufflehog.yml`, `trivy.yml`, `secretlint.yml`, `codeql.yml`, `.pre-commit-config.yaml` 導入済み。カスタム `.gitleaks.toml` にて AI トークン等はカバー済み。
- 未カバー領域: 決済（Stripe）、オブザーバビリティ（Sentry, Datadog）、GCPサービスアカウント専用の明示的な高精度カスタムルール（デフォルトルールは存在するが、プロジェクト固有のタグ付けや管理としては未定義）。
- 直近の漏洩リスク兆候: 特になし（漏洩の痕跡は発見されませんでした）。

## このPRで導入・強化するもの

- 対象: 既存の `.gitleaks.toml` カスタムルールおよび `docs/security/leak-prevention.md`
- ツール名とバージョン: Gitleaks (既存の CI / pre-commit に適用される設定ファイルのみの強化)
- 期待される効果: コミット前（ローカル）および CI（プッシュ・PR時）における Stripe, Sentry, Datadog, GCP サービスアカウントの意図せぬ混入を、独自のタグ付けとアロリストによって高精度かつ確実に検知しブロックします。

## 検知漏れリスクと補完策

- 検知できないケース: 正規表現にマッチしない短すぎる独自形式のトークンや、環境変数経由ではなく難読化されたシークレット。
- 補完策: 既存の TruffleHog (検証済みシークレット検知)、Secretlint、および GitHub ネイティブの Secret Scanning (リポジトリ設定) と組み合わせて多層防御を維持します。

## マージ前に必要な手動作業（チェックリスト）

レビュアーは PR をマージする前に必ず以下を実施してください。
本 PR の CI は手動作業完了を前提に通る設計です。

- [ ] 設定ファイルの変更のみのため、既存の CI ワークフローがすべて Green になることを確認する。

## マージ後の確認手順

- [ ] 次の push / PR で Gitleaks スキャンが正常に動作し続けることを確認する。
- [ ] 意図的なダミーの SaaS トークン（Stripe等）をローカルで `git add` し、コミットがブロックされることを確認する。

## ロールバック手順

万が一誤検知（False Positive）が多発した場合は、`.gitleaks.toml` の `[rules.allowlist]` セクションに該当のパターンを追加するか、本 PR を Revert してください。

## 参考情報

- 公式ドキュメント: https://github.com/gitleaks/gitleaks
- 比較検討した他案: 新規の検知ツール（detect-secrets等のCI追加）は、既存の多層防御と役割が重複し、CI実行時間の増加や管理コスト増となるため見送り、既存の `gitleaks` 設定の厳格化を優先しました。

---
*PR created automatically by Jules for task [7890556804855720968](https://jules.google.com/task/7890556804855720968) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **セキュリティ**
  - Observabilityトークン、決済トークン、GCPサービスアカウントの認証情報を検出するチェックを追加しました。
  - 誤検知を抑制するため、既知のダミー情報を検出対象から除外しました。
  - 機密情報の誤公開を早期に検知し、情報漏えいリスクを低減します。

- **ドキュメント**
  - GCPサービスアカウントが機密情報チェックの対象であることを追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->