### PR TITLE
chore(security): 🔒 Gitleaks カスタムルール拡張による Subscription ID および AI トークンの検知強化

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -44,7 +44,7 @@ regexes = [
 [[rules]]
 id = "monopo-cloud-id"
 description = "クラウドリソース識別子 (AWS Account ID, GCP Project ID, Azure Subscription ID) の露出"
-regex = '''(?i)(?:(?:aws_account_id|account_id)[\s]*[:=][\s]*["']?\d{12}["']?|(?:gcp_project|project_id)[\s]*[:=][\s]*["']?[a-z][a-z0-9-]{5,29}["']?|(?:azure_subscription_id|subscription_id)[\s]*[:=][\s]*["']?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}["']?)'''
+regex = '''(?i)(?:(?:aws_account_id|account_id)[\s]*[:=][\s]*["']?\d{12}["']?|(?:gcp_project|project_id)[\s]*[:=][\s]*["']?[a-z][a-z0-9-]{5,29}["']?|\bazure_subscription_id\b[\s]*[:=][\s]*["']?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}["']?)'''
 tags = ["cloud", "identifier"]
 secretGroup = 0
 entropy = 0.0

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -87,7 +87,7 @@ regexes = [
 [[rules]]
 id = "monopo-ai-api-key"
 description = "AI サービス (OpenAI, Anthropic, Groq, OpenRouter, DeepSeek 等) の API キーハードコード検知"
-regex = '''(?i)(?:sk-proj-[a-zA-Z0-9\-_]{100,}|sk-svc-[a-zA-Z0-9\-_]{100,}|sk-[a-zA-Z0-9]{48}|sk-ant-api03-[a-zA-Z0-9\-_]{95}|gsk_[a-zA-Z0-9]{52}\b|sk-or-v1-[a-f0-9]{64}|\bsk-[a-f0-9]{32}\b)'''
+regex = '''(?i)(?:\bsk-proj-[a-zA-Z0-9\-_]{100,}|\bsk-svc-[a-zA-Z0-9\-_]{100,}|sk-[a-zA-Z0-9]{48}|sk-ant-api03-[a-zA-Z0-9\-_]{95}|gsk_[a-zA-Z0-9]{52}\b|sk-or-v1-[a-f0-9]{64}|\bsk-[a-f0-9]{32}\b)'''
 tags = ["ai", "api-key", "credential"]
 secretGroup = 0
 entropy = 0.0

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -43,8 +43,8 @@ regexes = [
 
 [[rules]]
 id = "monopo-cloud-id"
-description = "クラウドリソース識別子 (AWS Account ID, GCP Project ID) の露出"
-regex = '''(?i)(?:(?:aws_account_id|account_id)[\s]*[:=][\s]*["']?\d{12}["']?|(?:gcp_project|project_id)[\s]*[:=][\s]*["']?[a-z][a-z0-9-]{5,29}["']?)'''
+description = "クラウドリソース識別子 (AWS Account ID, GCP Project ID, Azure Subscription ID) の露出"
+regex = '''(?i)(?:(?:aws_account_id|account_id)[\s]*[:=][\s]*["']?\d{12}["']?|(?:gcp_project|project_id)[\s]*[:=][\s]*["']?[a-z][a-z0-9-]{5,29}["']?|(?:azure_subscription_id|subscription_id)[\s]*[:=][\s]*["']?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}["']?)'''
 tags = ["cloud", "identifier"]
 secretGroup = 0
 entropy = 0.0
@@ -87,7 +87,7 @@ regexes = [
 [[rules]]
 id = "monopo-ai-api-key"
 description = "AI サービス (OpenAI, Anthropic, Groq, OpenRouter, DeepSeek 等) の API キーハードコード検知"
-regex = '''(?i)(?:sk-proj-[a-zA-Z0-9\-_]{100,}|sk-[a-zA-Z0-9]{48}|sk-ant-api03-[a-zA-Z0-9\-_]{95}|gsk_[a-zA-Z0-9]{52}\b|sk-or-v1-[a-f0-9]{64}|\bsk-[a-f0-9]{32}\b)'''
+regex = '''(?i)(?:sk-proj-[a-zA-Z0-9\-_]{100,}|sk-svc-[a-zA-Z0-9\-_]{100,}|sk-[a-zA-Z0-9]{48}|sk-ant-api03-[a-zA-Z0-9\-_]{95}|gsk_[a-zA-Z0-9]{52}\b|sk-or-v1-[a-f0-9]{64}|\bsk-[a-f0-9]{32}\b)'''
 tags = ["ai", "api-key", "credential"]
 secretGroup = 0
 entropy = 0.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,3 +72,8 @@ TruffleHog および pre-commit（gitleaks/detect-secrets）による CI スキ�
 ### 接続文字列・バックエンドURLのハードコード禁止
 
 データベース（PostgreSQL, MongoDB, MySQL）やキャッシュ（Redis）への完全な接続文字列（`postgres://...` や `redis://...` 等）のソースコードへのハードコードは、`.gitleaks.toml` のカスタムルール (`monopo-connection-string`) によって検知・ブロックされます。パスワードが含まれていない場合でも、環境によって接続先が変わるべき値であるため、必ず環境変数経由で設定してください。
+
+### 追加のカスタム漏洩検知・抑止対策 (Gitleaks 強化)
+
+クラウドリソースの識別子（Azure Subscription ID など）や、最新の AI サービストークン（OpenAI Service Account Token など）がコードベースにハードコードされるリスクを防ぐため、リポジトリ直下の `.gitleaks.toml` カスタムルールを拡張しました。
+これにより、標準の Gitleaks ルールではカバーしきれない特定のクラウドプロバイダや AI ツールの識別子がローカルおよび CI の双方で早期に検知・ブロックされ、漏洩リスクをさらに低減しています。

--- a/docs/security/leak-prevention.md
+++ b/docs/security/leak-prevention.md
@@ -121,3 +121,8 @@ CI の監査ワークフロー (`.github/workflows/permissions-audit.yml`) に�
 ### Dependabot による pre-commit ツールの自動更新
 
 シークレット検知ツール（gitleaks, trufflehog, detect-secrets）を含む `pre-commit` フックのバージョンを常に最新かつ安全に保つため、`.github/dependabot.yml` にて `pre-commit` エコシステムの自動更新を有効化しています。これにより、新しいシークレットパターンへの対応や脆弱性修正が継続的かつ自動で取り込まれ、漏洩防止の防御力が維持されます。
+
+### 追加のカスタム漏洩検知・抑止対策 (Gitleaks 強化)
+
+クラウドリソースの識別子（Azure Subscription ID など）や、最新の AI サービストークン（OpenAI Service Account Token など）がコードベースにハードコードされるリスクを防ぐため、リポジトリ直下の `.gitleaks.toml` カスタムルールを拡張しました。
+これにより、標準の Gitleaks ルールではカバーしきれない特定のクラウドプロバイダや AI ツールの識別子がローカルおよび CI の双方で早期に検知・ブロックされ、漏洩リスクをさらに低減しています。


### PR DESCRIPTION
## 背景
事前調査の結果、本リポジトリには既に `gitleaks`、`trufflehog`、`secretlint` などによる強固な防御層が存在することが確認できました。一方、クラウドの Subscription ID や最新の OpenAI Service Account トークンなど、一部の識別子についてはローカルの `gitleaks` カスタムルールに明示的に登録されていない状態でした。

## 現状認識（事前調査結果のサマリー）
- 既存防御策: `gitleaks.yml`, `codeql.yml`, `trivy.yml`, `.pre-commit-config.yaml` 等が網羅的に導入済み
- 未カバー領域: Azure Subscription ID 等のクラウド識別子、および最新の AI トークンフォーマット
- 直近の漏洩リスク兆候: `.env` 等のコミット痕跡はなく、全体的に高い水準で保護されていることを確認

## このPRで導入・強化するもの
- 対象: 既存の `.gitleaks.toml` カスタムルール拡張、および関連セキュリティドキュメント (`SECURITY.md`, `docs/security/leak-prevention.md`) の更新
- ツール名とバージョン: Gitleaks (v8.30.1)
- 期待される効果: コミット前にローカルおよび CI で、Azure Subscription ID および OpenAI Service Account Token (`sk-svc-`) などの混入を新たに検出して拒否する

## 検知漏れリスクと補完策
- 検知できないケース: エントロピーが低く、特定のフォーマットを持たない独自のパスワードなど
- 補完策: `detect-secrets` や `trufflehog` など、既に導入済みの別アプローチのツールと組み合わせることで多層防御を実現

## マージ前に必要な手動作業（チェックリスト）
レビュアーは PR をマージする前に必ず以下を実施してください。
本 PR の CI は手動作業完了を前提に通る設計です。

- [ ] リポジトリ設定 (Settings > Code security and analysis) から、GitHub ネイティブの **Secret Scanning** と **Push Protection** が有効化されていることを確認（未設定であれば有効化）
- [ ] 開発チーム全体へ `gitleaks` カスタムルールのアップデート内容（新規パターンの追加）を共有

## マージ後の確認手順
- [ ] 次の push / PR で `gitleaks.yml` の CI が正常に終了（green になること）を確認
- [ ] ローカルでテスト用に Subscription ID 形式のダミー文字列を追加し、コミットがブロックされるかを確認

## ロールバック手順
問題が発生した場合、本 PR のコミットを `git revert` していただくか、`.gitleaks.toml` の `monopo-cloud-id` および `monopo-ai-api-key` の正規表現を前の状態に戻してください。

## 参考情報
- 公式ドキュメント: https://github.com/gitleaks/gitleaks
- 比較検討した他案: `trufflehog` pre-push フックの追加や新規ワークフローの追加を検討しましたが、既存設定のカバレッジ拡張を優先し、カスタムルールの強化を行いました。
- 直近の関連 PR / Issue: なし

---
*PR created automatically by Jules for task [18435962336479137498](https://jules.google.com/task/18435962336479137498) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **セキュリティ**
  * UUID形式のAzure Subscription IDや、`sk-svc-`で始まる長いAIサービスキーを検出できるようになりました。
  * ローカル環境およびCIで、対象となるクラウド識別子・AIサービストークンの漏洩を検知・ブロックします。

* **ドキュメント**
  * 追加された検知対象と、漏洩防止の運用方針をセキュリティ関連ドキュメントに追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->