### PR TITLE
chore(security): 🔒 Gitleaks カスタムルールによる Modern PaaS/DBaaS トークン検知強化

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -219,7 +219,7 @@ regexes = [
 [[rules]]
 id = "monopo-modern-paas-token"
 description = "Modern PaaS/DBaaS トークン (Figma, Render, PlanetScale, Fly.io, Neon 等) のハードコード検知"
-regex = '''(?i)(?:\bfigd_[a-zA-Z0-9\-_]{43}\b|\brnd_[a-zA-Z0-9]{32,}\b|\bpscale_tkn_[a-zA-Z0-9\-_]{43}\b|\bfm2_[a-zA-Z0-9\-_]{40,}\b|\bneon_[a-zA-Z0-9]{64}\b)'''
+regex = '''(?i)\b(figd_[a-zA-Z0-9\-_]{43}|rnd_[a-zA-Z0-9]{32,}|pscale_tkn_[a-zA-Z0-9\-_]{43}|fm2_[a-zA-Z0-9\-_]{40,}|neon_[a-zA-Z0-9]{64})(?:$|[^a-zA-Z0-9\-_])'''
 tags = ["saas", "api-key", "credential", "paas", "dbaas"]
-secretGroup = 0
+secretGroup = 1
 entropy = 0.0

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -219,7 +219,7 @@ regexes = [
 [[rules]]
 id = "monopo-modern-paas-token"
 description = "Modern PaaS/DBaaS トークン (Figma, Render, PlanetScale, Fly.io, Neon 等) のハードコード検知"
-regex = '''(?i)\b(figd_[a-zA-Z0-9\-_]{43}|rnd_[a-zA-Z0-9]{32,}|pscale_tkn_[a-zA-Z0-9\-_]{43}|fm2_[a-zA-Z0-9\-_]{40,}|neon_[a-zA-Z0-9]{64})(?:$|[^a-zA-Z0-9\-_])'''
+regex = '''\b(figd_[a-zA-Z0-9\-_]{43}|rnd_[a-zA-Z0-9]{32,}|pscale_tkn_[a-zA-Z0-9\-_]{43}|fm2_[a-zA-Z0-9\-_]{40,}|neon_[a-zA-Z0-9]{64})(?:$|[^a-zA-Z0-9\-_])'''
 tags = ["saas", "api-key", "credential", "paas", "dbaas"]
 secretGroup = 1
 entropy = 0.0

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -215,3 +215,11 @@ entropy = 0.0
 regexes = [
     '''(?i)bearer\s+\$\{.*\}'''
 ]
+
+[[rules]]
+id = "monopo-modern-paas-token"
+description = "Modern PaaS/DBaaS トークン (Figma, Render, PlanetScale, Fly.io, Neon 等) のハードコード検知"
+regex = '''(?i)(?:\bfigd_[a-zA-Z0-9\-_]{43}\b|\brnd_[a-zA-Z0-9]{32,}\b|\bpscale_tkn_[a-zA-Z0-9\-_]{43}\b|\bfm2_[a-zA-Z0-9\-_]{40,}\b|\bneon_[a-zA-Z0-9]{64}\b)'''
+tags = ["saas", "api-key", "credential", "paas", "dbaas"]
+secretGroup = 0
+entropy = 0.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,3 +77,7 @@ TruffleHog および pre-commit（gitleaks/detect-secrets）による CI スキ�
 
 クラウドリソースの識別子（Azure Subscription ID など）や、最新の AI サービストークン（OpenAI Service Account Token など）がコードベースにハードコードされるリスクを防ぐため、リポジトリ直下の `.gitleaks.toml` カスタムルールを拡張しました。
 これにより、標準の Gitleaks ルールではカバーしきれない特定のクラウドプロバイダや AI ツールの識別子がローカルおよび CI の双方で早期に検知・ブロックされ、漏洩リスクをさらに低減しています。
+
+### 追加のカスタム漏洩検知・抑止対策 (Gitleaks 強化 - Modern PaaS/DBaaS対応)
+
+Vite / React 系のモダンな技術スタックにおいて利用頻度が高い PaaS や DBaaS (Figma, Render, PlanetScale, Fly.io, Neon 等) の API トークンがコードベースにハードコードされるリスクを防ぐため、リポジトリ直下の `.gitleaks.toml` カスタムルール (`monopo-modern-paas-token`) を追加しました。これにより、標準の Gitleaks ルールではカバーしきれない特有のフォーマットのシークレットも、コミット前および CI にて即座に検知・ブロックされます。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -80,4 +80,4 @@ TruffleHog および pre-commit（gitleaks/detect-secrets）による CI スキ�
 
 ### 追加のカスタム漏洩検知・抑止対策 (Gitleaks 強化 - Modern PaaS/DBaaS対応)
 
-Vite / React 系のモダンな技術スタックにおいて利用頻度が高い PaaS や DBaaS (Figma, Render, PlanetScale, Fly.io, Neon 等) の API トークンがコードベースにハードコードされるリスクを防ぐため、リポジトリ直下の `.gitleaks.toml` カスタムルール (`monopo-modern-paas-token`) を追加しました。これにより、標準の Gitleaks ルールではカバーしきれない特有のフォーマットのシークレットも、コミット前および CI にて即座に検知・ブロックされます。
+Vite / React 系のモダンな技術スタックにおいて利用頻度が高い PaaS や DBaaS (Figma, Render, PlanetScale, Fly.io, Neon 等) の API トークンがコードベースにハードコードされるリスクを防ぐため、リポジトリ直下の `.gitleaks.toml` カスタムルール (`monopo-modern-paas-token`) を追加しました。検知対象は正規表現で定義された特定のプレフィックス・文字数の形式（`figd_` 43文字、`rnd_` 32文字以上、`pscale_tkn_` 43文字、`fm2_` 40文字以上、`neon_` 64文字）に限定されており、各サービスの API トークン全般を網羅するものではありません。これにより、上記フォーマットに一致するシークレットが、コミット前および CI にて検知・ブロックされます。


### PR DESCRIPTION
## 背景

リポジトリの実態調査（現状認識）として、既存の防御策は `gitleaks`, `trufflehog`, `secretlint` などを多層的に配置し、非常に高いカバー率を誇っています。一方で、Vite / React 系のモダンな技術スタックにおいて使用される可能性が高いクラウドプロバイダ・DBaaS トークン（PlanetScale, Render, Neon, Fly.io, Figma等）に関する特化したシークレット検知ルールがデフォルト及び既存のカスタムルールでカバーされていないギャップがありました。

## 現状認識（事前調査結果のサマリー）

- 既存防御策: `gitleaks.yml`, `trufflehog.yml`, `secretlint.yml`, `pre-commit-config.yaml` 等が導入・強化済み
- 未カバー領域: モダン PaaS/DBaaS の特定フォーマットのアクセストークン（Figma, Render, PlanetScale, Fly.io, Neon 等）がハードコードされた際の即時検知
- 直近の漏洩リスク兆候: `.env` 等のファイルは `.gitignore` に登録されているものの、一時的なデバッグ目的等でテストファイル内にハードコードされるリスクが残存

## このPRで導入・強化するもの

- 対象: 既存の `.gitleaks.toml` カスタムルール
- ツール名とバージョン: Gitleaks (既存の pre-commit および CI ワークフローを利用)
- 期待される効果: コミット前（ローカル）および CI において、Figma (`figd_`), Render (`rnd_`), PlanetScale (`pscale_tkn_`), Fly.io (`fm2_`), Neon (`neon_`) のトークンハードコードを早期検知・拒否

## 検知漏れリスクと補完策

- 検知できないケース: 正規表現に合致しない旧形式のトークンや、意図的に分割された文字列
- 補完策: TruffleHog による検証済みシークレットスキャンおよび GitHub Secret Scanning での二重化

## マージ前に必要な手動作業（チェックリスト）

レビュアーは PR をマージする前に必ず以下を実施してください。
本 PR の CI は手動作業完了を前提に通る設計です。

- [x] 特になし（Gitleaks のルール追加のみのため設定不要）

## マージ後の確認手順

- [ ] 次の push / PR で既存の gitleaks workflow が green になることを確認
- [ ] ローカルで Gitleaks が正常にフックとして動作することを確認

## ロールバック手順

本 PR による誤検知が多発した場合は、`.gitleaks.toml` から `monopo-modern-paas-token` ルールを削除、または `[rules.allowlist]` を追加する PR を作成して対応してください。

## 参考情報

- 公式ドキュメント: https://github.com/gitleaks/gitleaks
- 比較検討した他案: secretlint へのルール追加（Gitleaks のカスタムルールの方が柔軟かつコミット前ブロック・CI 検知に直接寄与するため Gitleaks 側を採用）

---
*PR created automatically by Jules for task [8455559807434378985](https://jules.google.com/task/8455559807434378985) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **セキュリティ**
  - Figma、Render、PlanetScale、Fly.io、Neon などの PaaS／DBaaS トークンを自動検出できるようになりました。
  - 検出対象には SaaS/API キーや認証情報も含まれ、コミット前および CI での漏えい防止に役立ちます。

- **ドキュメント**
  - 新しいシークレット検出ルールと、検出・ブロックの対象をセキュリティガイドに追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->