### PR TITLE
🎨 Palette: アイコンのみのボタンにツールチップを追加

### DIFF
--- a/src/components/Setup/Setup.tsx
+++ b/src/components/Setup/Setup.tsx
@@ -174,7 +174,9 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
           }}
           aria-disabled={playerCount <= MIN_PLAYERS}
           title={
-            playerCount <= MIN_PLAYERS ? MIN_PLAYERS_DISABLED_MSG : undefined
+            playerCount <= MIN_PLAYERS
+              ? MIN_PLAYERS_DISABLED_MSG
+              : 'プレイヤーを減らす'
           }
           aria-label="プレイヤーを減らす"
           aria-describedby={
@@ -199,7 +201,9 @@ export default function Setup({ onStart, onResume, savedGame }: SetupProps) {
           }}
           aria-disabled={playerCount >= MAX_PLAYERS}
           title={
-            playerCount >= MAX_PLAYERS ? MAX_PLAYERS_DISABLED_MSG : undefined
+            playerCount >= MAX_PLAYERS
+              ? MAX_PLAYERS_DISABLED_MSG
+              : 'プレイヤーを増やす'
           }
           aria-label="プレイヤーを増やす"
           aria-describedby={


### PR DESCRIPTION
## 概要
初期設定画面におけるプレイヤー数増減ボタン（アイコンのみのボタン）に、有効時でも表示されるツールチップ（title属性）を追加しました。

### 💡 What
`src/components/Setup/Setup.tsx` のプレイヤー数を増減する `+` / `-` ボタンに、有効状態でも「プレイヤーを増やす」「プレイヤーを減らす」というツールチップ（title）が表示されるよう修正しました。

### 🎯 Why
アイコンのみのボタンは、特に新規ユーザーにとって機能が直感的に伝わりにくい場合があります。ボタンが有効な状態でもツールチップを提供することで、操作の確実性とアクセシビリティを向上させるためです。

### 📸 Before/After
- **Before:** ボタンが無効状態の時のみエラー理由がツールチップ表示され、有効時はツールチップがありませんでした。
- **After:** ボタンが有効状態の時は操作内容を、無効状態の時はエラー理由をツールチップとして表示するようにしました。

### ♿️ Accessibility
スクリーンリーダー向けの `aria-label` に加え、マウスホバー時等に視覚的に情報を補足する `title` を追加し、認知の負荷を軽減しました。

## 関連 Issue / 設計ドキュメント
特になし

## 動作確認
- [x] プレイヤー数増減ボタンにホバーしてツールチップが表示されることを確認
- [x] lint, typecheck, testがすべてパスすることを確認

## セルフチェック
- [x] コーディング規約に沿っている

---
*PR created automatically by Jules for task [7800725978928835364](https://jules.google.com/task/7800725978928835364) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **アクセシビリティ改善**
  * プレイヤー人数の増減ボタンに、状態に応じた日本語の説明を表示するよう改善しました。
  * 無効時は既存の説明を、操作可能な場合は実行できる操作内容を表示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->