### PR TITLE
⚡ Bolt: Optimize total assets calculation in GameBoard

### DIFF
--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -408,7 +408,7 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
       });
   }, [showPlayerDetail, playersById, state.board, state.propertyStates]);
 
-  // ⚡ Bolt: useMemo to prevent recalculating total assets (which involves O(P) iteration over owned properties) on every render while the player dialog is open.
+  // ⚡ Bolt: プレイヤー詳細ダイアログ表示中の総資産再計算を防ぐため、所有物件の走査結果をメモ化する。
   const detailPlayerTotalAssets = useMemo(() => {
     const detailPlayer = showPlayerDetail
       ? playersById[showPlayerDetail]

--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -408,6 +408,19 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
       });
   }, [showPlayerDetail, playersById, state.board, state.propertyStates]);
 
+  // ⚡ Bolt: useMemo to prevent recalculating total assets (which involves O(P) iteration over owned properties) on every render while the player dialog is open.
+  const detailPlayerTotalAssets = useMemo(() => {
+    const detailPlayer = showPlayerDetail
+      ? playersById[showPlayerDetail]
+      : null;
+    if (!detailPlayer) return 0;
+    return calculateTotalAssets(
+      detailPlayer,
+      state.propertyStates,
+      state.board,
+    );
+  }, [showPlayerDetail, playersById, state.propertyStates, state.board]);
+
   return (
     <div className={styles.gameBoard}>
       <div className={styles.boardSection}>
@@ -1042,11 +1055,7 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
         (() => {
           const detailPlayer = playersById[showPlayerDetail];
           if (!detailPlayer) return null;
-          const totalAssets = calculateTotalAssets(
-            detailPlayer,
-            state.propertyStates,
-            state.board,
-          );
+          const totalAssets = detailPlayerTotalAssets;
           const ownedProps = detailPlayerProps;
           const currentSpaceName =
             state.board[detailPlayer.position]?.name ?? '';


### PR DESCRIPTION
Title: ⚡ Bolt: Optimize total assets calculation in GameBoard

## 概要
総資産計算（`calculateTotalAssets`）はプレイヤーの所有物件をループ処理するため、60fpsのアニメーション中などにおいてPlayer detail dialogが開いている間、毎フレーム再計算されると不要な負荷になります。これを `useMemo` でキャッシュすることで、不要なO(N)の再計算を抑制しました。

### 💡 What
- `GameBoard.tsx` のPlayer detail dialog内で呼ばれていた `calculateTotalAssets` の結果を `detailPlayerTotalAssets` として `useMemo` でメモ化しました。
- 描画処理では再計算を行わず、メモ化された値を使用するように変更しました。

### 🎯 Why
パフォーマンスの最適化のため。特にアニメーションによる高頻度な再レンダリング時の不要な計算コストを削減し、アプリケーションの動作をスムーズにします。

### 📊 Impact
Player detail dialog が開かれている間、コンポーネントが再レンダリングされる度に所有物件の数に比例したループ処理が実行されていましたが、これが抑制されます。O(N)の処理が不要になるため、レンダー処理が軽量化されます。

### 🔬 Measurement
`src/components/GameBoard/GameBoard.tsx` 内で `detailPlayerTotalAssets` が `useMemo` でラップされ、正しく利用されていることをコードレベルで確認可能です。また、アニメーション中のダイアログ表示において、処理落ちのリスクが低減されることを期待できます。

### ♿️ Accessibility
- 特にUIや操作性に変更はありません。既存のアクセシビリティ対応を維持しています。

## 関連 Issue / 設計ドキュメント
- 無し

## 動作確認
- `bun run test` を実行し、既存テストが全てパスすることを確認しました。
- ローカル環境でビルドエラーが発生しないことを確認しました。

## セルフチェック
- [x] フォーマット、リンターなどの静的解析ツールが全て通過している

---
*PR created automatically by Jules for task [4152464375200204342](https://jules.google.com/task/4152464375200204342) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **パフォーマンス改善**
  * プレイヤー詳細ダイアログ表示時の総資産計算を最適化しました。
  * 関連する値に変更がない場合、再レンダリング時の不要な再計算を抑制します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->