### PR TITLE
chore(ai): 🤖 AIツール設定の最適化 (GitHub Models gpt-4o-mini への移行)

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -44,12 +44,12 @@
 - Claude Code や OpenCode といった最新のAIコーディングツールを活用する際は、意図しない破壊的変更を避けるため、プレビュー機能を活用して差分を確認しながら適用してください。
 
 - ローカルAIエージェントやAI-native IDE（Windsurf, Trae, Aider, Cline, Roo Code, Continue.devなど）を利用する際は、リポジトリ固有のルールを遵守し、作業ディレクトリ（`.aider*`、`.continue/`、`.windsurf`、`.roo/`、`.trae/` など）をコミットしないように注意してください。
-- 本リポジトリでは無料・オープンソースのベストプラクティスに基づき、GitHub Models (o3-mini) を利用した自作の AI PR Reviewer を導入し、SaaS依存を低減しつつ高度なコードレビューを自動化しています。
-- 最新のフロントエンド（React 19, Bun等）やAI CI/CDのトレンドを要約し、チームの継続的な学習を促進するための AI Weekly Tech Trend Analyzer (`.github/workflows/ai-tech-trend-analyzer.yml`) プロトタイプを導入しています。**GitHub Models (o3-mini) の廃止に伴い、スケジュール実行（cron）は現在停止中です（Refs #539）。** 手動実行（`workflow_dispatch`）のみ可能です。
+- 本リポジトリでは無料・オープンソースのベストプラクティスに基づき、GitHub Models (gpt-4o-mini) を利用した自作の AI PR Reviewer を導入し、SaaS依存を低減しつつ高度なコードレビューを自動化しています。
+- 最新のフロントエンド（React 19, Bun等）やAI CI/CDのトレンドを要約し、チームの継続的な学習を促進するための AI Weekly Tech Trend Analyzer (`.github/workflows/ai-tech-trend-analyzer.yml`) プロトタイプを導入しています。**GitHub Models (o3-mini) の廃止に伴い、スケジュール実行（cron）は現在停止中でしたが、gpt-4o-mini への移行が完了しました。再開する場合は設定を確認してください。** 手動実行（`workflow_dispatch`）のみ可能です。
 
 - 最新のAIエージェント（GitHub Copilot Agent, GPT-5.5, Claude 3.7, DeepSeek-R1 連携等）を利用する際は、生成されたコードのセキュリティリスク（機密情報の出力やインジェクション脆弱性）をローカルで必ず検証し、自動レビューツールとの多層的なチェックを行ってください。
 
 - 新たなAIツールやサービスを導入する際は、公開リポジトリにおいて無料で利用可能であることを前提としてください。また、それらを設定するための手動の事前作業（Secretsへのトークン追加など）は必ずプルリクエストの説明に記載してください。
-- 開発進捗の要約や課題分析には、GitHub Models (o3-mini) と Tavily Search API を連携した自動プロジェクトマネジメントツール (`.github/workflows/ai-weekly-summary.yml`) を用意しています。利用にあたっては、リポジトリの Secrets に `GH_MODELS_TOKEN` と `TAVILY_API_KEY` の事前登録が必須です。**GitHub Models (o3-mini) の廃止によりスケジュール実行（cron）は現在停止中で、週次での自動生成は行われません（Refs #539）。** 再開する場合は代替モデルの選定が必要です。
+- 開発進捗の要約や課題分析には、GitHub Models (gpt-4o-mini) と Tavily Search API を連携した自動プロジェクトマネジメントツール (`.github/workflows/ai-weekly-summary.yml`) を用意しています。利用にあたっては、リポジトリの Secrets に `GH_MODELS_TOKEN` と `TAVILY_API_KEY` の事前登録が必須です。**GitHub Models (o3-mini) の廃止によりスケジュール実行（cron）は現在停止中でしたが、gpt-4o-mini への移行により再開の準備が整いました。**
 
 - `CLAUDE.md` は Claude Code 向けの設定ファイルとして自動生成されます。

--- a/.cursorrules
+++ b/.cursorrules
@@ -44,12 +44,12 @@
 - Claude Code や OpenCode といった最新のAIコーディングツールを活用する際は、意図しない破壊的変更を避けるため、プレビュー機能を活用して差分を確認しながら適用してください。
 
 - ローカルAIエージェントやAI-native IDE（Windsurf, Trae, Aider, Cline, Roo Code, Continue.devなど）を利用する際は、リポジトリ固有のルールを遵守し、作業ディレクトリ（`.aider*`、`.continue/`、`.windsurf`、`.roo/`、`.trae/` など）をコミットしないように注意してください。
-- 本リポジトリでは無料・オープンソースのベストプラクティスに基づき、GitHub Models (o3-mini) を利用した自作の AI PR Reviewer を導入し、SaaS依存を低減しつつ高度なコードレビューを自動化しています。
-- 最新のフロントエンド（React 19, Bun等）やAI CI/CDのトレンドを要約し、チームの継続的な学習を促進するための AI Weekly Tech Trend Analyzer (`.github/workflows/ai-tech-trend-analyzer.yml`) プロトタイプを導入しています。**GitHub Models (o3-mini) の廃止に伴い、スケジュール実行（cron）は現在停止中です（Refs #539）。** 手動実行（`workflow_dispatch`）のみ可能です。
+- 本リポジトリでは無料・オープンソースのベストプラクティスに基づき、GitHub Models (gpt-4o-mini) を利用した自作の AI PR Reviewer を導入し、SaaS依存を低減しつつ高度なコードレビューを自動化しています。
+- 最新のフロントエンド（React 19, Bun等）やAI CI/CDのトレンドを要約し、チームの継続的な学習を促進するための AI Weekly Tech Trend Analyzer (`.github/workflows/ai-tech-trend-analyzer.yml`) プロトタイプを導入しています。**GitHub Models (o3-mini) の廃止に伴い、スケジュール実行（cron）は現在停止中でしたが、gpt-4o-mini への移行が完了しました。再開する場合は設定を確認してください。** 手動実行（`workflow_dispatch`）のみ可能です。
 
 - 最新のAIエージェント（GitHub Copilot Agent, GPT-5.5, Claude 3.7, DeepSeek-R1 連携等）を利用する際は、生成されたコードのセキュリティリスク（機密情報の出力やインジェクション脆弱性）をローカルで必ず検証し、自動レビューツールとの多層的なチェックを行ってください。
 
 - 新たなAIツールやサービスを導入する際は、公開リポジトリにおいて無料で利用可能であることを前提としてください。また、それらを設定するための手動の事前作業（Secretsへのトークン追加など）は必ずプルリクエストの説明に記載してください。
-- 開発進捗の要約や課題分析には、GitHub Models (o3-mini) と Tavily Search API を連携した自動プロジェクトマネジメントツール (`.github/workflows/ai-weekly-summary.yml`) を用意しています。利用にあたっては、リポジトリの Secrets に `GH_MODELS_TOKEN` と `TAVILY_API_KEY` の事前登録が必須です。**GitHub Models (o3-mini) の廃止によりスケジュール実行（cron）は現在停止中で、週次での自動生成は行われません（Refs #539）。** 再開する場合は代替モデルの選定が必要です。
+- 開発進捗の要約や課題分析には、GitHub Models (gpt-4o-mini) と Tavily Search API を連携した自動プロジェクトマネジメントツール (`.github/workflows/ai-weekly-summary.yml`) を用意しています。利用にあたっては、リポジトリの Secrets に `GH_MODELS_TOKEN` と `TAVILY_API_KEY` の事前登録が必須です。**GitHub Models (o3-mini) の廃止によりスケジュール実行（cron）は現在停止中でしたが、gpt-4o-mini への移行により再開の準備が整いました。**
 
 - `CLAUDE.md` は Claude Code 向けの設定ファイルとして自動生成されます。

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,12 +44,12 @@
 - Claude Code や OpenCode といった最新のAIコーディングツールを活用する際は、意図しない破壊的変更を避けるため、プレビュー機能を活用して差分を確認しながら適用してください。
 
 - ローカルAIエージェントやAI-native IDE（Windsurf, Trae, Aider, Cline, Roo Code, Continue.devなど）を利用する際は、リポジトリ固有のルールを遵守し、作業ディレクトリ（`.aider*`、`.continue/`、`.windsurf`、`.roo/`、`.trae/` など）をコミットしないように注意してください。
-- 本リポジトリでは無料・オープンソースのベストプラクティスに基づき、GitHub Models (o3-mini) を利用した自作の AI PR Reviewer を導入し、SaaS依存を低減しつつ高度なコードレビューを自動化しています。
-- 最新のフロントエンド（React 19, Bun等）やAI CI/CDのトレンドを要約し、チームの継続的な学習を促進するための AI Weekly Tech Trend Analyzer (`.github/workflows/ai-tech-trend-analyzer.yml`) プロトタイプを導入しています。**GitHub Models (o3-mini) の廃止に伴い、スケジュール実行（cron）は現在停止中です（Refs #539）。** 手動実行（`workflow_dispatch`）のみ可能です。
+- 本リポジトリでは無料・オープンソースのベストプラクティスに基づき、GitHub Models (gpt-4o-mini) を利用した自作の AI PR Reviewer を導入し、SaaS依存を低減しつつ高度なコードレビューを自動化しています。
+- 最新のフロントエンド（React 19, Bun等）やAI CI/CDのトレンドを要約し、チームの継続的な学習を促進するための AI Weekly Tech Trend Analyzer (`.github/workflows/ai-tech-trend-analyzer.yml`) プロトタイプを導入しています。**GitHub Models (o3-mini) の廃止に伴い、スケジュール実行（cron）は現在停止中でしたが、gpt-4o-mini への移行が完了しました。再開する場合は設定を確認してください。** 手動実行（`workflow_dispatch`）のみ可能です。
 
 - 最新のAIエージェント（GitHub Copilot Agent, GPT-5.5, Claude 3.7, DeepSeek-R1 連携等）を利用する際は、生成されたコードのセキュリティリスク（機密情報の出力やインジェクション脆弱性）をローカルで必ず検証し、自動レビューツールとの多層的なチェックを行ってください。
 
 - 新たなAIツールやサービスを導入する際は、公開リポジトリにおいて無料で利用可能であることを前提としてください。また、それらを設定するための手動の事前作業（Secretsへのトークン追加など）は必ずプルリクエストの説明に記載してください。
-- 開発進捗の要約や課題分析には、GitHub Models (o3-mini) と Tavily Search API を連携した自動プロジェクトマネジメントツール (`.github/workflows/ai-weekly-summary.yml`) を用意しています。利用にあたっては、リポジトリの Secrets に `GH_MODELS_TOKEN` と `TAVILY_API_KEY` の事前登録が必須です。**GitHub Models (o3-mini) の廃止によりスケジュール実行（cron）は現在停止中で、週次での自動生成は行われません（Refs #539）。** 再開する場合は代替モデルの選定が必要です。
+- 開発進捗の要約や課題分析には、GitHub Models (gpt-4o-mini) と Tavily Search API を連携した自動プロジェクトマネジメントツール (`.github/workflows/ai-weekly-summary.yml`) を用意しています。利用にあたっては、リポジトリの Secrets に `GH_MODELS_TOKEN` と `TAVILY_API_KEY` の事前登録が必須です。**GitHub Models (o3-mini) の廃止によりスケジュール実行（cron）は現在停止中でしたが、gpt-4o-mini への移行により再開の準備が整いました。**
 
 - `CLAUDE.md` は Claude Code 向けの設定ファイルとして自動生成されます。

--- a/.github/workflows/ai-a11y-reviewer.yml
+++ b/.github/workflows/ai-a11y-reviewer.yml
@@ -124,7 +124,7 @@ jobs:
                 const aiData = await aiRes.json();
                 analysis = aiData.choices?.[0]?.message?.content;
                 if (!analysis) {
-                  // content 空は推論トークンが max_completion_tokens を使い切ったサイン。
+                  // content 空は max_tokens を使い切った（finish_reason: 'length'）可能性のあるサイン。
                   core.warning(`GitHub Models から分析結果が返されませんでした。${JSON.stringify(aiData).slice(0, 500)}`);
                 }
               } else {

--- a/.github/workflows/ai-a11y-reviewer.yml
+++ b/.github/workflows/ai-a11y-reviewer.yml
@@ -114,10 +114,9 @@ jobs:
                   'Authorization': `Bearer ${process.env.GH_MODELS_TOKEN}`
                 },
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [{ role: 'user', content: prompt }],
-                  reasoning_effort: 'high',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
 

--- a/.github/workflows/ai-architecture-reviewer.yml
+++ b/.github/workflows/ai-architecture-reviewer.yml
@@ -117,10 +117,9 @@ jobs:
                   'Authorization': `Bearer ${process.env.GH_MODELS_TOKEN}`
                 },
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [{ role: 'user', content: prompt }],
-                  reasoning_effort: 'high',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
 

--- a/.github/workflows/ai-architecture-reviewer.yml
+++ b/.github/workflows/ai-architecture-reviewer.yml
@@ -127,7 +127,7 @@ jobs:
                 const aiData = await aiRes.json();
                 analysis = aiData.choices?.[0]?.message?.content;
                 if (!analysis) {
-                  // content 空は推論トークンが max_completion_tokens を使い切ったサイン。
+                  // content 空は max_tokens を使い切った（finish_reason: 'length'）可能性のあるサイン。
                   core.warning(`GitHub Models から分析結果が返されませんでした。${JSON.stringify(aiData).slice(0, 500)}`);
                 }
               } else {

--- a/.github/workflows/ai-ci-analyzer.yml
+++ b/.github/workflows/ai-ci-analyzer.yml
@@ -136,10 +136,9 @@ jobs:
                 },
                 signal: AbortSignal.timeout(120000),
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [{ role: 'user', content: prompt }],
-                  reasoning_effort: 'high',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
             } catch (e) {

--- a/.github/workflows/ai-code-optimizer.yml
+++ b/.github/workflows/ai-code-optimizer.yml
@@ -97,10 +97,9 @@ jobs:
                 },
                 signal: AbortSignal.timeout(120000),
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [{ role: 'user', content: prompt }],
-                  reasoning_effort: 'high',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
             } catch (e) {

--- a/.github/workflows/ai-code-optimizer.yml
+++ b/.github/workflows/ai-code-optimizer.yml
@@ -122,7 +122,7 @@ jobs:
             }
             const report = aiData.choices?.[0]?.message?.content;
             if (!report) {
-              // content 空は推論トークンが max_completion_tokens を使い切ったサイン。
+              // content 空は max_tokens を使い切った（finish_reason: 'length'）可能性のあるサイン。
               core.warning(`GitHub Models から分析結果が返されませんでした。${JSON.stringify(aiData).slice(0, 500)}`);
               return;
             }

--- a/.github/workflows/ai-dependency-research.yml
+++ b/.github/workflows/ai-dependency-research.yml
@@ -164,10 +164,9 @@ jobs:
                 },
                 signal: AbortSignal.timeout(120000),
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [{ role: 'user', content: prompt }],
-                  reasoning_effort: 'high',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
             } catch (e) {

--- a/.github/workflows/ai-dependency-review.yml
+++ b/.github/workflows/ai-dependency-review.yml
@@ -83,10 +83,9 @@ jobs:
                 },
                 signal: AbortSignal.timeout(120000),
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [{ role: 'user', content: prompt }],
-                  reasoning_effort: 'high',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
             } catch (e) {

--- a/.github/workflows/ai-doc-generator.yml
+++ b/.github/workflows/ai-doc-generator.yml
@@ -109,10 +109,9 @@ jobs:
                   'Authorization': `Bearer ${process.env.GH_MODELS_TOKEN}`
                 },
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [{ role: 'user', content: prompt }],
-                  reasoning_effort: 'high',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
 

--- a/.github/workflows/ai-doc-sync-checker.yml
+++ b/.github/workflows/ai-doc-sync-checker.yml
@@ -124,7 +124,7 @@ jobs:
                 },
                 signal: AbortSignal.timeout(120000),
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [
                     { role: 'developer', content: systemPolicy },
                     { role: 'user', content: externalInput }
@@ -132,8 +132,7 @@ jobs:
                   // o系列モデルの max_completion_tokens は推論トークンと可視出力トークンの合算上限。
                   // 'high' だと推論だけで予算を使い切り、可視出力が空 (finish_reason: 'length') になる恐れがあるため
                   // まずは 'medium' を既定とし、品質とトークン消費を見ながら調整する。
-                  reasoning_effort: 'medium',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
             } catch (error) {

--- a/.github/workflows/ai-doc-sync-checker.yml
+++ b/.github/workflows/ai-doc-sync-checker.yml
@@ -129,9 +129,7 @@ jobs:
                     { role: 'developer', content: systemPolicy },
                     { role: 'user', content: externalInput }
                   ],
-                  // o系列モデルの max_completion_tokens は推論トークンと可視出力トークンの合算上限。
-                  // 'high' だと推論だけで予算を使い切り、可視出力が空 (finish_reason: 'length') になる恐れがあるため
-                  // まずは 'medium' を既定とし、品質とトークン消費を見ながら調整する。
+                  // max_tokens は可視出力トークンの上限。品質とトークン消費を見ながら調整する。
                   max_tokens: 15000
                 })
               });
@@ -158,9 +156,9 @@ jobs:
             const analysis = choice?.message?.content;
 
             if (!analysis || analysis.trim().length === 0) {
-              // content 空は推論トークンが max_completion_tokens を使い切ったサイン。
+              // content 空は max_tokens を使い切ったサイン。
               // 無言スキップを避けて finish_reason をログに残す。
-              core.warning(`AI 分析の応答が空でした (finish_reason: ${choice?.finish_reason ?? 'unknown'})。推論トークンが max_completion_tokens を使い切った可能性があります。`);
+              core.warning(`AI 分析の応答が空でした (finish_reason: ${choice?.finish_reason ?? 'unknown'})。max_tokens を使い切った可能性があります。`);
               return;
             }
 

--- a/.github/workflows/ai-issue-autofix.yml
+++ b/.github/workflows/ai-issue-autofix.yml
@@ -105,10 +105,9 @@ jobs:
                 },
                 signal: AbortSignal.timeout(120000),
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [{ role: 'user', content: prompt }],
-                  reasoning_effort: 'high',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
             } catch (e) {

--- a/.github/workflows/ai-issue-plan.yml
+++ b/.github/workflows/ai-issue-plan.yml
@@ -94,13 +94,12 @@ jobs:
                 },
                 signal: AbortSignal.timeout(120000),
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [
                     { role: 'system', content: systemPolicy },
                     { role: 'user', content: externalInput }
                   ],
-                  reasoning_effort: 'high',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
 

--- a/.github/workflows/ai-issue-research.yml
+++ b/.github/workflows/ai-issue-research.yml
@@ -85,10 +85,9 @@ jobs:
                 },
                 signal: AbortSignal.timeout(120000),
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [{ role: 'user', content: prompt }],
-                  reasoning_effort: 'high',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
 

--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -79,10 +79,9 @@ jobs:
                 },
                 signal: AbortSignal.timeout(120000),
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [{ role: 'user', content: prompt }],
-                  reasoning_effort: 'high',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
 

--- a/.github/workflows/ai-pr-description.yml
+++ b/.github/workflows/ai-pr-description.yml
@@ -84,13 +84,12 @@ jobs:
                   'Authorization': `Bearer ${process.env.GH_MODELS_TOKEN}`
                 },
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [
                     { role: 'developer', content: systemPolicy },
                     { role: 'user', content: externalInput }
                   ],
-                  reasoning_effort: 'medium',
-                  max_completion_tokens: 5000
+                  max_tokens: 5000
                 })
               });
             } catch (error) {

--- a/.github/workflows/ai-pr-reviewer.yml
+++ b/.github/workflows/ai-pr-reviewer.yml
@@ -125,7 +125,7 @@ jobs:
                 },
                 signal: AbortSignal.timeout(120000),
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [
                     { role: 'developer', content: systemPolicy },
                     { role: 'user', content: externalInput }
@@ -133,8 +133,7 @@ jobs:
                   // o系列モデルの max_completion_tokens は推論トークンと可視出力トークンの合算上限。
                   // 'high' だと推論だけで予算を使い切り、可視出力が空 (finish_reason: 'length') になる恐れがあるため
                   // まずは 'medium' を既定とし、品質とトークン消費を見ながら調整する。
-                  reasoning_effort: 'medium',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
             } catch (e) {

--- a/.github/workflows/ai-security-analyzer.yml
+++ b/.github/workflows/ai-security-analyzer.yml
@@ -121,7 +121,7 @@ jobs:
                 },
                 signal: AbortSignal.timeout(120000),
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [
                     { role: 'developer', content: systemPolicy },
                     { role: 'user', content: externalInput }
@@ -129,8 +129,7 @@ jobs:
                   // o系列モデルの max_completion_tokens は推論トークンと可視出力トークンの合算上限。
                   // 'high' だと推論だけで予算を使い切り、可視出力が空 (finish_reason: 'length') になる恐れがあるため
                   // まずは 'medium' を既定とし、品質とトークン消費を見ながら調整する。
-                  reasoning_effort: 'medium',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
             } catch (e) {

--- a/.github/workflows/ai-tech-news-digest.yml
+++ b/.github/workflows/ai-tech-news-digest.yml
@@ -81,10 +81,9 @@ jobs:
                 },
                 signal: AbortSignal.timeout(120000),
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [{ role: 'user', content: prompt }],
-                  reasoning_effort: 'high',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
 

--- a/.github/workflows/ai-tech-trend-analyzer.yml
+++ b/.github/workflows/ai-tech-trend-analyzer.yml
@@ -104,10 +104,9 @@ jobs:
                 },
                 signal: AbortSignal.timeout(120000),
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [{ role: 'user', content: prompt }],
-                  reasoning_effort: 'high',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
 

--- a/.github/workflows/ai-test-automation.yml
+++ b/.github/workflows/ai-test-automation.yml
@@ -104,7 +104,7 @@ jobs:
                 },
                 signal: AbortSignal.timeout(120000),
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [
                     { role: 'developer', content: systemPolicy },
                     { role: 'user', content: externalInput }
@@ -112,8 +112,7 @@ jobs:
                   // o系列モデルの max_completion_tokens は推論トークンと可視出力トークンの合算上限。
                   // 'high' だと推論だけで予算を使い切り、可視出力が空 (finish_reason: 'length') になる恐れがあるため
                   // まずは 'medium' を既定とし、品質とトークン消費を見ながら調整する。
-                  reasoning_effort: 'medium',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
             } catch (e) {

--- a/.github/workflows/ai-test-generator.yml
+++ b/.github/workflows/ai-test-generator.yml
@@ -72,10 +72,9 @@ jobs:
                 },
                 signal: AbortSignal.timeout(120000),
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [{ role: 'user', content: prompt }],
-                  reasoning_effort: 'high',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
 

--- a/.github/workflows/ai-tool-evaluator.yml
+++ b/.github/workflows/ai-tool-evaluator.yml
@@ -93,10 +93,9 @@ jobs:
                 },
                 signal: AbortSignal.timeout(120000),
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [{ role: 'user', content: prompt }],
-                  reasoning_effort: 'high',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
             } catch (e) {

--- a/.github/workflows/ai-tool-evaluator.yml
+++ b/.github/workflows/ai-tool-evaluator.yml
@@ -118,7 +118,7 @@ jobs:
             }
             const evaluation = aiData.choices?.[0]?.message?.content;
             if (!evaluation) {
-              // content 空は推論トークンが max_completion_tokens を使い切ったサイン。
+              // content 空は max_tokens を使い切った（finish_reason: 'length'）可能性のあるサイン。
               core.warning(`GitHub Models から分析結果が返されませんでした。${JSON.stringify(aiData).slice(0, 500)}`);
               return;
             }

--- a/.github/workflows/ai-weekly-summary.yml
+++ b/.github/workflows/ai-weekly-summary.yml
@@ -130,10 +130,9 @@ jobs:
                 },
                 signal: AbortSignal.timeout(120000),
                 body: JSON.stringify({
-                  model: 'openai/o3-mini',
+                  model: 'gpt-4o-mini',
                   messages: [{ role: 'user', content: prompt }],
-                  reasoning_effort: 'high',
-                  max_completion_tokens: 15000
+                  max_tokens: 15000
                 })
               });
 

--- a/.roorules
+++ b/.roorules
@@ -44,12 +44,12 @@
 - Claude Code や OpenCode といった最新のAIコーディングツールを活用する際は、意図しない破壊的変更を避けるため、プレビュー機能を活用して差分を確認しながら適用してください。
 
 - ローカルAIエージェントやAI-native IDE（Windsurf, Trae, Aider, Cline, Roo Code, Continue.devなど）を利用する際は、リポジトリ固有のルールを遵守し、作業ディレクトリ（`.aider*`、`.continue/`、`.windsurf`、`.roo/`、`.trae/` など）をコミットしないように注意してください。
-- 本リポジトリでは無料・オープンソースのベストプラクティスに基づき、GitHub Models (o3-mini) を利用した自作の AI PR Reviewer を導入し、SaaS依存を低減しつつ高度なコードレビューを自動化しています。
-- 最新のフロントエンド（React 19, Bun等）やAI CI/CDのトレンドを要約し、チームの継続的な学習を促進するための AI Weekly Tech Trend Analyzer (`.github/workflows/ai-tech-trend-analyzer.yml`) プロトタイプを導入しています。**GitHub Models (o3-mini) の廃止に伴い、スケジュール実行（cron）は現在停止中です（Refs #539）。** 手動実行（`workflow_dispatch`）のみ可能です。
+- 本リポジトリでは無料・オープンソースのベストプラクティスに基づき、GitHub Models (gpt-4o-mini) を利用した自作の AI PR Reviewer を導入し、SaaS依存を低減しつつ高度なコードレビューを自動化しています。
+- 最新のフロントエンド（React 19, Bun等）やAI CI/CDのトレンドを要約し、チームの継続的な学習を促進するための AI Weekly Tech Trend Analyzer (`.github/workflows/ai-tech-trend-analyzer.yml`) プロトタイプを導入しています。**GitHub Models (o3-mini) の廃止に伴い、スケジュール実行（cron）は現在停止中でしたが、gpt-4o-mini への移行が完了しました。再開する場合は設定を確認してください。** 手動実行（`workflow_dispatch`）のみ可能です。
 
 - 最新のAIエージェント（GitHub Copilot Agent, GPT-5.5, Claude 3.7, DeepSeek-R1 連携等）を利用する際は、生成されたコードのセキュリティリスク（機密情報の出力やインジェクション脆弱性）をローカルで必ず検証し、自動レビューツールとの多層的なチェックを行ってください。
 
 - 新たなAIツールやサービスを導入する際は、公開リポジトリにおいて無料で利用可能であることを前提としてください。また、それらを設定するための手動の事前作業（Secretsへのトークン追加など）は必ずプルリクエストの説明に記載してください。
-- 開発進捗の要約や課題分析には、GitHub Models (o3-mini) と Tavily Search API を連携した自動プロジェクトマネジメントツール (`.github/workflows/ai-weekly-summary.yml`) を用意しています。利用にあたっては、リポジトリの Secrets に `GH_MODELS_TOKEN` と `TAVILY_API_KEY` の事前登録が必須です。**GitHub Models (o3-mini) の廃止によりスケジュール実行（cron）は現在停止中で、週次での自動生成は行われません（Refs #539）。** 再開する場合は代替モデルの選定が必要です。
+- 開発進捗の要約や課題分析には、GitHub Models (gpt-4o-mini) と Tavily Search API を連携した自動プロジェクトマネジメントツール (`.github/workflows/ai-weekly-summary.yml`) を用意しています。利用にあたっては、リポジトリの Secrets に `GH_MODELS_TOKEN` と `TAVILY_API_KEY` の事前登録が必須です。**GitHub Models (o3-mini) の廃止によりスケジュール実行（cron）は現在停止中でしたが、gpt-4o-mini への移行により再開の準備が整いました。**
 
 - `CLAUDE.md` は Claude Code 向けの設定ファイルとして自動生成されます。

--- a/.traerules
+++ b/.traerules
@@ -44,12 +44,12 @@
 - Claude Code や OpenCode といった最新のAIコーディングツールを活用する際は、意図しない破壊的変更を避けるため、プレビュー機能を活用して差分を確認しながら適用してください。
 
 - ローカルAIエージェントやAI-native IDE（Windsurf, Trae, Aider, Cline, Roo Code, Continue.devなど）を利用する際は、リポジトリ固有のルールを遵守し、作業ディレクトリ（`.aider*`、`.continue/`、`.windsurf`、`.roo/`、`.trae/` など）をコミットしないように注意してください。
-- 本リポジトリでは無料・オープンソースのベストプラクティスに基づき、GitHub Models (o3-mini) を利用した自作の AI PR Reviewer を導入し、SaaS依存を低減しつつ高度なコードレビューを自動化しています。
-- 最新のフロントエンド（React 19, Bun等）やAI CI/CDのトレンドを要約し、チームの継続的な学習を促進するための AI Weekly Tech Trend Analyzer (`.github/workflows/ai-tech-trend-analyzer.yml`) プロトタイプを導入しています。**GitHub Models (o3-mini) の廃止に伴い、スケジュール実行（cron）は現在停止中です（Refs #539）。** 手動実行（`workflow_dispatch`）のみ可能です。
+- 本リポジトリでは無料・オープンソースのベストプラクティスに基づき、GitHub Models (gpt-4o-mini) を利用した自作の AI PR Reviewer を導入し、SaaS依存を低減しつつ高度なコードレビューを自動化しています。
+- 最新のフロントエンド（React 19, Bun等）やAI CI/CDのトレンドを要約し、チームの継続的な学習を促進するための AI Weekly Tech Trend Analyzer (`.github/workflows/ai-tech-trend-analyzer.yml`) プロトタイプを導入しています。**GitHub Models (o3-mini) の廃止に伴い、スケジュール実行（cron）は現在停止中でしたが、gpt-4o-mini への移行が完了しました。再開する場合は設定を確認してください。** 手動実行（`workflow_dispatch`）のみ可能です。
 
 - 最新のAIエージェント（GitHub Copilot Agent, GPT-5.5, Claude 3.7, DeepSeek-R1 連携等）を利用する際は、生成されたコードのセキュリティリスク（機密情報の出力やインジェクション脆弱性）をローカルで必ず検証し、自動レビューツールとの多層的なチェックを行ってください。
 
 - 新たなAIツールやサービスを導入する際は、公開リポジトリにおいて無料で利用可能であることを前提としてください。また、それらを設定するための手動の事前作業（Secretsへのトークン追加など）は必ずプルリクエストの説明に記載してください。
-- 開発進捗の要約や課題分析には、GitHub Models (o3-mini) と Tavily Search API を連携した自動プロジェクトマネジメントツール (`.github/workflows/ai-weekly-summary.yml`) を用意しています。利用にあたっては、リポジトリの Secrets に `GH_MODELS_TOKEN` と `TAVILY_API_KEY` の事前登録が必須です。**GitHub Models (o3-mini) の廃止によりスケジュール実行（cron）は現在停止中で、週次での自動生成は行われません（Refs #539）。** 再開する場合は代替モデルの選定が必要です。
+- 開発進捗の要約や課題分析には、GitHub Models (gpt-4o-mini) と Tavily Search API を連携した自動プロジェクトマネジメントツール (`.github/workflows/ai-weekly-summary.yml`) を用意しています。利用にあたっては、リポジトリの Secrets に `GH_MODELS_TOKEN` と `TAVILY_API_KEY` の事前登録が必須です。**GitHub Models (o3-mini) の廃止によりスケジュール実行（cron）は現在停止中でしたが、gpt-4o-mini への移行により再開の準備が整いました。**
 
 - `CLAUDE.md` は Claude Code 向けの設定ファイルとして自動生成されます。

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -44,12 +44,12 @@
 - Claude Code や OpenCode といった最新のAIコーディングツールを活用する際は、意図しない破壊的変更を避けるため、プレビュー機能を活用して差分を確認しながら適用してください。
 
 - ローカルAIエージェントやAI-native IDE（Windsurf, Trae, Aider, Cline, Roo Code, Continue.devなど）を利用する際は、リポジトリ固有のルールを遵守し、作業ディレクトリ（`.aider*`、`.continue/`、`.windsurf`、`.roo/`、`.trae/` など）をコミットしないように注意してください。
-- 本リポジトリでは無料・オープンソースのベストプラクティスに基づき、GitHub Models (o3-mini) を利用した自作の AI PR Reviewer を導入し、SaaS依存を低減しつつ高度なコードレビューを自動化しています。
-- 最新のフロントエンド（React 19, Bun等）やAI CI/CDのトレンドを要約し、チームの継続的な学習を促進するための AI Weekly Tech Trend Analyzer (`.github/workflows/ai-tech-trend-analyzer.yml`) プロトタイプを導入しています。**GitHub Models (o3-mini) の廃止に伴い、スケジュール実行（cron）は現在停止中です（Refs #539）。** 手動実行（`workflow_dispatch`）のみ可能です。
+- 本リポジトリでは無料・オープンソースのベストプラクティスに基づき、GitHub Models (gpt-4o-mini) を利用した自作の AI PR Reviewer を導入し、SaaS依存を低減しつつ高度なコードレビューを自動化しています。
+- 最新のフロントエンド（React 19, Bun等）やAI CI/CDのトレンドを要約し、チームの継続的な学習を促進するための AI Weekly Tech Trend Analyzer (`.github/workflows/ai-tech-trend-analyzer.yml`) プロトタイプを導入しています。**GitHub Models (o3-mini) の廃止に伴い、スケジュール実行（cron）は現在停止中でしたが、gpt-4o-mini への移行が完了しました。再開する場合は設定を確認してください。** 手動実行（`workflow_dispatch`）のみ可能です。
 
 - 最新のAIエージェント（GitHub Copilot Agent, GPT-5.5, Claude 3.7, DeepSeek-R1 連携等）を利用する際は、生成されたコードのセキュリティリスク（機密情報の出力やインジェクション脆弱性）をローカルで必ず検証し、自動レビューツールとの多層的なチェックを行ってください。
 
 - 新たなAIツールやサービスを導入する際は、公開リポジトリにおいて無料で利用可能であることを前提としてください。また、それらを設定するための手動の事前作業（Secretsへのトークン追加など）は必ずプルリクエストの説明に記載してください。
-- 開発進捗の要約や課題分析には、GitHub Models (o3-mini) と Tavily Search API を連携した自動プロジェクトマネジメントツール (`.github/workflows/ai-weekly-summary.yml`) を用意しています。利用にあたっては、リポジトリの Secrets に `GH_MODELS_TOKEN` と `TAVILY_API_KEY` の事前登録が必須です。**GitHub Models (o3-mini) の廃止によりスケジュール実行（cron）は現在停止中で、週次での自動生成は行われません（Refs #539）。** 再開する場合は代替モデルの選定が必要です。
+- 開発進捗の要約や課題分析には、GitHub Models (gpt-4o-mini) と Tavily Search API を連携した自動プロジェクトマネジメントツール (`.github/workflows/ai-weekly-summary.yml`) を用意しています。利用にあたっては、リポジトリの Secrets に `GH_MODELS_TOKEN` と `TAVILY_API_KEY` の事前登録が必須です。**GitHub Models (o3-mini) の廃止によりスケジュール実行（cron）は現在停止中でしたが、gpt-4o-mini への移行により再開の準備が整いました。**
 
 - `CLAUDE.md` は Claude Code 向けの設定ファイルとして自動生成されます。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,12 +44,12 @@
 - Claude Code や OpenCode といった最新のAIコーディングツールを活用する際は、意図しない破壊的変更を避けるため、プレビュー機能を活用して差分を確認しながら適用してください。
 
 - ローカルAIエージェントやAI-native IDE（Windsurf, Trae, Aider, Cline, Roo Code, Continue.devなど）を利用する際は、リポジトリ固有のルールを遵守し、作業ディレクトリ（`.aider*`、`.continue/`、`.windsurf`、`.roo/`、`.trae/` など）をコミットしないように注意してください。
-- 本リポジトリでは無料・オープンソースのベストプラクティスに基づき、GitHub Models (o3-mini) を利用した自作の AI PR Reviewer を導入し、SaaS依存を低減しつつ高度なコードレビューを自動化しています。
-- 最新のフロントエンド（React 19, Bun等）やAI CI/CDのトレンドを要約し、チームの継続的な学習を促進するための AI Weekly Tech Trend Analyzer (`.github/workflows/ai-tech-trend-analyzer.yml`) プロトタイプを導入しています。**GitHub Models (o3-mini) の廃止に伴い、スケジュール実行（cron）は現在停止中です（Refs #539）。** 手動実行（`workflow_dispatch`）のみ可能です。
+- 本リポジトリでは無料・オープンソースのベストプラクティスに基づき、GitHub Models (gpt-4o-mini) を利用した自作の AI PR Reviewer を導入し、SaaS依存を低減しつつ高度なコードレビューを自動化しています。
+- 最新のフロントエンド（React 19, Bun等）やAI CI/CDのトレンドを要約し、チームの継続的な学習を促進するための AI Weekly Tech Trend Analyzer (`.github/workflows/ai-tech-trend-analyzer.yml`) プロトタイプを導入しています。**GitHub Models (o3-mini) の廃止に伴い、スケジュール実行（cron）は現在停止中でしたが、gpt-4o-mini への移行が完了しました。再開する場合は設定を確認してください。** 手動実行（`workflow_dispatch`）のみ可能です。
 
 - 最新のAIエージェント（GitHub Copilot Agent, GPT-5.5, Claude 3.7, DeepSeek-R1 連携等）を利用する際は、生成されたコードのセキュリティリスク（機密情報の出力やインジェクション脆弱性）をローカルで必ず検証し、自動レビューツールとの多層的なチェックを行ってください。
 
 - 新たなAIツールやサービスを導入する際は、公開リポジトリにおいて無料で利用可能であることを前提としてください。また、それらを設定するための手動の事前作業（Secretsへのトークン追加など）は必ずプルリクエストの説明に記載してください。
-- 開発進捗の要約や課題分析には、GitHub Models (o3-mini) と Tavily Search API を連携した自動プロジェクトマネジメントツール (`.github/workflows/ai-weekly-summary.yml`) を用意しています。利用にあたっては、リポジトリの Secrets に `GH_MODELS_TOKEN` と `TAVILY_API_KEY` の事前登録が必須です。**GitHub Models (o3-mini) の廃止によりスケジュール実行（cron）は現在停止中で、週次での自動生成は行われません（Refs #539）。** 再開する場合は代替モデルの選定が必要です。
+- 開発進捗の要約や課題分析には、GitHub Models (gpt-4o-mini) と Tavily Search API を連携した自動プロジェクトマネジメントツール (`.github/workflows/ai-weekly-summary.yml`) を用意しています。利用にあたっては、リポジトリの Secrets に `GH_MODELS_TOKEN` と `TAVILY_API_KEY` の事前登録が必須です。**GitHub Models (o3-mini) の廃止によりスケジュール実行（cron）は現在停止中でしたが、gpt-4o-mini への移行により再開の準備が整いました。**
 
 - `CLAUDE.md` は Claude Code 向けの設定ファイルとして自動生成されます。

--- a/docs/ai-guidelines.md
+++ b/docs/ai-guidelines.md
@@ -37,12 +37,12 @@
 - Claude Code や OpenCode といった最新のAIコーディングツールを活用する際は、意図しない破壊的変更を避けるため、プレビュー機能を活用して差分を確認しながら適用してください。
 
 - ローカルAIエージェントやAI-native IDE（Windsurf, Trae, Aider, Cline, Roo Code, Continue.devなど）を利用する際は、リポジトリ固有のルールを遵守し、作業ディレクトリ（`.aider*`、`.continue/`、`.windsurf`、`.roo/`、`.trae/` など）をコミットしないように注意してください。
-- 本リポジトリでは無料・オープンソースのベストプラクティスに基づき、GitHub Models (o3-mini) を利用した自作の AI PR Reviewer を導入し、SaaS依存を低減しつつ高度なコードレビューを自動化しています。
-- 最新のフロントエンド（React 19, Bun等）やAI CI/CDのトレンドを要約し、チームの継続的な学習を促進するための AI Weekly Tech Trend Analyzer (`.github/workflows/ai-tech-trend-analyzer.yml`) プロトタイプを導入しています。**GitHub Models (o3-mini) の廃止に伴い、スケジュール実行（cron）は現在停止中です（Refs #539）。** 手動実行（`workflow_dispatch`）のみ可能です。
+- 本リポジトリでは無料・オープンソースのベストプラクティスに基づき、GitHub Models (gpt-4o-mini) を利用した自作の AI PR Reviewer を導入し、SaaS依存を低減しつつ高度なコードレビューを自動化しています。
+- 最新のフロントエンド（React 19, Bun等）やAI CI/CDのトレンドを要約し、チームの継続的な学習を促進するための AI Weekly Tech Trend Analyzer (`.github/workflows/ai-tech-trend-analyzer.yml`) プロトタイプを導入しています。**GitHub Models (o3-mini) の廃止に伴い、スケジュール実行（cron）は現在停止中でしたが、gpt-4o-mini への移行が完了しました。再開する場合は設定を確認してください。** 手動実行（`workflow_dispatch`）のみ可能です。
 
 - 最新のAIエージェント（GitHub Copilot Agent, GPT-5.5, Claude 3.7, DeepSeek-R1 連携等）を利用する際は、生成されたコードのセキュリティリスク（機密情報の出力やインジェクション脆弱性）をローカルで必ず検証し、自動レビューツールとの多層的なチェックを行ってください。
 
 - 新たなAIツールやサービスを導入する際は、公開リポジトリにおいて無料で利用可能であることを前提としてください。また、それらを設定するための手動の事前作業（Secretsへのトークン追加など）は必ずプルリクエストの説明に記載してください。
-- 開発進捗の要約や課題分析には、GitHub Models (o3-mini) と Tavily Search API を連携した自動プロジェクトマネジメントツール (`.github/workflows/ai-weekly-summary.yml`) を用意しています。利用にあたっては、リポジトリの Secrets に `GH_MODELS_TOKEN` と `TAVILY_API_KEY` の事前登録が必須です。**GitHub Models (o3-mini) の廃止によりスケジュール実行（cron）は現在停止中で、週次での自動生成は行われません（Refs #539）。** 再開する場合は代替モデルの選定が必要です。
+- 開発進捗の要約や課題分析には、GitHub Models (gpt-4o-mini) と Tavily Search API を連携した自動プロジェクトマネジメントツール (`.github/workflows/ai-weekly-summary.yml`) を用意しています。利用にあたっては、リポジトリの Secrets に `GH_MODELS_TOKEN` と `TAVILY_API_KEY` の事前登録が必須です。**GitHub Models (o3-mini) の廃止によりスケジュール実行（cron）は現在停止中でしたが、gpt-4o-mini への移行により再開の準備が整いました。**
 
 - `CLAUDE.md` は Claude Code 向けの設定ファイルとして自動生成されます。


### PR DESCRIPTION
Title: chore(ai): 🤖 AIツール設定の最適化 (GitHub Models gpt-4o-mini への移行)

## 概要

### 💡 What
GitHub Actions の AI ワークフローにて使用されている GitHub Models API 呼び出しにおけるモデル指定を `o3-mini` から `gpt-4o-mini` に移行し、あわせて不要な `reasoning_effort` パラメータの削除、及び `max_completion_tokens` から `max_tokens` への変更を行いました。さらにマスタとなる `docs/ai-guidelines.md` と関連する AI エージェントの設定ファイルを同期しました。

### 🎯 Why
GitHub Models (o3-mini) は retirement brownout に入るか、あるいは推論コスト/安定性の観点で CI/CD パイプラインにおける自動化のボトルネックになる可能性があるため、無料で利用可能かつより安定して高速に動作する `gpt-4o-mini` へと移行し、AI 活用自動化の最適化を図るためです。

### 📸 Before/After
- **Before:** 各種 AI ワークフローが `o3-mini` を指定し、`reasoning_effort` や `max_completion_tokens` を用いて GitHub Models API へリクエストを送信。
- **After:** 各種 AI ワークフローが `gpt-4o-mini` を指定し、仕様に沿うよう不要な `reasoning_effort` を削除、`max_tokens` へ変更。

### ♿️ Accessibility
N/A

## 関連 Issue / 設計ドキュメント
- プロジェクト要件および生成 AI 最適化のプロトタイプ推進に基づく。

## 動作確認
- 変更したワークフローファイルに YAML シンタックスエラーが無いことを確認。
- `bun run sync:ai-guidelines` により各 AI アシスタント用設定ファイルがマスタの `docs/ai-guidelines.md` の記述と一致していることを確認。

## セルフチェック
- [x] パッケージインストール (`bun install`) 実行確認
- [x] Linter / Formatter の通過確認
- [x] `bun run test` の通過確認

### マージ前に必要な手動作業（チェックリスト）
- 事前作業: なし (既存の `GH_MODELS_TOKEN` をそのまま利用します)

---
*PR created automatically by Jules for task [579149242574433363](https://jules.google.com/task/579149242574433363) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * AI関連の自動レビュー、分析、要約などで使用するモデルを `gpt-4o-mini` に更新しました。
  * モデル移行に伴い、停止していた定期実行の再開準備が整いました。

* **ドキュメント**
  * AIツールの利用モデルと稼働状況に関する説明を最新化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->