### PR TITLE
🎨 Palette: [PlayerPanel] 刑務所バッジのツールチップ対応を改善

### DIFF
--- a/src/components/PlayerPanel/PlayerPanel.tsx
+++ b/src/components/PlayerPanel/PlayerPanel.tsx
@@ -117,7 +117,11 @@ const MemoizedPlayerChip = memo(function MemoizedPlayerChip({
           </span>
         )}
         {player.inJail && (
-          <span className={styles.jailBadge} aria-hidden="true">
+          <span
+            className={styles.jailBadge}
+            aria-hidden="true"
+            title={isDisabled ? undefined : '刑務所に入っています'}
+          >
             🔒
           </span>
         )}


### PR DESCRIPTION
## 概要
### 💡 What
`PlayerPanel` 内の「刑務所に入っている」ことを示すアイコン（🔒）を含む `span` 要素に、マウスユーザー向けのツールチップ表示（`title={isDisabled ? undefined : '刑務所に入っています'}`）を追加しました。

### 🎯 Why
元のコードでは、親のボタン要素の `aria-label` にてスクリーンリーダーへの対応（「刑務所に入っています」の読み上げ）は行われていましたが、バッジ自体にはテキスト情報が視覚的に表示されていなかったため、マウスユーザーがアイコンの意味を理解しづらい可能性がありました。
他のバッジ（信用スコア、ローン残高など）と同様の挙動になるように `title` 属性を追加することで、マウスユーザーに対してホバーでツールチップが表示され、情報を容易に確認できるようになりました。

### 📸 Before/After
（視覚的なデザインの変更はありません。刑務所アイコンにホバーした際に「刑務所に入っています」というツールチップが表示されるようになりました）

### ♿️ Accessibility
- 刑務所アイコンの `span` 要素に `title` 属性を追加し、状態を視覚的なテキストでも認識・確認できるようにしました（スクリーンリーダー対応は既存のボタンの `aria-label` で既にカバーされています）。
- 他のプレイヤーの操作中（`isDisabled` が true の時）は不要な情報読み上げや表示を防ぐため `undefined` を設定し、全体の動作一貫性を担保しました。

## 動作確認
- `bun run test` により既存テストのパスを確認。
- `bun run format`, `bun run lint`, `bun run typecheck` を通過。

## セルフチェック
- [x] 50行以内の小規模なUX/アクセシビリティ改善である
- [x] `.jules/palette.md` にCRITICALな学習内容を追記した
- [x] コマンドによるフォーマット・リント・テストが成功している

---
*PR created automatically by Jules for task [13843809703653409678](https://jules.google.com/task/13843809703653409678) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 刑務所バッジにカーソルを合わせると、対象者が刑務所に入っていることを示すツールチップが表示されるようになりました。
  * 無効状態のバッジではツールチップは表示されません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->