### PR TITLE
🎨 Palette: Add explicit labels to loan dialog inputs

### DIFF
--- a/src/components/ActionDialog/LoanDialog.tsx
+++ b/src/components/ActionDialog/LoanDialog.tsx
@@ -50,6 +50,8 @@ export default function LoanDialog({
 }: LoanDialogProps) {
   const borrowHintId = useId();
   const repayHintId = useId();
+  const borrowInputId = useId();
+  const repayInputId = useId();
   const [loanType, setLoanType] = useState<LoanType>('variable');
   const [borrowAmount, setBorrowAmount] = useState('');
   const [repayAmount, setRepayAmount] = useState('');
@@ -136,7 +138,7 @@ export default function LoanDialog({
         {maxBorrow > 0 && (
           <div className={styles.buildItem} style={{ marginTop: 12 }}>
             <div className={styles.buildItemContent}>
-              <label htmlFor="borrowInput" className={styles.buildItemName}>
+              <label htmlFor={borrowInputId} className={styles.buildItemName}>
                 💰 借りる
               </label>
               <div className={styles.buildItemInfo}>
@@ -163,7 +165,7 @@ export default function LoanDialog({
               </div>
               <div className={styles.buildItemActions}>
                 <input
-                  id="borrowInput"
+                  id={borrowInputId}
                   type="number"
                   min={1}
                   max={maxBorrow}
@@ -219,12 +221,12 @@ export default function LoanDialog({
         {loanBalance > 0 && (
           <div className={styles.buildItem} style={{ marginTop: 12 }}>
             <div className={styles.buildItemContent}>
-              <label htmlFor="repayInput" className={styles.buildItemName}>
+              <label htmlFor={repayInputId} className={styles.buildItemName}>
                 💳 返済する
               </label>
               <div className={styles.buildItemActions}>
                 <input
-                  id="repayInput"
+                  id={repayInputId}
                   type="number"
                   min={1}
                   max={Math.min(loanBalance, currentPlayer.money)}

--- a/src/components/ActionDialog/LoanDialog.tsx
+++ b/src/components/ActionDialog/LoanDialog.tsx
@@ -179,7 +179,6 @@ export default function LoanDialog({
                   }}
                   placeholder={`最大 ${maxBorrow}`}
                   style={{ width: 120 }}
-                  aria-label="借入金額"
                   aria-invalid={!canBorrow && borrowAmount !== ''}
                   aria-errormessage={
                     !canBorrow && borrowAmount !== '' ? borrowHintId : undefined
@@ -240,7 +239,6 @@ export default function LoanDialog({
                   }}
                   placeholder={`残高 ${loanBalance}`}
                   style={{ width: 120 }}
-                  aria-label="返済金額"
                   aria-invalid={!canRepay && repayAmount !== ''}
                   aria-errormessage={
                     !canRepay && repayAmount !== '' ? repayHintId : undefined

--- a/src/components/ActionDialog/LoanDialog.tsx
+++ b/src/components/ActionDialog/LoanDialog.tsx
@@ -136,7 +136,9 @@ export default function LoanDialog({
         {maxBorrow > 0 && (
           <div className={styles.buildItem} style={{ marginTop: 12 }}>
             <div className={styles.buildItemContent}>
-              <div className={styles.buildItemName}>💰 借りる</div>
+              <label htmlFor="borrowInput" className={styles.buildItemName}>
+                💰 借りる
+              </label>
               <div className={styles.buildItemInfo}>
                 <label>
                   金利タイプ:&nbsp;
@@ -161,6 +163,7 @@ export default function LoanDialog({
               </div>
               <div className={styles.buildItemActions}>
                 <input
+                  id="borrowInput"
                   type="number"
                   min={1}
                   max={maxBorrow}
@@ -216,9 +219,12 @@ export default function LoanDialog({
         {loanBalance > 0 && (
           <div className={styles.buildItem} style={{ marginTop: 12 }}>
             <div className={styles.buildItemContent}>
-              <div className={styles.buildItemName}>💳 返済する</div>
+              <label htmlFor="repayInput" className={styles.buildItemName}>
+                💳 返済する
+              </label>
               <div className={styles.buildItemActions}>
                 <input
+                  id="repayInput"
                   type="number"
                   min={1}
                   max={Math.min(loanBalance, currentPlayer.money)}

--- a/src/components/ActionDialog/__tests__/LoanDialog.test.tsx
+++ b/src/components/ActionDialog/__tests__/LoanDialog.test.tsx
@@ -57,7 +57,7 @@ describe('LoanDialog', () => {
         onClose={vi.fn()}
       />,
     );
-    const input = screen.getByLabelText('借入金額');
+    const input = screen.getByLabelText('💰 借りる');
     fireEvent.change(input, { target: { value: '-1' } });
     // 入力は無視されず state に反映される（無反応にしない）
     expect(input).toHaveValue(-1);
@@ -80,7 +80,7 @@ describe('LoanDialog', () => {
         onClose={vi.fn()}
       />,
     );
-    const input = screen.getByLabelText('返済金額');
+    const input = screen.getByLabelText('💳 返済する');
     fireEvent.change(input, { target: { value: '-1' } });
     expect(input).toHaveValue(-1);
     expect(


### PR DESCRIPTION
## 概要
### 💡 What
Added semantic `<label>` elements to the borrow and repay inputs in the Loan Dialog (`LoanDialog.tsx`), replacing the previous generic `<div>` elements that acted as visual labels.

### 🎯 Why
Inputs without associated semantic labels can be confusing for screen reader users, as the visual description is disconnected from the input field itself. Connecting them via `id` and `htmlFor` improves accessibility.

### 📸 Before/After
No visual changes.

### ♿️ Accessibility
Improved form control accessibility by mapping the visual labels ("💰 借りる" and "💳 返済する") to their respective `<input type="number">` elements using `htmlFor` and `id` attributes.

---
*PR created automatically by Jules for task [12214456561095527441](https://jules.google.com/task/12214456561095527441) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **アクセシビリティ**
  * 借入・返済セクションの見出しと入力欄を関連付け、ラベルから入力欄を識別しやすくしました。
  * 入力欄の操作性と支援技術への対応を改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->