### PR TITLE
⚡ Bolt: Replace map.filter chains with for-loops to reduce GC overhead

### DIFF
--- a/src/components/ActionDialog/BuildDialog.tsx
+++ b/src/components/ActionDialog/BuildDialog.tsx
@@ -60,12 +60,16 @@ export default function BuildDialog({
   // ⚡ Bolt: useMemo to prevent mapping, filtering, and sorting the properties array on every render.
   // This avoids O(N log N) recalculation of ownedProperties on every keystroke or update within the dialog.
   const ownedProperties = useMemo(() => {
-    return currentPlayer.properties
-      .map((id: string) => getSpaceById(id, board))
-      .filter(
-        (s): s is BoardSpace => !!s && s.type === 'property' && !!s.houseCost,
-      )
-      .sort((a, b) => compareByColorOrder(a.color, b.color, COLOR_ORDER));
+    const props: BoardSpace[] = [];
+    for (const id of currentPlayer.properties) {
+      const space = getSpaceById(id, board);
+      if (space && space.type === 'property' && space.houseCost) {
+        props.push(space);
+      }
+    }
+    return props.sort((a, b) =>
+      compareByColorOrder(a.color, b.color, COLOR_ORDER),
+    );
   }, [currentPlayer.properties, board]);
 
   return (

--- a/src/components/ActionDialog/InsuranceDialog.tsx
+++ b/src/components/ActionDialog/InsuranceDialog.tsx
@@ -72,10 +72,16 @@ export default function InsuranceDialog({
   // 火災リスクのある「土地（property）」のみ保険対象。鉄道・公共施設は除外する。
   // 60FPS アニメーション中の再レンダリングでの再計算を避けるためメモ化する。
   const ownedProperties = useMemo(() => {
-    return currentPlayer.properties
-      .map((id: string) => getSpaceById(id, board))
-      .filter((s): s is BoardSpace => !!s && s.type === 'property')
-      .sort((a, b) => compareByColorOrder(a.color, b.color, COLOR_ORDER));
+    const props: BoardSpace[] = [];
+    for (const id of currentPlayer.properties) {
+      const space = getSpaceById(id, board);
+      if (space && space.type === 'property') {
+        props.push(space);
+      }
+    }
+    return props.sort((a, b) =>
+      compareByColorOrder(a.color, b.color, COLOR_ORDER),
+    );
   }, [currentPlayer.properties, board]);
 
   // 未加入時に火災で失う割合（%）。スクラップ率の裏返しを子供向けに表示する。

--- a/src/components/ActionDialog/MortgageDialog.tsx
+++ b/src/components/ActionDialog/MortgageDialog.tsx
@@ -27,12 +27,14 @@ export default function MortgageDialog({
   // ⚡ Bolt: 毎回のレンダリングで物件配列のマッピングとフィルタリングが行われるのを防ぐため、useMemo を使用します。
   // これにより、抵当ダイアログが開いている状態での親コンポーネントの状態変更に伴うレンダリングのオーバーヘッドを削減します。
   const ownedProperties = useMemo(() => {
-    return currentPlayer.properties
-      .map((id: string) => getSpaceById(id, board))
-      .filter(
-        (s): s is BoardSpace =>
-          s !== undefined && s.mortgageValue !== undefined,
-      );
+    const props: BoardSpace[] = [];
+    for (const id of currentPlayer.properties) {
+      const space = getSpaceById(id, board);
+      if (space && space.mortgageValue !== undefined) {
+        props.push(space);
+      }
+    }
+    return props;
   }, [currentPlayer.properties, board]);
 
   return (

--- a/src/components/ActionDialog/SellDialog.tsx
+++ b/src/components/ActionDialog/SellDialog.tsx
@@ -57,10 +57,16 @@ export default function SellDialog({
   // ⚡ Bolt: useMemo to prevent mapping, filtering, and sorting the properties array on every render.
   // This reduces rendering overhead especially when the dialog is open and parent state changes.
   const ownedProperties = useMemo(() => {
-    return currentPlayer.properties
-      .map((id: string) => getSpaceById(id, board))
-      .filter((s): s is BoardSpace => !!s)
-      .sort((a, b) => compareByColorOrder(a.color, b.color, COLOR_ORDER));
+    const props: BoardSpace[] = [];
+    for (const id of currentPlayer.properties) {
+      const space = getSpaceById(id, board);
+      if (space) {
+        props.push(space);
+      }
+    }
+    return props.sort((a, b) =>
+      compareByColorOrder(a.color, b.color, COLOR_ORDER),
+    );
   }, [currentPlayer.properties, board]);
 
   const title = forced

--- a/src/components/ActionDialog/TradeDialog.tsx
+++ b/src/components/ActionDialog/TradeDialog.tsx
@@ -111,21 +111,25 @@ export default function TradeDialog({
   // ⚡ Bolt: useMemo to prevent repeated mapping and filtering of property arrays on every render.
   // TradeDialog involves frequent state updates (typing money amount), and computing properties on every render hurts input latency.
   const myProperties = useMemo(() => {
-    return currentPlayer.properties
-      .map((id: string) => getSpaceById(id, board))
-      .filter(
-        (s): s is BoardSpace =>
-          !!s && (propertyStates[s.id]?.houses ?? 0) === 0,
-      );
+    const props: BoardSpace[] = [];
+    for (const id of currentPlayer.properties) {
+      const space = getSpaceById(id, board);
+      if (space && (propertyStates[space.id]?.houses ?? 0) === 0) {
+        props.push(space);
+      }
+    }
+    return props;
   }, [currentPlayer.properties, board, propertyStates]);
 
   const theirProperties = useMemo(() => {
-    return targetPlayer.properties
-      .map((id: string) => getSpaceById(id, board))
-      .filter(
-        (s): s is BoardSpace =>
-          !!s && (propertyStates[s.id]?.houses ?? 0) === 0,
-      );
+    const props: BoardSpace[] = [];
+    for (const id of targetPlayer.properties) {
+      const space = getSpaceById(id, board);
+      if (space && (propertyStates[space.id]?.houses ?? 0) === 0) {
+        props.push(space);
+      }
+    }
+    return props;
   }, [targetPlayer.properties, board, propertyStates]);
 
   const toggleOffer = (id: string) => {

--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -12,6 +12,7 @@ import type {
   ColorGroup,
   GameState,
   Player,
+  PropertyState,
 } from '../../game/types';
 import type { GameAction } from '../../game/actions';
 import { MAX_JAIL_TURNS } from '../../game/reducer';
@@ -353,17 +354,23 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
   const tradeOfferSpaces = useMemo(() => {
     const trade = state.trade;
     if (state.turnPhase !== 'tradeConfirm' || !trade) return [];
-    return trade.offerProperties
-      .map((id) => getSpaceById(id, state.board))
-      .filter((space): space is BoardSpace => !!space);
+    const spaces: BoardSpace[] = [];
+    for (const id of trade.offerProperties) {
+      const space = getSpaceById(id, state.board);
+      if (space) spaces.push(space);
+    }
+    return spaces;
   }, [state.turnPhase, state.trade, state.board]);
 
   const tradeRequestSpaces = useMemo(() => {
     const trade = state.trade;
     if (state.turnPhase !== 'tradeConfirm' || !trade) return [];
-    return trade.requestProperties
-      .map((id) => getSpaceById(id, state.board))
-      .filter((space): space is BoardSpace => !!space);
+    const spaces: BoardSpace[] = [];
+    for (const id of trade.requestProperties) {
+      const space = getSpaceById(id, state.board);
+      if (space) spaces.push(space);
+    }
+    return spaces;
   }, [state.turnPhase, state.trade, state.board]);
 
   // ⚡ Bolt: useMemo to prevent O(S log S) filtering and sorting of player stocks on every render (e.g. 60 FPS animation) while the player dialog is open.
@@ -389,23 +396,24 @@ export default function GameBoard({ state, dispatch }: GameBoardProps) {
     const board = state.board;
     const propertyStates = state.propertyStates;
     if (!board || !propertyStates) return [];
-    return detailPlayer.properties
-      .map((id) => {
-        const space = getSpaceById(id, board);
-        const propertyState = propertyStates[id];
-        return space && propertyState ? { space, state: propertyState } : null;
-      })
-      .filter((item): item is NonNullable<typeof item> => item !== null)
-      .sort((a, b) => {
-        const colorCompare = compareByColorOrder(
-          a.space.color,
-          b.space.color,
-          COLOR_ORDER,
-        );
-        return colorCompare !== 0
-          ? colorCompare
-          : a.space.position - b.space.position;
-      });
+    const props: { space: BoardSpace; state: PropertyState }[] = [];
+    for (const id of detailPlayer.properties) {
+      const space = getSpaceById(id, board);
+      const propertyState = propertyStates[id];
+      if (space && propertyState) {
+        props.push({ space, state: propertyState });
+      }
+    }
+    return props.sort((a, b) => {
+      const colorCompare = compareByColorOrder(
+        a.space.color,
+        b.space.color,
+        COLOR_ORDER,
+      );
+      return colorCompare !== 0
+        ? colorCompare
+        : a.space.position - b.space.position;
+    });
   }, [showPlayerDetail, playersById, state.board, state.propertyStates]);
 
   // ⚡ Bolt: プレイヤー詳細ダイアログ表示中の総資産再計算を防ぐため、所有物件の走査結果をメモ化する。


### PR DESCRIPTION
## 💡 What
Replaced `.map().filter()` chained patterns with simple `for...of` loops (and `push()`) in `GameBoard.tsx` and various Action Dialog components (`BuildDialog`, `InsuranceDialog`, `MortgageDialog`, `TradeDialog`, `SellDialog`).

## 🎯 Why
React component memoization hooks like `useMemo` evaluate during renders, so intermediate array allocations within them (such as `.map(id => space).filter(space => !!space)`) can trigger unwanted garbage collections. During 60FPS animations or frequent parent state changes, these re-evaluations degrade performance unnecessarily by iterating multiple times and allocating intermediate arrays.

## 📊 Impact
Reduces object creation and array allocations during render phases in multiple frequently-rendered components, particularly reducing garbage collection overhead during animation loops. It changes `O(2N)` iteration overhead into `O(N)`.

## 🔬 Measurement
Verify application rendering remains smooth and no functionality regressions occur when opening action dialogs or hovering over map components. Performance profiles will show fewer array allocations during React render phases.

---
*PR created automatically by Jules for task [2867981968705856716](https://jules.google.com/task/2867981968705856716) started by @genzouw*