### PR TITLE
🎨 Palette: [UX improvement] Visually hide repetitive disabled reason text

### DIFF
--- a/src/components/PlayerPanel/PlayerPanel.module.css
+++ b/src/components/PlayerPanel/PlayerPanel.module.css
@@ -58,11 +58,13 @@
   min-height: 52px;
 }
 .helperText {
-  font-size: 11px;
-  color: var(--color-text-secondary, #888);
-  text-align: center;
-  margin-top: 4px;
-  white-space: normal;
-  max-width: 120px;
-  line-height: 1.3;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }


### PR DESCRIPTION
## 概要

### 💡 What
`PlayerPanel` 内の各プレイヤーチップが非アクティブなときに表示される補助メッセージ「他のプレイヤーの操作中や処理中は詳細を見られません」を、画面上で視覚的に非表示（screen-reader-only）にする CSS の変更を行いました。

### 🎯 Why
サイコロを振っている最中など、操作がロックされるタイミングで、すべてのプレイヤーチップの下に同じ補助メッセージが一斉に表示されることで、レイアウトシフトが発生し、画面がごちゃついて見えるという問題がありました。非表示にすることでこの不要なノイズを削減し、スッキリとしたインターフェースを保ちます。

### 📸 Before/After
- **Before:** 他プレイヤーの操作中、すべてのプレイヤーチップの下部に「他のプレイヤーの操作中や処理中は詳細を見られません」というテキストが表示され、縦方向にレイアウトシフトが発生。
- **After:** テキストは視覚的に隠され、レイアウトシフトは発生しません。マウスユーザーはチップのツールチップ（`title`）で理由を確認でき、スクリーンリーダーユーザーには引き続き `aria-describedby` 経由でテキストが読み上げられます。

### ♿ Accessibility
スクリーンリーダー用にテキスト（`sr-only` 相当の CSS プロパティ）を残しているため、フォーカス時の音声読み上げによる無効理由のフィードバックは以前と変わらず維持されます。マウスホバーによる `title` 表示も保持されています。

---
*PR created automatically by Jules for task [3363884042422321621](https://jules.google.com/task/3363884042422321621) started by @genzouw*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **アクセシビリティ**
  * 補助テキストを画面上には表示せず、スクリーンリーダーなどの支援技術から利用できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->