### PR TITLE
docs: Issue #489 の指摘は対象ワークフロー削除により解消済みであることを明記

### DIFF
--- a/docs/security/ai-ci-tools.md
+++ b/docs/security/ai-ci-tools.md
@@ -182,6 +182,7 @@ PR作成時にGitHub Models (gpt-4o-mini) を利用して、PRテンプレート
 
 PRの自動承認を行う `.github/workflows/ai-codeball-approver.yml`（Codeball, `sturdy-dev/codeball-action`）を導入していましたが、本リポジトリのAction許可リスト（`genzouw` 所有 / GitHub作成 / Marketplace検証済み / 個別許可パターンのいずれかに限定）に `sturdy-dev/codeball-action` が含まれておらず、CIが恒常的に失敗する状態となっていたため削除しました。
 再導入する場合は、リポジトリ管理者が `Settings > Actions > General > Allow select actions and reusable workflows` にて `sturdy-dev/codeball-action` を許可リストに追加した上で対応してください。
+また、この削除により Issue #489 で指摘されていた「外側を40桁コミットSHAで固定しても、composite action内部の `baller`/`status`/`labeler`/`approver`/`suggester` が可変タグ `@v2`（かつNode16）で参照される」というSHA固定漏れの問題も、対象ワークフロー自体が存在しなくなったことで解消しています。再導入時は、この内部参照のSHA固定漏れとNode16依存を解消した上で（フォークして内部参照を固定するか、代替Actionへの乗り換えを検討した上で）対応してください。
 
 ## AI連携ワークフロー全体の最適化について
 


### PR DESCRIPTION
## 概要

Issue #489 は、`.github/workflows/ai-codeball-approver.yml` の外側Action（`sturdy-dev/codeball-action`）を40桁コミットSHAで固定しても、composite action内部の `baller`/`status`/`labeler`/`approver`/`suggester` が可変タグ `@v2`（かつNode16）でリモート参照されているため、SHA固定が実質的に無効化されているという指摘でした。

## 現状分析

調査の結果、指摘対象の `.github/workflows/ai-codeball-approver.yml` は、Issue作成のわずか約28分後、コミット [`fb38d77`](https://github.com/genzouw/monopo/commit/fb38d77bc2d2788603848a270df8ed5ee133820d)（`fix(ci): 許可リスト外アクションを使うCodeball承認ワークフローを削除`）で既に削除されていることを確認しました。

削除理由自体はIssue #489の指摘（SHA固定漏れ）とは別（`sturdy-dev/codeball-action` がリポジトリのAction許可リストに含まれておらず、CIが恒常的に失敗していたため）ですが、結果として対象ワークフロー自体が存在しなくなったため、Issue #489で指摘された内部Action参照のSHA固定漏れ問題も解消済みです。`sturdy-dev/codeball-action` への参照はリポジトリ内に残っていません（`docs/security/ai-ci-tools.md` の削除記録のみ）。

## 対応内容

`docs/security/ai-ci-tools.md` の「削除: AI Codeball PR Approver について」の節に、Issue #489で指摘された内部Action参照のSHA固定漏れ問題も本削除により解消済みであること、および再導入時に同問題（内部参照のSHA固定漏れ・Node16依存）を解消してから対応すべき旨を追記しました。

Closes #489

<!-- local-ai-pr-description:start -->
### 🤖 Local AI Generated Description (Ollama - qwen2.5-coder:0.5b)

# 💡 What
PR作成時にGitHub Models (gpt-4o-mini) を利用して、PRテンプレートを完成しました。

PRの自動承認を行う `.github/workflows/ai-codeball-approver.yml`（Codeball, `sturdy-dev/codeball-action`）を導入していましたが、本リポジトリのAction許可リスト（`genzouw` 所有 / GitHub作成 / Marketplace検証済み / 個別許可パターンのいずれかに限定）に `sturdy-dev/codeball-action` が含まれておらず、CIが恒常的に失敗する状態となっていたため削除しました。
 再導入する場合は、リポジトリ管理者が `Settings > Actions > General > Allow select actions and reusable workflows` にて `sturdy-dev/codeball-action` を許可リストに追加した上で対応してください。
+また、この削除により Issue #489 で指摘されていた「外側を40桁コミットSHAで固定しても、composite action内部の `baller`/`status`/`labeler`/`approver`/`suggester` が可変タグ `@​v2`（かつNode16）で参照される」というSHA固定漏れの問題も、対象ワークフロー自体が存在しなくなったことで解消しています。再導入時は、この内部参照のSHA固定漏れとNode16依存を解消した上で（フォークして内部参照を固定するか、代替Actionへの乗り換えを検討した上で）対応してください。

## AI連携ワークフロー全体の最適化について
- `baller`/`status`/`labeler`/`approver`/`suggester` は可変タグ `@​v2`（かつNode16）で参照されるSHA固定漏れが解消したため、この内部参照のSHA固定漏れとNode16依存を解消した上で（フォークして内部参照を固定するか、代替Actionへの乗り換えを検討した上で）対応してください。

---

This change optimizes the GitHub Actions workflow for AI integration. The `.github/workflows/ai-codeball-approver.yml` file was mistakenly deleted, and a new Action named `sturdy-dev/codeball-action` was introduced to address this issue. The internal SHA reference for `baller`, `status`, `labeler`, `approver`, and `suggester` was fixed, thus eliminating the SHA fixed overflow issue. Additionally, the internal SHA reference for `@​v2` (and Node16) was fixed, which is a common issue with SHA references in CI/CD pipelines.
<!-- local-ai-pr-description:end -->